### PR TITLE
Hotfix client data checker return

### DIFF
--- a/src/connection/httpClient.ts
+++ b/src/connection/httpClient.ts
@@ -129,9 +129,9 @@ export const httpClient = (config: ConnectionParams): HttpClient => {
 
 const makeUrl = (basePath: string) => (path: string) => basePath + path;
 
-const makeCheckStatus = (expectResponseBody: any) => (res: any) => {
+const makeCheckStatus = (expectResponseBody: boolean) => (res: Response) => {
   if (res.status >= 400) {
-    return res.text().then((errText: any) => {
+    return res.text().then((errText: string) => {
       let err;
       try {
         // in case of invalid json response (like empty string)
@@ -148,11 +148,11 @@ const makeCheckStatus = (expectResponseBody: any) => (res: any) => {
   }
 };
 
-const handleHeadResponse = (expectResponseBody: any) => (res: any) => {
+const handleHeadResponse = (expectResponseBody: boolean) => (res: Response) => {
   if (res.status == 204 || res.status == 404) {
     return res.status == 204;
   }
-  return makeCheckStatus(expectResponseBody);
+  return makeCheckStatus(expectResponseBody)(res);
 };
 
 function addAuthHeaderIfNeeded(request: any, bearerToken: string) {

--- a/src/connection/httpClient.ts
+++ b/src/connection/httpClient.ts
@@ -132,14 +132,14 @@ const makeUrl = (basePath: string) => (path: string) => basePath + path;
 const makeCheckStatus = (expectResponseBody: boolean) => (res: Response) => {
   if (res.status >= 400) {
     return res.text().then((errText: string) => {
-      let err;
+      let err: string;
       try {
         // in case of invalid json response (like empty string)
         err = JSON.stringify(JSON.parse(errText));
       } catch (e) {
         err = errText;
       }
-      return Promise.reject(new Error(`usage error (${res.status}): ${err}`));
+      return Promise.reject(new Error(`usage error (${res.status} ${res.statusText}): ${err}`));
     });
   }
 

--- a/src/connection/httpClient.ts
+++ b/src/connection/httpClient.ts
@@ -139,7 +139,7 @@ const makeCheckStatus = (expectResponseBody: boolean) => (res: Response) => {
       } catch (e) {
         err = errText;
       }
-      return Promise.reject(new Error(`usage error (${res.status} ${res.statusText}): ${err}`));
+      return Promise.reject(new Error(`usage error (${res.status} ${res.statusText}), detail: ${err}`));
     });
   }
 


### PR DESCRIPTION
This PR fixes a bug raised in https://github.com/weaviate/typescript-client/issues/63 where a >400 error code returned from a HEAD request does not propagate correctly to the user. Also contained are small type improvements to help with DevEx and increased ease of understanding of the codebase.

@parkerduckworth :grin: