### PR TITLE
Fix default exports

### DIFF
--- a/examples/javascript/index.js
+++ b/examples/javascript/index.js
@@ -5,6 +5,38 @@ const client = weaviate.client({
   host: 'localhost:8080',
 });
 
+console.log(
+  JSON.stringify(
+    new weaviate.AuthAccessTokenCredentials({
+      accessToken: 'token123',
+      expiresIn: 123,
+    })
+  )
+);
+
+console.log(
+  JSON.stringify(
+    new weaviate.AuthUserPasswordCredentials({
+      username: 'user123',
+      password: 'password',
+    })
+  )
+);
+
+console.log(
+  JSON.stringify(
+    new weaviate.AuthClientCredentials({
+      clientSecret: 'secret123',
+    })
+  )
+);
+
+console.log(weaviate.backup.Backend.GCS);
+console.log(weaviate.batch.DeleteOutput.MINIMAL);
+console.log(weaviate.cluster.NodeStatus.HEALTHY);
+console.log(weaviate.filters.Operator.AND);
+console.log(weaviate.replication.ConsistencyLevel.QUORUM);
+
 client.misc
   .metaGetter()
   .do()

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -5,6 +5,38 @@ const client = weaviate.client({
   host: 'localhost:8080',
 });
 
+console.log(
+  JSON.stringify(
+    new weaviate.AuthAccessTokenCredentials({
+      accessToken: 'token123',
+      expiresIn: 123,
+    })
+  )
+);
+
+console.log(
+  JSON.stringify(
+    new weaviate.AuthUserPasswordCredentials({
+      username: 'user123',
+      password: 'password',
+    })
+  )
+);
+
+console.log(
+  JSON.stringify(
+    new weaviate.AuthClientCredentials({
+      clientSecret: 'secret123',
+    })
+  )
+);
+
+console.log(weaviate.backup.Backend.GCS);
+console.log(weaviate.batch.DeleteOutput.MINIMAL);
+console.log(weaviate.cluster.NodeStatus.HEALTHY);
+console.log(weaviate.filters.Operator.AND);
+console.log(weaviate.replication.ConsistencyLevel.QUORUM);
+
 client.misc
   .metaGetter()
   .do()

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,10 @@ const app = {
   filters: filtersConsts,
   cluster: clusterConsts,
   replication: replicationConsts,
+
+  AuthUserPasswordCredentials,
+  AuthAccessTokenCredentials,
+  AuthClientCredentials,
 };
 
 function initDbVersionProvider(conn: Connection) {
@@ -97,4 +101,3 @@ function initDbVersionProvider(conn: Connection) {
 
 module.exports = app;
 export default app;
-export { AuthUserPasswordCredentials, AuthAccessTokenCredentials, Operator };


### PR DESCRIPTION
The AuthCredentials classes were not being re-exported properly. Now they are.
Additionally, the examples have been updated to reflect this change, and demonstrate usage.