### PR TITLE
UUIDv5 support

### DIFF
--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -38,7 +38,7 @@ console.log(
 );
 
 console.log(JSON.stringify(new ApiKey('abcd1234')));
-console.log(generateUuid5({ prop1: 'hello', prop2: 'world' }, 'the-best-namespace'));
+console.log(generateUuid5('55dfccce-0142-4807-a1ff-60be9b38f5cc', 'the-best-namespace'));
 
 client.misc
   .metaGetter()

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -3,6 +3,7 @@ import weaviate, {
   AuthUserPasswordCredentials,
   ApiKey,
   AuthAccessTokenCredentials,
+  generateUuid5,
 } from 'weaviate-ts-client';
 
 const client = weaviate.client({
@@ -37,6 +38,7 @@ console.log(
 );
 
 console.log(JSON.stringify(new ApiKey('abcd1234')));
+console.log(generateUuid5({ prop1: 'hello', prop2: 'world' }, 'the-best-namespace'));
 
 client.misc
   .metaGetter()

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "graphql-request": "^5.1.0",
-        "isomorphic-fetch": "^3.0.0"
+        "isomorphic-fetch": "^3.0.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
@@ -22,6 +23,7 @@
         "@types/isomorphic-fetch": "^0.0.36",
         "@types/jest": "^29.4.0",
         "@types/node": "^18.14.0",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.54.1",
         "@typescript-eslint/parser": "^5.54.1",
         "babel-jest": "^29.4.3",
@@ -1794,6 +1796,12 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
@@ -6451,6 +6459,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -7764,6 +7780,12 @@
     },
     "@types/stack-utils": {
       "version": "2.0.1",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/ws": {
@@ -10804,6 +10826,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "homepage": "https://github.com/weaviate/typescript-client#readme",
   "dependencies": {
     "graphql-request": "^5.1.0",
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
@@ -57,6 +58,7 @@
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.14.0",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
     "babel-jest": "^29.4.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,3 +104,4 @@ export * from './c11y';
 export * from './backup';
 export * from './cluster';
 export * from './connection';
+export * from './utils/uuid';

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,8 @@
+import { v5 as uuid5 } from 'uuid';
+
+// Generates UUIDv5, used to consistently generate the same UUID for
+// a specific identifier and namespace
+export function generateUuid5(identifier: any, namespace: any = ''): string {
+  const stringified = JSON.stringify(identifier) + JSON.stringify(namespace);
+  return uuid5(stringified, uuid5.DNS).toString();
+}

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -2,7 +2,7 @@ import { v5 as uuid5 } from 'uuid';
 
 // Generates UUIDv5, used to consistently generate the same UUID for
 // a specific identifier and namespace
-export function generateUuid5(identifier: any, namespace: any = ''): string {
+export function generateUuid5(identifier: string | number, namespace: string | number = ''): string {
   const stringified = JSON.stringify(identifier) + JSON.stringify(namespace);
   return uuid5(stringified, uuid5.DNS).toString();
 }

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -3,6 +3,6 @@ import { v5 as uuid5 } from 'uuid';
 // Generates UUIDv5, used to consistently generate the same UUID for
 // a specific identifier and namespace
 export function generateUuid5(identifier: string | number, namespace: string | number = ''): string {
-  const stringified = JSON.stringify(identifier) + JSON.stringify(namespace);
+  const stringified = identifier.toString() + namespace.toString();
   return uuid5(stringified, uuid5.DNS).toString();
 }


### PR DESCRIPTION
Introduces a `generateUuid5` function, which takes in any identifier and an optional namespace, to generate deterministic UUIDs.

Example: 
```ts
import { generateUuid5 } from 'weaviate-ts-client';

const withNamespace = generateUuid5('some-string-identifer', 'some-namespace');
console.log(withNamespace);

const withoutNamespace = generateUuid5('some-string-identifer');
console.log(withoutNamespace);
```