### PR TITLE
Rename interfaces to be more idiomatic

### DIFF
--- a/src/backup/index.ts
+++ b/src/backup/index.ts
@@ -4,17 +4,14 @@ import BackupRestorer from './backupRestorer';
 import BackupRestoreStatusGetter from './backupRestoreStatusGetter';
 import Connection from '../connection';
 
-// import BackupGetter from "./backupGetter";
-
-export interface IWeaviateClientBackup {
+export interface Backup {
   creator: () => BackupCreator;
   createStatusGetter: () => BackupCreateStatusGetter;
   restorer: () => BackupRestorer;
   restoreStatusGetter: () => BackupRestoreStatusGetter;
-  // getter: () => BackupGetter
 }
 
-const backup = (client: Connection): IWeaviateClientBackup => {
+const backup = (client: Connection): Backup => {
   return {
     creator: () =>
       new BackupCreator(client, new BackupCreateStatusGetter(client)),
@@ -22,7 +19,6 @@ const backup = (client: Connection): IWeaviateClientBackup => {
     restorer: () =>
       new BackupRestorer(client, new BackupRestoreStatusGetter(client)),
     restoreStatusGetter: () => new BackupRestoreStatusGetter(client),
-    // getter: () => new BackupGetter(client),
   };
 };
 

--- a/src/backup/journey.test.ts
+++ b/src/backup/journey.test.ts
@@ -1,4 +1,4 @@
-import weaviate, { IWeaviateClient } from '../index';
+import weaviate, { WeaviateClient } from '../index';
 
 const {
   createTestFoodSchemaAndData,
@@ -886,16 +886,16 @@ describe('fail restoring backup for both include and exclude classes', () => {
 //   it("cleans up", () => cleanupTestFood(client));
 // });
 
-function assertThatAllPizzasExist(client: IWeaviateClient) {
+function assertThatAllPizzasExist(client: WeaviateClient) {
   return assertThatAllFoodObjectsExist(client, 'Pizza', 4);
 }
 
-function assertThatAllSoupsExist(client: IWeaviateClient) {
+function assertThatAllSoupsExist(client: WeaviateClient) {
   return assertThatAllFoodObjectsExist(client, 'Soup', 2);
 }
 
 function assertThatAllFoodObjectsExist(
-  client: IWeaviateClient,
+  client: WeaviateClient,
   className: string,
   number: number
 ) {

--- a/src/batch/index.ts
+++ b/src/batch/index.ts
@@ -6,7 +6,7 @@ import { BeaconPath } from '../utils/beaconPath';
 import { DbVersionSupport } from '../utils/dbVersion';
 import Connection from '../connection';
 
-export interface IWeaviateClientBatch {
+export interface Batch {
   objectsBatcher: () => ObjectsBatcher;
   objectsBatchDeleter: () => ObjectsBatchDeleter;
   referencesBatcher: () => ReferencesBatcher;
@@ -16,7 +16,7 @@ export interface IWeaviateClientBatch {
 const batch = (
   client: Connection,
   dbVersionSupport: DbVersionSupport
-): IWeaviateClientBatch => {
+): Batch => {
   const beaconPath = new BeaconPath(dbVersionSupport);
 
   return {

--- a/src/batch/journey.test.ts
+++ b/src/batch/journey.test.ts
@@ -1,4 +1,4 @@
-import weaviate, { IWeaviateClient } from '../index';
+import weaviate, { WeaviateClient } from '../index';
 
 const thingClassName = 'BatchJourneyTestThing';
 const otherThingClassName = 'BatchJourneyTestOtherThing';
@@ -530,7 +530,7 @@ describe('batch deleting', () => {
   it('tears down and cleans up', () => cleanup(client));
 });
 
-const setup = async (client: IWeaviateClient) => {
+const setup = async (client: WeaviateClient) => {
   // first import the classes
   await Promise.all([
     client.schema
@@ -572,11 +572,11 @@ const setup = async (client: IWeaviateClient) => {
     .do();
 };
 
-const setupData = (client: IWeaviateClient) => {
+const setupData = (client: WeaviateClient) => {
   return client.batch.objectsBatcher().withObjects(someObjects).do();
 };
 
-const cleanup = (client: IWeaviateClient) =>
+const cleanup = (client: WeaviateClient) =>
   Promise.all([
     client.schema.classDeleter().withClassName(thingClassName).do(),
     client.schema.classDeleter().withClassName(otherThingClassName).do(),

--- a/src/c11y/index.ts
+++ b/src/c11y/index.ts
@@ -2,12 +2,12 @@ import ExtensionCreator from './extensionCreator';
 import ConceptsGetter from './conceptsGetter';
 import Connection from '../connection';
 
-export interface IWeaviateClientC11y {
+export interface C11y {
   conceptsGetter: () => ConceptsGetter;
   extensionCreator: () => ExtensionCreator;
 }
 
-const c11y = (client: Connection): IWeaviateClientC11y => {
+const c11y = (client: Connection): C11y => {
   return {
     conceptsGetter: () => new ConceptsGetter(client),
     extensionCreator: () => new ExtensionCreator(client),

--- a/src/classifications/index.ts
+++ b/src/classifications/index.ts
@@ -2,12 +2,12 @@ import Scheduler from './scheduler';
 import Getter from './getter';
 import Connection from '../connection';
 
-export interface IWeaviateClientClassifications {
+export interface Classifications {
   scheduler: () => Scheduler;
   getter: () => Getter;
 }
 
-const data = (client: Connection): IWeaviateClientClassifications => {
+const data = (client: Connection): Classifications => {
   return {
     scheduler: () => new Scheduler(client),
     getter: () => new Getter(client),

--- a/src/classifications/knn.journey.test.ts
+++ b/src/classifications/knn.journey.test.ts
@@ -1,4 +1,4 @@
-import weaviate, { IWeaviateClient } from '../index';
+import weaviate, { WeaviateClient } from '../index';
 import Connection from '../connection';
 
 const targetDessertId = 'cd54852a-209d-423b-bf1c-884468215237';
@@ -205,7 +205,7 @@ describe('a classification journey', () => {
   });
 });
 
-const setup = async (client: IWeaviateClient) => {
+const setup = async (client: WeaviateClient) => {
   let targetClass = {
     class: 'ClassificationJourneyTarget',
     properties: [
@@ -286,7 +286,7 @@ const setup = async (client: IWeaviateClient) => {
     .do();
 };
 
-const cleanup = (client: IWeaviateClient) => {
+const cleanup = (client: WeaviateClient) => {
   return Promise.all([
     client.schema
       .classDeleter()

--- a/src/cluster/index.ts
+++ b/src/cluster/index.ts
@@ -1,11 +1,11 @@
 import NodesStatusGetter from './nodesStatusGetter';
 import Connection from '../connection';
 
-export interface IWeaviateClientCluster {
+export interface Cluster {
   nodesStatusGetter: () => NodesStatusGetter;
 }
 
-const cluster = (client: Connection): IWeaviateClientCluster => {
+const cluster = (client: Connection): Cluster => {
   return {
     nodesStatusGetter: () => new NodesStatusGetter(client),
   };

--- a/src/connection/gqlClient.ts
+++ b/src/connection/gqlClient.ts
@@ -1,12 +1,12 @@
-import { GraphQLClient } from 'graphql-request';
-import { IConnectionParams } from '../index';
+import { GraphQLClient as Client } from 'graphql-request';
+import { ConnectionParams } from '../index';
 
 export type TQuery = any;
-export interface IGraphQLClient {
+export interface GraphQLClient {
   query: (query: TQuery, headers?: HeadersInit) => Promise<{ data: any }>;
 }
 
-export const gqlClient = (config: IConnectionParams): IGraphQLClient => {
+export const gqlClient = (config: ConnectionParams): GraphQLClient => {
   const scheme = config.scheme;
   const host = config.host;
   const defaultHeaders = config.headers;
@@ -14,7 +14,7 @@ export const gqlClient = (config: IConnectionParams): IGraphQLClient => {
     // for backward compatibility with replaced graphql-client lib,
     // results are wrapped into { data: data }
     query: (query: TQuery, headers?: HeadersInit) => {
-      return new GraphQLClient(`${scheme}://${host}/v1/graphql`, {
+      return new Client(`${scheme}://${host}/v1/graphql`, {
         headers: {
           ...defaultHeaders,
           ...headers,

--- a/src/connection/httpClient.ts
+++ b/src/connection/httpClient.ts
@@ -1,7 +1,7 @@
 import fetch from 'isomorphic-fetch';
-import { IConnectionParams } from '../index';
+import { ConnectionParams } from '../index';
 
-export interface IHttpClient {
+export interface HttpClient {
   patch: (path: string, payload: any, bearerToken?: string) => any;
   head: (path: string, payload: any, bearerToken?: string) => any;
   post: (
@@ -32,7 +32,7 @@ export interface IHttpClient {
   externalGet: (externalUrl: string) => Promise<any>;
 }
 
-export const httpClient = (config: IConnectionParams): IHttpClient => {
+export const httpClient = (config: ConnectionParams): HttpClient => {
   const baseUri = `${config.scheme}://${config.host}/v1`;
   const url = makeUrl(baseUri);
 

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -1,17 +1,17 @@
 import { Authenticator } from './auth';
 import OpenidConfigurationGetter from '../misc/openidConfigurationGetter';
 
-import httpClient, { IHttpClient } from './httpClient';
-import gqlClient, { IGraphQLClient } from './gqlClient';
-import { IConnectionParams } from '../index';
+import httpClient, { HttpClient } from './httpClient';
+import gqlClient, { GraphQLClient } from './gqlClient';
+import { ConnectionParams } from '../index';
 
 export default class Connection {
   public readonly auth: any;
   private readonly authEnabled: boolean;
-  private gql: IGraphQLClient;
-  public readonly http: IHttpClient;
+  private gql: GraphQLClient;
+  public readonly http: HttpClient;
 
-  constructor(params: IConnectionParams) {
+  constructor(params: ConnectionParams) {
     this.http = httpClient(params);
     this.gql = gqlClient(params);
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -14,9 +14,9 @@ import { ObjectsPath, ReferencesPath } from './path';
 import { BeaconPath } from '../utils/beaconPath';
 import { DbVersionSupport } from '../utils/dbVersion';
 import Connection from '../connection';
-import { IWeaviateClient } from '../index';
+import { WeaviateClient } from '../index';
 
-export interface IWeaviateClientData {
+export interface Data {
   creator: () => Creator;
   validator: () => Validator;
   updater: () => Updater;
@@ -31,10 +31,7 @@ export interface IWeaviateClientData {
   referencePayloadBuilder: () => ReferencePayloadBuilder;
 }
 
-const data = (
-  client: Connection,
-  dbVersionSupport: DbVersionSupport
-): IWeaviateClientData => {
+const data = (client: Connection, dbVersionSupport: DbVersionSupport): Data => {
   const objectsPath = new ObjectsPath(dbVersionSupport);
   const referencesPath = new ReferencesPath(dbVersionSupport);
   const beaconPath = new BeaconPath(dbVersionSupport);

--- a/src/data/journey.test.ts
+++ b/src/data/journey.test.ts
@@ -1,4 +1,4 @@
-import weaviate, { IWeaviateClient } from '../index';
+import weaviate, { WeaviateClient } from '../index';
 
 const thingClassName = 'DataJourneyTestThing';
 const refSourceClassName = 'DataJourneyTestRefSource';
@@ -1132,7 +1132,7 @@ describe('data', () => {
   });
 });
 
-const setup = async (client: IWeaviateClient) => {
+const setup = async (client: WeaviateClient) => {
   const thing = {
     class: thingClassName,
     properties: [

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -4,14 +4,14 @@ import Explorer from './explorer';
 import Raw from './raw';
 import Connection from '../connection';
 
-export interface IWeaviateClientGraphQL {
+export interface GraphQL {
   get: () => Getter;
   aggregate: () => Aggregator;
   explore: () => Explorer;
   raw: () => Raw;
 }
 
-const graphql = (client: Connection): IWeaviateClientGraphQL => {
+const graphql = (client: Connection): GraphQL => {
   return {
     get: () => new Getter(client),
     aggregate: () => new Aggregator(client),

--- a/src/graphql/journey.test.ts
+++ b/src/graphql/journey.test.ts
@@ -1,8 +1,8 @@
-import weaviate, { IWeaviateClient } from '../index';
+import weaviate, { WeaviateClient } from '../index';
 import Connection from '../connection';
 
 describe('the graphql journey', () => {
-  let client: IWeaviateClient;
+  let client: WeaviateClient;
 
   beforeEach(() => {
     client = weaviate.client({
@@ -1274,7 +1274,7 @@ describe('the graphql journey', () => {
   });
 });
 
-const setup = async (client: IWeaviateClient) => {
+const setup = async (client: WeaviateClient) => {
   const thing = {
     class: 'Article',
     invertedIndexConfig: { indexTimestamps: true },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,17 @@
 import Connection from './connection/index';
-import graphql, { IWeaviateClientGraphQL } from './graphql/index';
-import schema, { IWeaviateClientSchema } from './schema/index';
-import data, { IWeaviateClientData } from './data/index';
-import classifications, {
-  IWeaviateClientClassifications,
-} from './classifications/index';
-import batch, { IWeaviateClientBatch } from './batch/index';
-import misc, { IWeaviateClientMisc } from './misc/index';
-import c11y, { IWeaviateClientC11y } from './c11y/index';
+import graphql, { GraphQL } from './graphql/index';
+import schema, { Schema } from './schema/index';
+import data, { Data } from './data/index';
+import classifications, { Classifications } from './classifications/index';
+import batch, { Batch } from './batch/index';
+import misc, { Misc } from './misc/index';
+import c11y, { C11y } from './c11y/index';
 import { DbVersionProvider, DbVersionSupport } from './utils/dbVersion';
-import backup, { IWeaviateClientBackup } from './backup/index';
+import backup, { Backup } from './backup/index';
 import backupConsts from './backup/consts';
 import batchConsts from './batch/consts';
-import filtersConsts, { Operator } from './filters/consts';
-import cluster, { IWeaviateClientCluster } from './cluster/index';
+import filtersConsts from './filters/consts';
+import cluster, { Cluster } from './cluster/index';
 import clusterConsts from './cluster/consts';
 import replicationConsts from './data/replication/consts';
 import {
@@ -24,7 +22,7 @@ import {
 import MetaGetter from './misc/metaGetter';
 import { EmbeddedDB, EmbeddedOptions } from './embedded';
 
-export interface IConnectionParams {
+export interface ConnectionParams {
   authClientSecret?:
     | AuthClientCredentials
     | AuthAccessTokenCredentials
@@ -35,21 +33,21 @@ export interface IConnectionParams {
   embedded?: EmbeddedOptions;
 }
 
-export interface IWeaviateClient {
-  graphql: IWeaviateClientGraphQL;
-  schema: IWeaviateClientSchema;
-  data: IWeaviateClientData;
-  classifications: IWeaviateClientClassifications;
-  batch: IWeaviateClientBatch;
-  misc: IWeaviateClientMisc;
-  c11y: IWeaviateClientC11y;
-  backup: IWeaviateClientBackup;
-  cluster: IWeaviateClientCluster;
+export interface WeaviateClient {
+  graphql: GraphQL;
+  schema: Schema;
+  data: Data;
+  classifications: Classifications;
+  batch: Batch;
+  misc: Misc;
+  c11y: C11y;
+  backup: Backup;
+  cluster: Cluster;
   embedded?: EmbeddedDB;
 }
 
 const app = {
-  client: function (params: IConnectionParams): IWeaviateClient {
+  client: function (params: ConnectionParams): WeaviateClient {
     // check if the URL is set
     if (!params.host) throw new Error('Missing `host` parameter');
 
@@ -63,7 +61,7 @@ const app = {
     const dbVersionProvider = initDbVersionProvider(conn);
     const dbVersionSupport = new DbVersionSupport(dbVersionProvider);
 
-    const ifc: IWeaviateClient = {
+    const ifc: WeaviateClient = {
       graphql: graphql(conn),
       schema: schema(conn),
       data: data(conn, dbVersionSupport),

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -5,7 +5,7 @@ import OpenidConfigurationGetter from './openidConfigurationGetter';
 import Connection from '../connection';
 import { DbVersionProvider } from '../utils/dbVersion';
 
-export interface IWeaviateClientMisc {
+export interface Misc {
   liveChecker: () => LiveChecker;
   readyChecker: () => ReadyChecker;
   metaGetter: () => MetaGetter;
@@ -15,7 +15,7 @@ export interface IWeaviateClientMisc {
 const misc = (
   client: Connection,
   dbVersionProvider: DbVersionProvider
-): IWeaviateClientMisc => {
+): Misc => {
   return {
     liveChecker: () => new LiveChecker(client, dbVersionProvider),
     readyChecker: () => new ReadyChecker(client, dbVersionProvider),

--- a/src/misc/openidConfigurationGetter.ts
+++ b/src/misc/openidConfigurationGetter.ts
@@ -1,8 +1,8 @@
-import { IHttpClient } from '../connection/httpClient';
+import { HttpClient } from '../connection/httpClient';
 
 export default class OpenidConfigurationGetterGetter {
-  private client: IHttpClient;
-  constructor(client: IHttpClient) {
+  private client: HttpClient;
+  constructor(client: HttpClient) {
     this.client = client;
   }
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -8,7 +8,7 @@ import ShardUpdater from './shardUpdater';
 import ShardsUpdater from './shardsUpdater';
 import Connection from '../connection';
 
-export interface IWeaviateClientSchema {
+export interface Schema {
   classCreator: () => ClassCreator;
   classDeleter: () => ClassDeleter;
   classGetter: () => ClassGetter;
@@ -19,7 +19,7 @@ export interface IWeaviateClientSchema {
   shardsUpdater: () => ShardsUpdater;
 }
 
-const schema = (client: Connection): IWeaviateClientSchema => {
+const schema = (client: Connection): Schema => {
   return {
     classCreator: () => new ClassCreator(client),
     classDeleter: () => new ClassDeleter(client),

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -1,4 +1,4 @@
-import weaviate, { IWeaviateClient } from '../index';
+import weaviate, { WeaviateClient } from '../index';
 
 describe('schema', () => {
   const client = weaviate.client({
@@ -494,7 +494,7 @@ function newClassObject(className: string) {
   };
 }
 
-function getShards(client: IWeaviateClient, className: string) {
+function getShards(client: WeaviateClient, className: string) {
   return client.schema
     .shardsGetter()
     .withClassName(className)
@@ -504,7 +504,7 @@ function getShards(client: IWeaviateClient, className: string) {
     });
 }
 
-function deleteClass(client: IWeaviateClient, className: string) {
+function deleteClass(client: WeaviateClient, className: string) {
   return client.schema
     .classDeleter()
     .withClassName(className)

--- a/src/utils/testData.ts
+++ b/src/utils/testData.ts
@@ -1,4 +1,4 @@
-import { IWeaviateClient } from '../index';
+import { WeaviateClient } from '../index';
 
 export const PIZZA_CLASS_NAME = 'Pizza';
 export const SOUP_CLASS_NAME = 'Soup';
@@ -102,14 +102,14 @@ const soupObjects = [
   },
 ];
 
-export function createTestFoodSchema(client: IWeaviateClient) {
+export function createTestFoodSchema(client: WeaviateClient) {
   return Promise.all([
     client.schema.classCreator().withClass(pizzaClass).do(),
     client.schema.classCreator().withClass(soupClass).do(),
   ]);
 }
 
-export function createTestFoodData(client: IWeaviateClient) {
+export function createTestFoodData(client: WeaviateClient) {
   return client.batch
     .objectsBatcher()
     .withObjects(pizzaObjects)
@@ -117,11 +117,11 @@ export function createTestFoodData(client: IWeaviateClient) {
     .do();
 }
 
-export function createTestFoodSchemaAndData(client: IWeaviateClient) {
+export function createTestFoodSchemaAndData(client: WeaviateClient) {
   return createTestFoodSchema(client).then(() => createTestFoodData(client));
 }
 
-export function cleanupTestFood(client: IWeaviateClient) {
+export function cleanupTestFood(client: WeaviateClient) {
   return Promise.all([
     client.schema.classDeleter().withClassName(PIZZA_CLASS_NAME).do(),
     client.schema.classDeleter().withClassName(SOUP_CLASS_NAME).do(),


### PR DESCRIPTION
- remove the `I` prefix
- remove redundant `WeaviateClient` prefix
- rename oidc credentials inputs