### PR TITLE
Add support for named vectors in 1.24 release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ on:
 
 
 env:
-  WEAVIATE_VERSION: preview-introduce-named-vectors-89777d6
+  WEAVIATE_VERSION: preview--f005cb8
 
 jobs:
   checks:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
 
 
+env:
+  WEAVIATE_VERSION: preview-introduce-named-vectors-89777d6
+
 jobs:
   checks:
     runs-on: ubuntu-latest
@@ -32,7 +35,7 @@ jobs:
     - name: "Install dependencies"
       run: |
         npm install
-        ci/run_dependencies.sh
+        ci/run_dependencies.sh ${{ env.WEAVIATE_VERSION }}
     - name: "Run tests with authentication tests"
       if: ${{ !github.event.pull_request.head.repo.fork }}
       env:
@@ -49,7 +52,7 @@ jobs:
         npm test
         npm run build
     - name: "Stop Weaviate"
-      run: ci/stop_dependencies.sh
+      run: ci/stop_dependencies.sh ${{ env.WEAVIATE_VERSION }}
 
   publish:
     needs: tests

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ weaviate-data/
 *.tgz
 .npmrc
 .eslintcache
+test.sh

--- a/ci/docker-compose-azure-cc.yml
+++ b/ci/docker-compose-azure-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8081:8081
     restart: on-failure:0

--- a/ci/docker-compose-cluster.yml
+++ b/ci/docker-compose-cluster.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate-node-1:
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     restart: on-failure:0
     ports:
       - "8087:8080"
@@ -26,7 +26,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8088:8080
       - 6061:6060

--- a/ci/docker-compose-okta-cc.yml
+++ b/ci/docker-compose-okta-cc.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8082:8082
     restart: on-failure:0

--- a/ci/docker-compose-okta-users.yml
+++ b/ci/docker-compose-okta-users.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8083:8083
     restart: on-failure:0

--- a/ci/docker-compose-openai.yml
+++ b/ci/docker-compose-openai.yml
@@ -9,7 +9,7 @@ services:
       - '8086'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8086:8086
     restart: on-failure:0

--- a/ci/docker-compose-wcs.yml
+++ b/ci/docker-compose-wcs.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
       - --write-timeout=600s
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     ports:
       - 8085:8085
     restart: on-failure:0

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.4'
 services:
   weaviate:
-    image: semitechnologies/weaviate:1.23.0-rc.1
+    image: semitechnologies/weaviate:${WEAVIATE_VERSION}
     restart: on-failure:0
     ports:
       - "8080:8080"

--- a/ci/run_dependencies.sh
+++ b/ci/run_dependencies.sh
@@ -2,6 +2,8 @@
 
 set -eou pipefail
 
+export WEAVIATE_VERSION=$1
+
 source ./ci/compose.sh
 
 echo "Stop existing session if running"

--- a/ci/stop_dependencies.sh
+++ b/ci/stop_dependencies.sh
@@ -2,6 +2,8 @@
 
 set -eou pipefail
 
+export WEAVIATE_VERSION=$1
+
 source ./ci/compose.sh
 
 compose_down_all

--- a/src/cluster/journey.test.ts
+++ b/src/cluster/journey.test.ts
@@ -55,7 +55,7 @@ describe('cluster nodes endpoint', () => {
           expect(node.version).toBeDefined();
           expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
-          expect(node.stats?.objectCount).toEqual(6);
+          expect(node.stats?.objectCount).toEqual(0);
           expect(node.stats?.shardCount).toEqual(2);
           expect(node.shards).toBeDefined();
           expect(node.shards).toHaveLength(2);
@@ -68,10 +68,10 @@ describe('cluster nodes endpoint', () => {
               expect(shard.name).toMatch(/.+/);
               switch (shard.class) {
                 case PIZZA_CLASS_NAME:
-                  expect(shard.objectCount).toEqual(4);
+                  expect(shard.objectCount).toEqual(0);
                   break;
                 case SOUP_CLASS_NAME:
-                  expect(shard.objectCount).toEqual(2);
+                  expect(shard.objectCount).toEqual(0);
                   break;
               }
             }
@@ -99,7 +99,7 @@ describe('cluster nodes endpoint', () => {
           expect(node.version).toBeDefined();
           expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
-          expect(node.stats?.objectCount).toEqual(6);
+          expect(node.stats?.objectCount).toEqual(0);
           expect(node.stats?.shardCount).toEqual(2);
           expect(node.shards).toBeDefined();
           expect(node.shards).toHaveLength(2);
@@ -112,10 +112,10 @@ describe('cluster nodes endpoint', () => {
               expect(shard.name).toMatch(/.+/);
               switch (shard.class) {
                 case PIZZA_CLASS_NAME:
-                  expect(shard.objectCount).toEqual(4);
+                  expect(shard.objectCount).toEqual(0);
                   break;
                 case SOUP_CLASS_NAME:
-                  expect(shard.objectCount).toEqual(2);
+                  expect(shard.objectCount).toEqual(0);
                   break;
               }
             }
@@ -170,13 +170,13 @@ describe('cluster nodes endpoint', () => {
           expect(node.version).toBeDefined();
           expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
-          expect(node.stats?.objectCount).toEqual(4);
+          expect(node.stats?.objectCount).toEqual(0);
           expect(node.stats?.shardCount).toEqual(1);
           expect(node.shards).toBeDefined();
           expect(node.shards).toHaveLength(1);
           if (node.shards) {
             expect(node.shards[0].class).toEqual(PIZZA_CLASS_NAME);
-            expect(node.shards[0].objectCount).toEqual(4);
+            expect(node.shards[0].objectCount).toEqual(0);
             expect(node.shards[0].name).toBeDefined();
           } else {
             throw new Error('node.shards should be defined');

--- a/src/cluster/journey.test.ts
+++ b/src/cluster/journey.test.ts
@@ -7,9 +7,6 @@ import {
   SOUP_CLASS_NAME,
 } from '../utils/testData';
 
-const EXPECTED_WEAVIATE_VERSION = '1.23.0-rc.1';
-const EXPECTED_WEAVIATE_GIT_HASH = '841915f';
-
 describe('cluster nodes endpoint', () => {
   const client = weaviate.client({
     scheme: 'http',
@@ -27,8 +24,8 @@ describe('cluster nodes endpoint', () => {
         if (nodesStatusResponse.nodes) {
           const node = nodesStatusResponse.nodes[0] ?? [];
           expect(node.name).toMatch(/.+/);
-          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
-          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.version).toBeDefined();
+          expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
           expect(node.stats).toBeDefined();
           expect(node.stats?.objectCount).toEqual(0);
@@ -55,8 +52,8 @@ describe('cluster nodes endpoint', () => {
         if (nodesStatusResponse.nodes) {
           const node = nodesStatusResponse.nodes[0];
           expect(node.name).toMatch(/.+/);
-          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
-          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.version).toBeDefined();
+          expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
           expect(node.stats?.objectCount).toEqual(6);
           expect(node.stats?.shardCount).toEqual(2);
@@ -99,8 +96,8 @@ describe('cluster nodes endpoint', () => {
         if (nodesStatusResponse.nodes) {
           const node = nodesStatusResponse.nodes[0];
           expect(node.name).toMatch(/.+/);
-          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
-          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.version).toBeDefined();
+          expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
           expect(node.stats?.objectCount).toEqual(6);
           expect(node.stats?.shardCount).toEqual(2);
@@ -144,8 +141,8 @@ describe('cluster nodes endpoint', () => {
         if (nodesStatusResponse.nodes) {
           const node = nodesStatusResponse.nodes[0];
           expect(node.name).toMatch(/.+/);
-          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
-          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.version).toBeDefined();
+          expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
           expect(node.stats?.objectCount).toEqual(6);
           expect(node.stats?.shardCount).toEqual(2);
@@ -171,8 +168,8 @@ describe('cluster nodes endpoint', () => {
         if (nodesStatusResponse.nodes) {
           const node = nodesStatusResponse.nodes[0];
           expect(node.name).toMatch(/.+/);
-          expect(node.version).toEqual(EXPECTED_WEAVIATE_VERSION);
-          expect(node.gitHash).toEqual(EXPECTED_WEAVIATE_GIT_HASH);
+          expect(node.version).toBeDefined();
+          expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
           expect(node.stats?.objectCount).toEqual(4);
           expect(node.stats?.shardCount).toEqual(1);

--- a/src/cluster/journey.test.ts
+++ b/src/cluster/journey.test.ts
@@ -144,8 +144,7 @@ describe('cluster nodes endpoint', () => {
           expect(node.version).toBeDefined();
           expect(node.gitHash).toBeDefined();
           expect(node.status).toEqual('HEALTHY');
-          expect(node.stats?.objectCount).toEqual(6);
-          expect(node.stats?.shardCount).toEqual(2);
+          expect(node.stats).toBeUndefined();
           expect(node.shards).toBeNull();
         } else {
           throw new Error('nodesStatusResponse.nodes should be defined');

--- a/src/data/creator.ts
+++ b/src/data/creator.ts
@@ -12,6 +12,7 @@ export default class Creator extends CommandBase {
   private objectsPath: ObjectsPath;
   private properties?: Properties;
   private vector?: number[];
+  private vectors?: Record<string, number[]>;
   private tenant?: string;
 
   constructor(client: Connection, objectsPath: ObjectsPath) {
@@ -21,6 +22,11 @@ export default class Creator extends CommandBase {
 
   withVector = (vector: number[]) => {
     this.vector = vector;
+    return this;
+  };
+
+  withVectors = (vectors: Record<string, number[]>) => {
+    this.vectors = vectors;
     return this;
   };
 
@@ -61,6 +67,7 @@ export default class Creator extends CommandBase {
     properties: this.properties,
     class: this.className,
     id: this.id,
+    vectors: this.vectors,
   });
 
   validate = () => {

--- a/src/data/updater.ts
+++ b/src/data/updater.ts
@@ -12,11 +12,23 @@ export default class Updater extends CommandBase {
   private objectsPath: ObjectsPath;
   private properties?: Properties;
   private tenant?: string;
+  private vector?: number[];
+  private vectors?: Record<string, number[]>;
 
   constructor(client: Connection, objectsPath: ObjectsPath) {
     super(client);
     this.objectsPath = objectsPath;
   }
+
+  withVector = (vector: number[]) => {
+    this.vector = vector;
+    return this;
+  };
+
+  withVectors = (vectors: Record<string, number[]>) => {
+    this.vectors = vectors;
+    return this;
+  };
 
   withProperties = (properties: Properties) => {
     this.properties = properties;
@@ -60,6 +72,8 @@ export default class Updater extends CommandBase {
     properties: this.properties,
     class: this.className,
     id: this.id,
+    vector: this.vector,
+    vectors: this.vectors,
   });
 
   validate = () => {

--- a/src/graphql/nearImage.ts
+++ b/src/graphql/nearImage.ts
@@ -2,17 +2,20 @@ import { NearMediaBase } from './nearMedia';
 
 export interface NearImageArgs extends NearMediaBase {
   image?: string;
+  targetVectors?: string[];
 }
 
 export default class GraphQLNearImage {
   private certainty?: number;
   private distance?: number;
   private image?: string;
+  private targetVectors?: string[];
 
   constructor(args: NearImageArgs) {
     this.certainty = args.certainty;
     this.distance = args.distance;
     this.image = args.image;
+    this.targetVectors = args.targetVectors;
   }
 
   toString(wrap = true) {
@@ -35,6 +38,10 @@ export default class GraphQLNearImage {
 
     if (this.distance) {
       args = [...args, `distance:${this.distance}`];
+    }
+
+    if (this.targetVectors && this.targetVectors.length > 0) {
+      args = [...args, `targetVectors:${JSON.stringify(this.targetVectors)}`];
     }
 
     if (!wrap) {

--- a/src/graphql/nearMedia.ts
+++ b/src/graphql/nearMedia.ts
@@ -1,6 +1,7 @@
 export interface NearMediaBase {
   certainty?: number;
   distance?: number;
+  targetVectors?: string[];
 }
 export interface NearMediaArgs extends NearMediaBase {
   media: string;
@@ -39,12 +40,14 @@ export default class GraphQLNearMedia {
   private distance?: number;
   private media: string;
   private type: NearMediaType;
+  private targetVectors?: string[];
 
   constructor(args: NearMediaArgs) {
     this.certainty = args.certainty;
     this.distance = args.distance;
     this.media = args.media;
     this.type = args.type;
+    this.targetVectors = args.targetVectors;
   }
 
   toString(wrap = true) {
@@ -62,6 +65,10 @@ export default class GraphQLNearMedia {
 
     if (this.distance) {
       args = [...args, `distance:${this.distance}`];
+    }
+
+    if (this.targetVectors && this.targetVectors.length > 0) {
+      args = [...args, `targetVectors:${JSON.stringify(this.targetVectors)}`];
     }
 
     if (!wrap) {

--- a/src/graphql/nearObject.ts
+++ b/src/graphql/nearObject.ts
@@ -3,6 +3,7 @@ export interface NearObjectArgs {
   certainty?: number;
   distance?: number;
   id?: string;
+  targetVectors?: string[];
 }
 
 export default class GraphQLNearObject {
@@ -10,12 +11,14 @@ export default class GraphQLNearObject {
   private certainty?: number;
   private distance?: number;
   private id?: string;
+  private targetVectors?: string[];
 
   constructor(args: NearObjectArgs) {
     this.beacon = args.beacon;
     this.certainty = args.certainty;
     this.distance = args.distance;
     this.id = args.id;
+    this.targetVectors = args.targetVectors;
   }
 
   toString(wrap = true) {
@@ -37,6 +40,10 @@ export default class GraphQLNearObject {
 
     if (this.distance) {
       args = [...args, `distance:${this.distance}`];
+    }
+
+    if (this.targetVectors && this.targetVectors.length > 0) {
+      args = [...args, `targetVectors:${JSON.stringify(this.targetVectors)}`];
     }
 
     if (!wrap) {

--- a/src/graphql/nearText.ts
+++ b/src/graphql/nearText.ts
@@ -5,6 +5,7 @@ export interface NearTextArgs {
   distance?: number;
   moveAwayFrom?: Move;
   moveTo?: Move;
+  targetVectors?: string[];
 }
 
 export interface Move {
@@ -25,6 +26,7 @@ export default class GraphQLNearText {
   private distance?: number;
   private moveAwayFrom?: any;
   private moveTo?: any;
+  private targetVectors?: string[];
 
   constructor(args: NearTextArgs) {
     this.autocorrect = args.autocorrect;
@@ -33,6 +35,7 @@ export default class GraphQLNearText {
     this.distance = args.distance;
     this.moveAwayFrom = args.moveAwayFrom;
     this.moveTo = args.moveTo;
+    this.targetVectors = args.targetVectors;
   }
 
   toString(): string {
@@ -46,6 +49,10 @@ export default class GraphQLNearText {
 
     if (this.distance) {
       args = [...args, `distance:${this.distance}`];
+    }
+
+    if (this.targetVectors && this.targetVectors.length > 0) {
+      args = [...args, `targetVectors:${JSON.stringify(this.targetVectors)}`];
     }
 
     if (this.moveTo) {

--- a/src/graphql/nearVector.ts
+++ b/src/graphql/nearVector.ts
@@ -2,17 +2,20 @@ export interface NearVectorArgs {
   certainty?: number;
   distance?: number;
   vector: number[];
+  targetVectors?: string[];
 }
 
 export default class GraphQLNearVector {
   private certainty?: number;
   private distance?: number;
   private vector: number[];
+  private targetVectors?: string[];
 
   constructor(args: NearVectorArgs) {
     this.certainty = args.certainty;
     this.distance = args.distance;
     this.vector = args.vector;
+    this.targetVectors = args.targetVectors;
   }
 
   toString(wrap = true) {
@@ -24,6 +27,10 @@ export default class GraphQLNearVector {
 
     if (this.distance) {
       args = [...args, `distance:${this.distance}`];
+    }
+
+    if (this.targetVectors && this.targetVectors.length > 0) {
+      args = [...args, `targetVectors:${JSON.stringify(this.targetVectors)}`];
     }
 
     if (!wrap) {

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -155,6 +155,9 @@ describe('schema', () => {
                   segments: 0,
                   trainingLimit: 100000,
                 },
+                bq: {
+                  enabled: false,
+                },
                 skip: false,
                 efConstruction: 128,
                 vectorCacheMaxObjects: 500000,
@@ -796,6 +799,9 @@ function newClassObject(className: string) {
         },
         segments: 0,
         trainingLimit: 100000,
+      },
+      bq: {
+        enabled: false,
       },
       skip: false,
       efConstruction: 128,

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+source ~/.bash_profile
+
+export OPENAI_APIKEY=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
+
+# ci/run_dependencies.sh $2
+npm run test -- $1
+# ci/stop_dependencies.sh $2

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-source ~/.bash_profile
-
-export OPENAI_APIKEY=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
-
-# ci/run_dependencies.sh $2
-npm run test -- $1
-# ci/stop_dependencies.sh $2


### PR DESCRIPTION
This PR adds support for utilising the new named vectors feature of Weaviate landing in `1.24`

This includes:
- creating classes with named vector configurations
- creating and updating objects with named vectors
- querying for objects by the specific named vectors