### PR TITLE
Add method to check if class exists

### DIFF
--- a/src/schema/classExists.ts
+++ b/src/schema/classExists.ts
@@ -1,0 +1,38 @@
+import { isValidStringProperty } from '../validation/string';
+import Connection from '../connection';
+import { CommandBase } from '../validation/commandBase';
+import { WeaviateSchema } from '../openapi/types';
+
+export default class ClassExists extends CommandBase {
+  private className?: string;
+
+  constructor(client: Connection) {
+    super(client);
+  }
+
+  withClassName = (className: string) => {
+    this.className = className;
+    return this;
+  };
+
+  validateClassName = () => {
+    if (!isValidStringProperty(this.className)) {
+      this.addError('className must be set - set with .withClassName(className)');
+    }
+  };
+
+  validate = () => {
+    this.validateClassName();
+  };
+
+  do = (): Promise<boolean> => {
+    this.validate();
+    if (this.errors.length > 0) {
+      return Promise.reject(new Error('invalid usage: ' + this.errors.join(', ')));
+    }
+    const path = `/schema`;
+    return this.client
+      .get(path)
+      .then((res: WeaviateSchema) => res.classes?.some((c) => c.class === this.className));
+  };
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,5 +1,6 @@
 import ClassCreator from './classCreator';
 import ClassDeleter from './classDeleter';
+import ClassExists from './classExists';
 import ClassGetter from './classGetter';
 import PropertyCreator from './propertyCreator';
 import SchemaGetter from './getter';
@@ -12,6 +13,7 @@ export interface Schema {
   classCreator: () => ClassCreator;
   classDeleter: () => ClassDeleter;
   classGetter: () => ClassGetter;
+  exists: (className: string) => Promise<boolean>;
   getter: () => SchemaGetter;
   propertyCreator: () => PropertyCreator;
   shardsGetter: () => ShardsGetter;
@@ -24,6 +26,7 @@ const schema = (client: Connection): Schema => {
     classCreator: () => new ClassCreator(client),
     classDeleter: () => new ClassDeleter(client),
     classGetter: () => new ClassGetter(client),
+    exists: (className: string) => new ClassExists(client).withClassName(className).do(),
     getter: () => new SchemaGetter(client),
     propertyCreator: () => new PropertyCreator(client),
     shardsGetter: () => new ShardsGetter(client),

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -31,15 +31,11 @@ describe('schema', () => {
   });
 
   it('checks class existence', () => {
-    return client.schema.exists(classObj.class).then((res: boolean) => {
-      expect(res).toEqual(true);
-    });
+    return client.schema.exists(classObj.class).then((res) => expect(res).toEqual(true));
   });
 
   it('checks class non-existence', () => {
-    return client.schema.exists('NonExistingClass').then((res: boolean) => {
-      expect(res).toEqual(false);
-    });
+    return client.schema.exists('NonExistingClass').then((res) => expect(res).toEqual(false));
   });
 
   it('extends the thing class with a new property', () => {

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -30,6 +30,18 @@ describe('schema', () => {
       });
   });
 
+  it('checks class existence', () => {
+    return client.schema.exists(classObj.class).then((res: boolean) => {
+      expect(res).toEqual(true);
+    });
+  });
+
+  it('checks class non-existence', () => {
+    return client.schema.exists('NonExistingClass').then((res: boolean) => {
+      expect(res).toEqual(false);
+    });
+  });
+
   it('extends the thing class with a new property', () => {
     const className = 'MyThingClass';
     const prop: Property = {


### PR DESCRIPTION
This PR introduces a method to the `schema` property of `client` that checks for the existence of a class within the database by its `className`.

In an effort to keep the implementation decoupled but logical, the `ClassExists` builder class is introduced that conforms to the logic of other builder classes within the `src/schema/` directory. The `do()` method of this class is, however, abstracted away from the end user such that they only access:
```typescript
const exists: boolean = await client
  .schema
  .exists('MyClass')
```
without the added overhead and complexity of making many builder calls to achieve the result. This was done to conform with the previously raised issue: https://github.com/weaviate/typescript-client/issues/16.

The implementation simply calls the `/schema` endpoint of the Weaviate REST API and uses the `.some()` `Array.prototype` method to compare the returned `classes` property with the provided `className`.

@dirkkul :grin: 
