### PR TITLE
Support 'latest' version, explicit binary URL for Embedded DB

### DIFF
--- a/src/embedded/index.ts
+++ b/src/embedded/index.ts
@@ -265,6 +265,7 @@ export class EmbeddedDB {
         })
           .on('finish', () => {
             tarball.close();
+            fs.unlinkSync(tarballPath);
             fs.renameSync(join(dirname(this.options.binaryPath), 'weaviate'), this.options.binaryPath);
             resolve(null);
           })

--- a/src/embedded/index.ts
+++ b/src/embedded/index.ts
@@ -10,7 +10,7 @@ import { extract } from 'tar';
 
 const defaultBinaryPath = join(homedir(), '.cache/weaviate-embedded');
 const defaultPersistenceDataPath = join(homedir(), '.local/share/weaviate');
-const defaultVersion = '1.18.0';
+const defaultVersion = '1.18.1';
 
 interface EmbeddedOptionsConfig {
   host?: string;
@@ -67,11 +67,15 @@ export class EmbeddedOptions {
     if (!cfg || !cfg.version) {
       return defaultVersion;
     }
+    if (cfg.version == 'latest') {
+      return 'latest';
+    }
     if (cfg.version.match(/[1-9]\.[1-9]{2}\..*/g)) {
       return cfg.version;
-    } else {
-      throw new Error(`invalid version: ${cfg.version}. version must resemble '{major}.{minor}.{patch}'`);
     }
+    throw new Error(
+      `invalid version: ${cfg.version}. version must resemble '{major}.{minor}.{patch}, or 'latest'`
+    );
   }
 
   getBinaryPath(cfg?: EmbeddedOptionsConfig): string {
@@ -101,16 +105,18 @@ export class EmbeddedDB {
   constructor(opt: EmbeddedOptions) {
     this.options = opt;
     this.pid = 0;
-    ensurePathsExist(this.options);
+    this.ensurePathsExist();
     checkSupportedPlatform();
   }
 
   async start() {
-    if (await isListening(this.options)) {
+    if (await this.isListening()) {
       console.log(`Embedded db already listening @ ${this.options.host}:${this.options.port}`);
     }
 
-    await ensureWeaviateBinaryExists(this.options);
+    await this.resolveWeaviateVersion().then(async () => {
+      await this.ensureWeaviateBinaryExists();
+    });
 
     if (!this.options.env.CLUSTER_GOSSIP_BIND_PORT) {
       this.options.env.CLUSTER_GOSSIP_BIND_PORT = await getRandomPort();
@@ -134,7 +140,7 @@ export class EmbeddedDB {
       `Started ${this.options.binaryPath} @ ${this.options.host}:${this.options.port} -- process ID ${this.pid}`
     );
 
-    await waitTillListening(this.options);
+    await this.waitTillListening();
   }
 
   stop() {
@@ -145,12 +151,166 @@ export class EmbeddedDB {
       console.log(`Tried to stop embedded db @ PID ${this.pid}.`, `PID not found, so nothing will be done`);
     }
   }
-}
 
-function ensurePathsExist(opt: EmbeddedOptions) {
-  const binPathDir = dirname(opt.binaryPath);
-  fs.mkdirSync(binPathDir, { recursive: true });
-  fs.mkdirSync(opt.persistenceDataPath, { recursive: true });
+  private resolveWeaviateVersion(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.options.version == 'latest') {
+        get(
+          'https://api.github.com/repos/weaviate/weaviate/releases/latest',
+          { headers: { 'User-Agent': 'Weaviate-Embedded-DB' } },
+          (resp) => {
+            let body = '';
+            resp.on('data', (chunk: string) => {
+              body += chunk;
+            });
+            resp.on('end', () => {
+              if (resp.statusCode === 200) {
+                try {
+                  const json = JSON.parse(body);
+                  this.options.version = (json.tag_name as string).slice(1); // trim the `v` prefix
+                  resolve();
+                } catch (err) {
+                  reject(new Error(`failed to parse latest binary version response: ${JSON.stringify(err)}`));
+                }
+              } else {
+                reject(
+                  new Error(`fetch latest binary version, unexpected status code ${resp.statusCode}: ${body}`)
+                );
+              }
+            });
+          }
+        ).on('error', (err) => {
+          reject(new Error(`failed to find latest binary version: ${JSON.stringify(err)}`));
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  private async ensureWeaviateBinaryExists() {
+    if (!fs.existsSync(`${this.options.binaryPath}`)) {
+      console.log(
+        `Binary ${this.options.binaryPath} does not exist.`,
+        `Downloading binary for version ${this.options.version}`
+      );
+      await this.downloadBinary().then((tarballPath) => this.untarBinary(tarballPath));
+    }
+  }
+
+  private ensurePathsExist() {
+    const binPathDir = dirname(this.options.binaryPath);
+    fs.mkdirSync(binPathDir, { recursive: true });
+    fs.mkdirSync(this.options.persistenceDataPath, { recursive: true });
+  }
+
+  private downloadBinary(): Promise<string> {
+    const tarballPath = `${this.options.binaryPath}.tgz`;
+    const file = fs.createWriteStream(tarballPath);
+    return new Promise((resolve, reject) => {
+      const url = this.buildBinaryUrl();
+      get(url, (resp) => {
+        if (resp.statusCode == 302 && resp.headers.location) {
+          get(resp.headers.location, (resp) => {
+            resp.pipe(file);
+            file.on('finish', () => {
+              file.close();
+              resolve(tarballPath);
+            });
+          });
+        } else if (resp.statusCode == 404) {
+          reject(
+            new Error(
+              `failed to download binary: not found. ` +
+                `are you sure Weaviate version ${this.options.version} exists? ` +
+                `note that embedded db is only supported for versions >= 1.18.0`
+            )
+          );
+        } else {
+          reject(new Error(`failed to download binary: unexpected status code: ${resp.statusCode}`));
+        }
+      }).on('error', (err) => {
+        fs.unlinkSync(tarballPath);
+        reject(new Error(`failed to download binary: ${JSON.stringify(err)}`));
+      });
+    });
+  }
+
+  private buildBinaryUrl(): string {
+    let arch: string;
+    switch (process.arch) {
+      case 'arm64':
+        arch = 'arm64';
+        break;
+      case 'x64':
+        arch = 'amd64';
+        break;
+      default:
+        throw new Error(`Embedded DB unsupported architecture: ${process.arch}`);
+    }
+
+    return (
+      `https://github.com/weaviate/weaviate/releases/download/v${this.options.version}` +
+      `/weaviate-v${this.options.version}-linux-${arch}.tar.gz`
+    );
+  }
+
+  private untarBinary(tarballPath: string): Promise<null> {
+    const tarball = fs.createReadStream(tarballPath);
+    return new Promise((resolve, reject) => {
+      tarball.pipe(
+        extract({
+          cwd: dirname(tarballPath),
+          strict: true,
+        })
+          .on('finish', () => {
+            tarball.close();
+            fs.renameSync(join(dirname(this.options.binaryPath), 'weaviate'), this.options.binaryPath);
+            resolve(null);
+          })
+          .on('error', (err) => {
+            reject(new Error(`failed to untar binary: ${JSON.stringify(err)}`));
+          })
+      );
+    });
+  }
+
+  private waitTillListening(): Promise<null> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        clearTimeout(timeout);
+        clearInterval(interval);
+        reject(new Error(`failed to connect to embedded db @ ${this.options.host}:${this.options.port}`));
+      }, 30000);
+
+      const interval = setInterval(() => {
+        this.isListening().then((listening) => {
+          if (listening) {
+            clearTimeout(timeout);
+            clearInterval(interval);
+            resolve(null);
+          }
+        });
+      }, 500);
+    });
+  }
+
+  private isListening(): Promise<boolean> {
+    const sock = net.connect(this.options.port, this.options.host);
+    return new Promise((resolve) => {
+      sock
+        .on('connect', () => {
+          console.log('connected to embedded db!');
+          sock.destroy();
+          resolve(true);
+        })
+        .on('error', (err) => {
+          console.log('Trying to connect to embedded db...', JSON.stringify(err));
+          sock.destroy();
+          resolve(false);
+        });
+    });
+  }
 }
 
 function checkSupportedPlatform() {
@@ -158,67 +318,6 @@ function checkSupportedPlatform() {
   if (platform == 'darwin' || platform == 'win32') {
     throw new Error(`${platform} is not supported with EmbeddedDB`);
   }
-}
-
-async function ensureWeaviateBinaryExists(opt: EmbeddedOptions) {
-  if (!fs.existsSync(`${opt.binaryPath}`)) {
-    console.log(`Binary ${opt.binaryPath} does not exist.`, `Downloading binary for version ${opt.version}`);
-    await downloadBinary(opt).then((tarballPath) => untarBinary(opt, tarballPath));
-  }
-}
-
-function downloadBinary(opt: EmbeddedOptions): Promise<string> {
-  const tarballPath = `${opt.binaryPath}.tgz`;
-  const file = fs.createWriteStream(tarballPath);
-  return new Promise((resolve, reject) => {
-    const url =
-      'https://github.com/weaviate/weaviate/releases' +
-      `/download/v${opt.version}/weaviate-v${opt.version}-linux-amd64.tar.gz`;
-    get(url, (resp) => {
-      if (resp.statusCode == 302 && resp.headers.location) {
-        get(resp.headers.location, (resp) => {
-          resp.pipe(file);
-          file.on('finish', () => {
-            file.close();
-            resolve(tarballPath);
-          });
-        });
-      } else if (resp.statusCode == 404) {
-        reject(
-          new Error(
-            `failed to download binary: not found. ` +
-              `are you sure Weaviate version ${opt.version} exists? ` +
-              `note that embedded db is only supported for versions >= 1.18.0`
-          )
-        );
-      } else {
-        reject(new Error(`failed to download binary: unexpected status code: ${resp.statusCode}`));
-      }
-    }).on('error', function (err) {
-      fs.unlinkSync(tarballPath);
-      reject(new Error(`failed to download binary: ${JSON.stringify(err)}`));
-    });
-  });
-}
-
-function untarBinary(opt: EmbeddedOptions, tarballPath: string): Promise<null> {
-  const tarball = fs.createReadStream(tarballPath);
-  return new Promise((resolve, reject) => {
-    tarball.pipe(
-      extract({
-        cwd: dirname(tarballPath),
-        strict: true,
-      })
-        .on('finish', () => {
-          tarball.close();
-          fs.renameSync(join(dirname(opt.binaryPath), 'weaviate'), opt.binaryPath);
-          resolve(null);
-        })
-        .on('error', function (err) {
-          reject(new Error(`failed to untar binary: ${JSON.stringify(err)}`));
-        })
-    );
-  });
 }
 
 function getRandomPort(): Promise<string> {
@@ -232,42 +331,5 @@ function getRandomPort(): Promise<string> {
         reject(new Error('failed to find open port'));
       }
     });
-  });
-}
-
-function waitTillListening(opt: EmbeddedOptions): Promise<null> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      clearTimeout(timeout);
-      clearInterval(interval);
-      reject(new Error(`failed to connect to embedded db @ ${opt.host}:${opt.port}`));
-    }, 30000);
-
-    const interval = setInterval(() => {
-      isListening(opt).then((listening) => {
-        if (listening) {
-          clearTimeout(timeout);
-          clearInterval(interval);
-          resolve(null);
-        }
-      });
-    }, 500);
-  });
-}
-
-function isListening(opt: EmbeddedOptions): Promise<boolean> {
-  const sock = net.connect(opt.port, opt.host);
-  return new Promise((resolve) => {
-    sock
-      .on('connect', () => {
-        console.log('connected to embedded db!');
-        sock.destroy();
-        resolve(true);
-      })
-      .on('error', (err) => {
-        console.log('Trying to connect to embedded db...', JSON.stringify(err));
-        sock.destroy();
-        resolve(false);
-      });
   });
 }

--- a/src/embedded/journey.test.ts
+++ b/src/embedded/journey.test.ts
@@ -8,7 +8,7 @@ describe('embedded', () => {
   it('creates EmbeddedOptions with defaults', () => {
     const opt = new EmbeddedOptions();
 
-    expect(opt.binaryPath).toEqual(join(homedir(), '.cache/weaviate-embedded-1.18.0'));
+    expect(opt.binaryPath).toEqual(join(homedir(), '.cache/weaviate-embedded-1.18.1'));
     expect(opt.persistenceDataPath).toEqual(join(homedir(), '.local/share/weaviate'));
     expect(opt.host).toEqual('127.0.0.1');
     expect(opt.port).toEqual(6666);
@@ -42,7 +42,7 @@ describe('embedded', () => {
       const opt = new EmbeddedOptions({
         version: '123',
       });
-    }).toThrow("invalid version: 123. version must resemble '{major}.{minor}.{patch}'");
+    }).toThrow("invalid version: 123. version must resemble '{major}.{minor}.{patch}, or 'latest'");
   });
 
   if (process.platform == 'linux') {
@@ -56,11 +56,21 @@ describe('embedded', () => {
       const db = new EmbeddedDB(
         new EmbeddedOptions({
           port: 7878,
-          version: '1.18.0',
+          version: '1.18.1',
           env: {
             QUERY_DEFAULTS_LIMIT: 50,
             DEFAULT_VECTORIZER_MODULE: 'text2vec-openai',
           },
+        })
+      );
+      await db.start();
+      db.stop();
+    });
+
+    it('starts/stops EmbeddedDB with latest version', async () => {
+      const db = new EmbeddedDB(
+        new EmbeddedOptions({
+          version: 'latest',
         })
       );
       await db.start();

--- a/src/embedded/journey.test.ts
+++ b/src/embedded/journey.test.ts
@@ -76,6 +76,29 @@ describe('embedded', () => {
       await db.start();
       db.stop();
     });
+
+    it('starts/stops EmbeddedDB with binaryUrl', async () => {
+      let binaryUrl = '';
+      const url = 'https://api.github.com/repos/weaviate/weaviate/releases/latest';
+      await fetch(url, {
+        method: 'GET',
+        headers: { 'content-type': 'application/json' },
+      })
+        .then((res: Response) => {
+          if (res.status != 200) {
+            fail(new Error(`unexpected status code: ${res.status}`));
+          }
+          return res.json();
+        })
+        .then((body: any) => {
+          binaryUrl = body.assets[0].browser_download_url as string;
+        })
+        .catch((e: any) => fail(new Error(`unexpected failure: ${JSON.stringify(e)}`)));
+
+      const db = new EmbeddedDB(new EmbeddedOptions({ binaryUrl: binaryUrl }));
+      await db.start();
+      db.stop();
+    });
   } else {
     console.warn(`Skipping because EmbeddedDB does not support ${process.platform}`);
   }


### PR DESCRIPTION
- Allow `'latest'` version to automatically download the latest Weaviate server version
- Support explicit URL to weaviate binary in the form of `binaryUrl` property of `EmbeddedOptions`
- Detect machine architecture to download correct binary