### PR TITLE
Support fetch in all environments

### DIFF
--- a/src/connection/gqlClient.ts
+++ b/src/connection/gqlClient.ts
@@ -19,6 +19,7 @@ export const gqlClient = (config: ConnectionParams): GraphQLClient => {
           ...defaultHeaders,
           ...headers,
         },
+        fetch,
       })
         .request(query, variables, headers)
         .then((data) => ({ data }));


### PR DESCRIPTION
Export fetch, in the case that cross-fetch (used by the gql client) is not supported in a given environment

Closes #54