### PR TITLE
Improve Embedded DB UX

### DIFF
--- a/src/embedded/index.ts
+++ b/src/embedded/index.ts
@@ -13,7 +13,6 @@ const defaultPersistenceDataPath = join(homedir(), '.local/share/weaviate');
 const defaultVersion = '1.18.0';
 
 interface EmbeddedOptionsConfig {
-  host?: string;
   port?: number;
   env?: object;
   version?: string;
@@ -24,13 +23,11 @@ export class EmbeddedOptions {
   persistenceDataPath: string;
   host: string;
   port: number;
-  clusterHostname: string;
   version: string;
   env: NodeJS.ProcessEnv;
 
   constructor(cfg?: EmbeddedOptionsConfig) {
-    this.clusterHostname = 'embedded';
-    this.host = (cfg && cfg.host) || '127.0.0.1';
+    this.host = '127.0.0.1';
     this.port = (cfg && cfg.port) || 6666;
     this.version = this.parseVersion(cfg);
     this.binaryPath = this.getBinaryPath(cfg);
@@ -48,7 +45,6 @@ export class EmbeddedOptions {
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true',
       QUERY_DEFAULTS_LIMIT: '20',
       PERSISTENCE_DATA_PATH: this.persistenceDataPath,
-      CLUSTER_HOSTNAME: this.clusterHostname,
       DEFAULT_VECTORIZER_MODULE: 'none',
       ENABLE_MODULES:
         'text2vec-openai,text2vec-cohere,text2vec-huggingface,' +

--- a/src/embedded/journey.test.ts
+++ b/src/embedded/journey.test.ts
@@ -12,12 +12,10 @@ describe('embedded', () => {
     expect(opt.persistenceDataPath).toEqual(join(homedir(), '.local/share/weaviate'));
     expect(opt.host).toEqual('127.0.0.1');
     expect(opt.port).toEqual(6666);
-    expect(opt.clusterHostname).toEqual('embedded');
   });
 
   it('creates EmbeddedOptions with custom options', () => {
     const opt = new EmbeddedOptions({
-      host: 'somehost.com',
       port: 7777,
       version: '1.18.1-alpha.0',
       env: {
@@ -33,7 +31,7 @@ describe('embedded', () => {
     expect(opt.env).toHaveProperty('ENABLE_MODULES', 'text2vec-contextionary');
     expect(opt.env).toHaveProperty('CONTEXTIONARY_URL', 'contextionary:9999');
     expect(opt.env).toHaveProperty('QUERY_DEFAULTS_LIMIT', 100);
-    expect(opt.host).toEqual('somehost.com');
+    expect(opt.host).toEqual('127.0.0.1');
     expect(opt.port).toEqual(7777);
   });
 


### PR DESCRIPTION
- remove unnecessary clusterHostName param
- restrict Embedded DB to only run on localhost 