### PR TITLE
make changes for 1.23 support

### DIFF
--- a/ci/docker-compose-azure-cc.yml
+++ b/ci/docker-compose-azure-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -25,7 +25,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     ports:
       - 8088:8080
       - 6061:6060

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate:
-    image: semitechnologies/weaviate:1.22.0
+    image: semitechnologies/weaviate:1.23.0-rc.1
     restart: on-failure:0
     ports:
       - "8080:8080"

--- a/src/cluster/journey.test.ts
+++ b/src/cluster/journey.test.ts
@@ -7,8 +7,8 @@ import {
   SOUP_CLASS_NAME,
 } from '../utils/testData';
 
-const EXPECTED_WEAVIATE_VERSION = '1.22.0';
-const EXPECTED_WEAVIATE_GIT_HASH = 'b4f2ffb';
+const EXPECTED_WEAVIATE_VERSION = '1.23.0-rc.1';
+const EXPECTED_WEAVIATE_GIT_HASH = '841915f';
 
 describe('cluster nodes endpoint', () => {
   const client = weaviate.client({
@@ -19,6 +19,7 @@ describe('cluster nodes endpoint', () => {
   it('get nodes status of empty db', () => {
     return client.cluster
       .nodesStatusGetter()
+      .withOutput('verbose')
       .do()
       .then((nodesStatusResponse: NodesStatusResponse) => {
         expect(nodesStatusResponse.nodes).toBeDefined();
@@ -44,7 +45,52 @@ describe('cluster nodes endpoint', () => {
 
   it('sets up db', () => createTestFoodSchemaAndData(client));
 
-  it('get nodes status of food db', () => {
+  it('get verbose nodes status of food db', () => {
+    return client.cluster
+      .nodesStatusGetter()
+      .withOutput('verbose')
+      .do()
+      .then((nodesStatusResponse: NodesStatusResponse) => {
+        expect(nodesStatusResponse.nodes).toHaveLength(1);
+        if (nodesStatusResponse.nodes) {
+          const node = nodesStatusResponse.nodes[0];
+          expect(node.name).toMatch(/.+/);
+          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
+          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.status).toEqual('HEALTHY');
+          expect(node.stats?.objectCount).toEqual(6);
+          expect(node.stats?.shardCount).toEqual(2);
+          expect(node.shards).toBeDefined();
+          expect(node.shards).toHaveLength(2);
+          if (node.shards) {
+            expect([node.shards[0].class, node.shards[1].class]).toEqual(
+              expect.arrayContaining([PIZZA_CLASS_NAME, SOUP_CLASS_NAME])
+            );
+            for (let i = 0; i < node.shards.length; i++) {
+              const shard = node.shards[i];
+              expect(shard.name).toMatch(/.+/);
+              switch (shard.class) {
+                case PIZZA_CLASS_NAME:
+                  expect(shard.objectCount).toEqual(4);
+                  break;
+                case SOUP_CLASS_NAME:
+                  expect(shard.objectCount).toEqual(2);
+                  break;
+              }
+            }
+          } else {
+            throw new Error('node.shards should be defined');
+          }
+        } else {
+          throw new Error('nodesStatusResponse.nodes should be defined');
+        }
+      })
+      .catch((e: any) => {
+        throw new Error('should not fail on getting nodes: ' + e);
+      });
+  });
+
+  it('get default nodes status of food db', () => {
     return client.cluster
       .nodesStatusGetter()
       .do()
@@ -88,10 +134,36 @@ describe('cluster nodes endpoint', () => {
       });
   });
 
+  it('get minimal nodes status of food db', () => {
+    return client.cluster
+      .nodesStatusGetter()
+      .withOutput('minimal')
+      .do()
+      .then((nodesStatusResponse: NodesStatusResponse) => {
+        expect(nodesStatusResponse.nodes).toHaveLength(1);
+        if (nodesStatusResponse.nodes) {
+          const node = nodesStatusResponse.nodes[0];
+          expect(node.name).toMatch(/.+/);
+          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
+          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.status).toEqual('HEALTHY');
+          expect(node.stats?.objectCount).toEqual(6);
+          expect(node.stats?.shardCount).toEqual(2);
+          expect(node.shards).toBeNull();
+        } else {
+          throw new Error('nodesStatusResponse.nodes should be defined');
+        }
+      })
+      .catch((e: any) => {
+        throw new Error('should not fail on getting nodes: ' + e);
+      });
+  });
+
   it('get nodes status of only Pizza class in food db', () => {
     return client.cluster
       .nodesStatusGetter()
       .withClassName(PIZZA_CLASS_NAME)
+      .withOutput('verbose')
       .do()
       .then((nodesStatusResponse: NodesStatusResponse) => {
         expect(nodesStatusResponse.nodes).toBeDefined();

--- a/src/cluster/nodesStatusGetter.ts
+++ b/src/cluster/nodesStatusGetter.ts
@@ -4,6 +4,7 @@ import { CommandBase } from '../validation/commandBase';
 
 export default class NodesStatusGetter extends CommandBase {
   private className?: string;
+  private output?: string;
 
   constructor(client: Connection) {
     super(client);
@@ -14,14 +15,25 @@ export default class NodesStatusGetter extends CommandBase {
     return this;
   };
 
+  withOutput = (output: 'minimal' | 'verbose') => {
+    this.output = output;
+    return this;
+  };
+
   validate() {
     // nothing to validate
   }
 
   do = (): Promise<NodesStatusResponse> => {
+    let path = '/nodes';
     if (this.className) {
-      return this.client.get(`/nodes/${this.className}`);
+      path = `${path}/${this.className}`;
     }
-    return this.client.get('/nodes');
+    if (this.output) {
+      path = `${path}?output=${this.output}`;
+    } else {
+      path = `${path}?output=verbose`;
+    }
+    return this.client.get(path);
   };
 }


### PR DESCRIPTION
Supports new `verbose` option in the Nodes API that has a server-side default of `minimal`. However, so as not to introduce a breaking client change, the client's default is `verbose`. This will default will be changed to `minimal` when Weaviate `1.24` releases to give a longer deprecation cycle