### PR TITLE
Handle existing scheme in host

### DIFF
--- a/src/connection/gqlClient.ts
+++ b/src/connection/gqlClient.ts
@@ -9,9 +9,7 @@ export interface GraphQLClient {
 export const gqlClient = (config: ConnectionParams): GraphQLClient => {
   const defaultHeaders = config.headers;
   const version = '/v1/graphql';
-  const baseUri = config.host.startsWith(`${config.scheme}://`)
-    ? `${config.host}${version}`
-    : `${config.scheme}://${config.host}${version}`;
+  const baseUri = `${config.host}${version}`;
 
   return {
     // for backward compatibility with replaced graphql-client lib,

--- a/src/connection/gqlClient.ts
+++ b/src/connection/gqlClient.ts
@@ -7,14 +7,17 @@ export interface GraphQLClient {
 }
 
 export const gqlClient = (config: ConnectionParams): GraphQLClient => {
-  const scheme = config.scheme;
-  const host = config.host;
   const defaultHeaders = config.headers;
+  const version = '/v1/graphql';
+  const baseUri = config.host.startsWith(`${config.scheme}://`)
+    ? `${config.host}${version}`
+    : `${config.scheme}://${config.host}${version}`;
+
   return {
     // for backward compatibility with replaced graphql-client lib,
     // results are wrapped into { data: data }
     query: (query: TQuery, variables?: Variables, headers?: HeadersInit) => {
-      return new Client(`${scheme}://${host}/v1/graphql`, {
+      return new Client(baseUri, {
         headers: {
           ...defaultHeaders,
           ...headers,

--- a/src/connection/httpClient.ts
+++ b/src/connection/httpClient.ts
@@ -15,9 +15,7 @@ export interface HttpClient {
 
 export const httpClient = (config: ConnectionParams): HttpClient => {
   const version = '/v1';
-  const baseUri = config.host.startsWith(`${config.scheme}://`)
-    ? `${config.host}${version}`
-    : `${config.scheme}://${config.host}${version}`;
+  const baseUri = `${config.host}${version}`;
   const url = makeUrl(baseUri);
 
   return {

--- a/src/connection/httpClient.ts
+++ b/src/connection/httpClient.ts
@@ -14,7 +14,10 @@ export interface HttpClient {
 }
 
 export const httpClient = (config: ConnectionParams): HttpClient => {
-  const baseUri = `${config.scheme}://${config.host}/v1`;
+  const version = '/v1';
+  const baseUri = config.host.startsWith(`${config.scheme}://`)
+    ? `${config.host}${version}`
+    : `${config.scheme}://${config.host}${version}`;
   const url = makeUrl(baseUri);
 
   return {

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -10,11 +10,13 @@ export default class Connection {
   private apiKey?: string;
   private authEnabled: boolean;
   private gql: GraphQLClient;
+  public readonly host: string;
   public readonly http: HttpClient;
   public oidcAuth?: OidcAuthenticator;
 
   constructor(params: ConnectionParams) {
     params = this.sanitizeParams(params);
+    this.host = params.host;
     this.http = httpClient(params);
     this.gql = gqlClient(params);
     this.authEnabled = this.parseAuthParams(params);
@@ -36,8 +38,30 @@ export default class Connection {
   }
 
   private sanitizeParams(params: ConnectionParams) {
+    // Remove trailing slashes from the host
     while (params.host.endsWith('/')) {
       params.host = params.host.slice(0, -1);
+    }
+
+    const protocolPattern = /^(https?:\/\/|ftp:\/\/|file:\/\/)/;
+    const extractedSchemeMatch = params.host.match(protocolPattern);
+
+    // Check for the existence of scheme in params
+    if (params.scheme) {
+      // If the host contains a scheme different than provided scheme, replace it and throw a warning
+      if (extractedSchemeMatch && extractedSchemeMatch[0] !== `${params.scheme}://`) {
+        throw new Error(
+          `The host contains a different protocol than specified in the scheme (scheme: ${params.scheme}:// != host: ${extractedSchemeMatch[0]})`
+        );
+      } else if (!extractedSchemeMatch) {
+        // If no scheme in the host, simply prefix with the provided scheme
+        params.host = `${params.scheme}://${params.host}`;
+      }
+      // If there's no scheme in params, ensure the host starts with a recognized protocol
+    } else if (!extractedSchemeMatch) {
+      throw new Error(
+        'The host must start with a recognized protocol (e.g., http:// or https://) if no scheme is provided.'
+      );
     }
 
     return params;

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -43,15 +43,15 @@ export default class Connection {
       params.host = params.host.slice(0, -1);
     }
 
-    const protocolPattern = /^(https?:\/\/|ftp:\/\/|file:\/\/)/;
+    const protocolPattern = /^(https?|ftp|file)(?::\/\/)/;
     const extractedSchemeMatch = params.host.match(protocolPattern);
 
     // Check for the existence of scheme in params
     if (params.scheme) {
       // If the host contains a scheme different than provided scheme, replace it and throw a warning
-      if (extractedSchemeMatch && extractedSchemeMatch[0] !== `${params.scheme}://`) {
+      if (extractedSchemeMatch && extractedSchemeMatch[1] !== `${params.scheme}`) {
         throw new Error(
-          `The host contains a different protocol than specified in the scheme (scheme: ${params.scheme}:// != host: ${extractedSchemeMatch[0]})`
+          `The host contains a different protocol than specified in the scheme (scheme: ${params.scheme} != host: ${extractedSchemeMatch[1]})`
         );
       } else if (!extractedSchemeMatch) {
         // If no scheme in the host, simply prefix with the provided scheme
@@ -60,7 +60,7 @@ export default class Connection {
       // If there's no scheme in params, ensure the host starts with a recognized protocol
     } else if (!extractedSchemeMatch) {
       throw new Error(
-        'The host must start with a recognized protocol (e.g., http:// or https://) if no scheme is provided.'
+        'The host must start with a recognized protocol (e.g., http or https) if no scheme is provided.'
       );
     }
 

--- a/src/connection/unit.test.ts
+++ b/src/connection/unit.test.ts
@@ -124,6 +124,40 @@ describe('mock server auth tests', () => {
     await conn.login().then((key) => expect(key).toEqual(apiKey));
   });
 
+  it('should construct the correct baseUri for conn.http when host contains scheme', async () => {
+    const apiKey = 'abcd123';
+
+    const conn = new Connection({
+      scheme: 'http',
+      host: 'http://localhost:' + server.port,
+      apiKey: new ApiKey(apiKey),
+    });
+
+    await conn.http.get('/testEndpoint');
+    const lastRequestURL = server.lastRequest().path; // Get the path of the last request
+    const expectedPath = '/v1/testEndpoint';
+    expect(lastRequestURL).toEqual(expectedPath);
+  });
+
+  it('should construct the correct baseUri for conn.query when host contains scheme', async () => {
+    const apiKey = 'abcd123';
+
+    const conn = new Connection({
+      scheme: 'http',
+      host: 'http://localhost:' + server.port,
+      apiKey: new ApiKey(apiKey),
+    });
+
+    try {
+      await conn.query('{ query { users } }');
+    } catch (error) {
+      // We just want to test the last request path
+    }
+    const lastRequestURL = server.lastRequest().path;
+    const expectedPath = '/v1/graphql';
+    expect(lastRequestURL).toEqual(expectedPath);
+  });
+
   it('shuts down the server', () => {
     return server.close();
   });

--- a/src/connection/unit.test.ts
+++ b/src/connection/unit.test.ts
@@ -174,7 +174,7 @@ describe('mock server auth tests', () => {
     };
 
     expect(createConnection).toThrow(
-      'The host contains a different protocol than specified in the scheme (scheme: https:// != host: http://)'
+      'The host contains a different protocol than specified in the scheme (scheme: https != host: http)'
     );
   });
 
@@ -189,7 +189,7 @@ describe('mock server auth tests', () => {
     };
 
     expect(createConnection).toThrow(
-      'The host must start with a recognized protocol (e.g., http:// or https://) if no scheme is provided.'
+      'The host must start with a recognized protocol (e.g., http or https) if no scheme is provided.'
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export interface ConnectionParams {
   authClientSecret?: AuthClientCredentials | AuthAccessTokenCredentials | AuthUserPasswordCredentials;
   apiKey?: ApiKey;
   host: string;
-  scheme: string;
+  scheme?: string;
   headers?: HeadersInit;
 }
 
@@ -43,9 +43,6 @@ const app = {
   client: function (params: ConnectionParams): WeaviateClient {
     // check if the URL is set
     if (!params.host) throw new Error('Missing `host` parameter');
-
-    // check if the scheme is set
-    if (!params.scheme) throw new Error('Missing `scheme` parameter');
 
     // check if headers are set
     if (!params.headers) params.headers = {};

--- a/test/server.ts
+++ b/test/server.ts
@@ -27,7 +27,7 @@ export function testServer() {
     lastRequest = ctx.request;
     return next();
   });
-  app.use(getLocalOidcConfig, getRemoteOidcConfig, issueToken);
+  app.use(getLocalOidcConfig, getRemoteOidcConfig, issueToken, mockGetEndpoint, mockGraphQLResponse);
   const server = app.listen(port);
 
   serverCache = {
@@ -45,6 +45,28 @@ export function testServer() {
 
   return serverCache;
 }
+
+const mockGetEndpoint = (ctx: any, next: any) => {
+  if (ctx.path !== '/v1/testEndpoint') {
+    return next();
+  }
+
+  ctx.response.status = 200;
+  ctx.response.body = { message: 'test endpoint' };
+};
+
+const mockGraphQLResponse = (ctx: any, next: any) => {
+  if (ctx.path !== '/v1/graphql') {
+    return next();
+  }
+
+  ctx.response.status = 200;
+  ctx.response.body = {
+    data: {
+      someField: 'someValue',
+    },
+  };
+};
 
 const getLocalOidcConfig = (ctx: any, next: any) => {
   if (ctx.path !== '/v1/.well-known/openid-configuration') {


### PR DESCRIPTION
This `PR` aims to fix https://github.com/weaviate/typescript-client/issues/87 and adds a simple check before creating the `baseUrl`

```
const version = '/v1';
const baseUri = config.host.startsWith(`${config.scheme}://`)
    ? `${config.host}${version}`
    : `${config.scheme}://${config.host}${version}`;
```

This allows users to use a host URL with a scheme if it matches the specified scheme.

The PR also adds two unit tests to verify that it constructs the correct URLs.