### PR TITLE
fix: pass-through tenant when batch-creating cross-references

### DIFF
--- a/src/batch/referencesBatcher.ts
+++ b/src/batch/referencesBatcher.ts
@@ -73,6 +73,7 @@ export default class ReferencesBatcher extends CommandBase {
     return this.beaconPath.rebuild(reference.to!).then((beaconTo: any) => ({
       from: reference.from,
       to: beaconTo,
+      tenant: reference.tenant,
     }));
   };
 }


### PR DESCRIPTION
When using multi tenancy and trying to use the cross-reference batcher, the tenant would not be passed through.
This caused an error because weaviate expects the tenant for tenant-enabled classes.