### PR TITLE
Support GQL `Get{}` tunable consistency

### DIFF
--- a/ci/compose.sh
+++ b/ci/compose.sh
@@ -19,5 +19,5 @@ function compose_down_all {
 }
 
 function all_weaviate_ports {
-  echo "8080 8081 8082 8083 8085 8086"
+  echo "8080 8081 8082 8083 8085 8086 8087 8088"
 }

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -16,17 +16,6 @@ services:
       CLUSTER_GOSSIP_BIND_PORT: "7110"
       CLUSTER_DATA_BIND_PORT: "7111"
 
-  contextionary:
-    image: semitechnologies/contextionary:en0.16.0-v1.2.0
-    ports:
-      - "9797:9999"
-    environment:
-      OCCURRENCE_WEIGHT_LINEAR_FACTOR: 0.75
-      EXTENSIONS_STORAGE_MODE: weaviate
-      EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080
-      NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
-      ENABLE_COMPOUND_SPLITTING: 'false'
-
   weaviate-node-2:
     init: true
     command:

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -1,0 +1,56 @@
+---
+version: '3.4'
+services:
+  weaviate-node-1:
+    image: semitechnologies/weaviate:preview-gql-handler-consistency-level-integration-4a12f55
+    restart: on-failure:0
+    ports:
+      - "8087:8080"
+    environment:
+      CONTEXTIONARY_URL: contextionary:9999
+      QUERY_DEFAULTS_LIMIT: 20
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: "./weaviate-node-1"
+      DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
+      ENABLE_MODULES: text2vec-contextionary
+      CLUSTER_GOSSIP_BIND_PORT: "7110"
+      CLUSTER_DATA_BIND_PORT: "7111"
+
+  contextionary:
+    image: semitechnologies/contextionary:en0.16.0-v1.2.0
+    ports:
+      - "9797:9999"
+    environment:
+      OCCURRENCE_WEIGHT_LINEAR_FACTOR: 0.75
+      EXTENSIONS_STORAGE_MODE: weaviate
+      EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080
+      NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
+      ENABLE_COMPOUND_SPLITTING: 'false'
+
+  weaviate-node-2:
+    init: true
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    image: semitechnologies/weaviate:preview-gql-handler-consistency-level-integration-4a12f55
+    ports:
+    - 8088:8080
+    - 6061:6060
+    restart: on-failure:0
+    environment:
+      CONTEXTIONARY_URL: contextionary:9999
+      LOG_LEVEL: 'debug'
+      QUERY_DEFAULTS_LIMIT: 20
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
+      PERSISTENCE_DATA_PATH: './weaviate-node-2'
+      DEFAULT_VECTORIZER_MODULE: text2vec-contextionary
+      ENABLE_MODULES: text2vec-contextionary
+      CLUSTER_HOSTNAME: 'node2' 
+      CLUSTER_GOSSIP_BIND_PORT: '7112'
+      CLUSTER_DATA_BIND_PORT: '7113'
+      CLUSTER_JOIN: 'weaviate-node-1:7110'
+...

--- a/src/graphql/getter.test.ts
+++ b/src/graphql/getter.test.ts
@@ -75,6 +75,44 @@ test('a simple query with a group', () => {
   expect(mockClient.query).toHaveBeenCalledWith(expectedQuery);
 });
 
+describe('query with consistency level', () => {
+  test('One', () => {
+    const mockClient: any = {
+      query: jest.fn(),
+    };
+
+    const expectedQuery = `{Get{Person(consistencyLevel:ONE){name}}}`;
+
+    new Getter(mockClient).withClassName('Person').withFields('name').withConsistencyLevel('ONE').do();
+
+    expect(mockClient.query).toHaveBeenCalledWith(expectedQuery);
+  });
+
+  test('Quorum', () => {
+    const mockClient: any = {
+      query: jest.fn(),
+    };
+
+    const expectedQuery = `{Get{Person(consistencyLevel:QUORUM){name}}}`;
+
+    new Getter(mockClient).withClassName('Person').withFields('name').withConsistencyLevel('QUORUM').do();
+
+    expect(mockClient.query).toHaveBeenCalledWith(expectedQuery);
+  });
+
+  test('All', () => {
+    const mockClient: any = {
+      query: jest.fn(),
+    };
+
+    const expectedQuery = `{Get{Person(consistencyLevel:ALL){name}}}`;
+
+    new Getter(mockClient).withClassName('Person').withFields('name').withConsistencyLevel('ALL').do();
+
+    expect(mockClient.query).toHaveBeenCalledWith(expectedQuery);
+  });
+});
+
 describe('where filters', () => {
   test('a query with a valid where filter', () => {
     const mockClient: any = {

--- a/src/graphql/getter.ts
+++ b/src/graphql/getter.ts
@@ -12,6 +12,7 @@ import Connection from '../connection';
 import { CommandBase } from '../validation/commandBase';
 import { WhereFilter } from '../openapi/types';
 import { GenerateArgs, GraphQLGenerate } from './generate';
+import { ConsistencyLevel } from '../data';
 
 export default class GraphQLGetter extends CommandBase {
   private after?: string;
@@ -31,6 +32,7 @@ export default class GraphQLGetter extends CommandBase {
   private sortString?: string;
   private whereString?: string;
   private generateString?: string;
+  private consistencyLevel?: ConsistencyLevel;
 
   constructor(client: Connection) {
     super(client);
@@ -176,6 +178,11 @@ export default class GraphQLGetter extends CommandBase {
     return this;
   };
 
+  withConsistencyLevel = (level: ConsistencyLevel) => {
+    this.consistencyLevel = level;
+    return this;
+  };
+
   validateIsSet = (prop: string | undefined | null, name: string, setter: string) => {
     if (prop == undefined || prop == null || prop.length == 0) {
       this.addError(`${name} must be set - set with ${setter}`);
@@ -254,6 +261,10 @@ export default class GraphQLGetter extends CommandBase {
       } else {
         this.fields = this.fields?.concat(` _additional{${this.generateString}}`);
       }
+    }
+
+    if (this.consistencyLevel) {
+      args = [...args, `consistencyLevel:${this.consistencyLevel}`];
     }
 
     if (args.length > 0) {


### PR DESCRIPTION
Introduces `client.graphql.get().withConsistencyLevel()` to set desired consistency level per query.

Example:

```ts
import weaviate, { WeaviateClient } from 'weaviate-ts-client';

const client: WeaviateClient = weaviate.client({
  scheme: 'http',
  host: 'localhost:8080',
});

const resp = await client.graphql
  .get()
  .withClassName('Article')
  .withFields('_additional { id isConsistent }')
  .withConsistencyLevel('ONE')
  .do();

console.log(`resp: ${JSON.stringify(resp)}`);
```