### PR TITLE
gh-43: Full support for ESM modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     }
   },
   "engines": {
@@ -18,11 +18,12 @@
   "files": [
     "/dist/index.js",
     "/dist/index.mjs",
-    "/dist/index.d.ts"
+    "/dist/index.d.ts",
+    "/dist/index.d.mts"
   ],
   "scripts": {
     "test": "tsc -noEmit -p tsconfig-test.json && jest --useStderr --runInBand --detectOpenHandles",
-    "build": "npm run lint && tsup src/index.ts --format cjs,esm --dts --clean --platform neutral --minify",
+    "build": "npm run lint && tsup src/index.ts --format cjs,esm --dts --clean --platform neutral --minify && cp ./dist/index.d.ts ./dist/index.d.mts",
     "prepack": "npm run build",
     "lint": "eslint --ext .ts,.js .",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
Fixes https://github.com/weaviate/typescript-client/issues/43 in `v1.3`

**Problem:**
In typescript when using more strict `moduleResolution` such as  `nodenext` or `node16`, typescript can't find type declarations of the esm module which has `.mjs` extension. This is because TypeScript ignores `.js` when there is an identically named `.d.ts` file beside it. Same happens with `.mjs` and `.d.mts` but if no such pair found, typescript thinks there are no type declarations. 
[More info in my comment here.](https://github.com/weaviate/typescript-client/pull/46#issuecomment-1545072740)

**Solution:**
Assuming that weaviate team doesn't want to change package module type from `commonjs` to `module`, keeping `commonjs` as default option, the smallest change is to generate `d.mts` declaration file. Since we don't have actual `.mts` files, it's not easy to emit one using standard bundlers and builders, [see](https://github.com/microsoft/TypeScript/issues/49462). The best workaround I see is to clone original type definitions after build. This will make this PR small and if one day weaviate team decides to implement a build pipeline it will be straightforward to implement this step using other tools.   

