### PR TITLE
Add support for target vectors in hybrid queries

### DIFF
--- a/src/graphql/hybrid.ts
+++ b/src/graphql/hybrid.ts
@@ -3,6 +3,7 @@ export interface HybridArgs {
   query: string;
   vector?: number[];
   properties?: string[];
+  targetVectors?: string[];
   fusionType?: FusionType;
 }
 
@@ -16,6 +17,7 @@ export default class GraphQLHybrid {
   private query: string;
   private vector?: number[];
   private properties?: string[];
+  private targetVectors?: string[];
   private fusionType?: FusionType;
 
   constructor(args: HybridArgs) {
@@ -23,6 +25,7 @@ export default class GraphQLHybrid {
     this.query = args.query;
     this.vector = args.vector;
     this.properties = args.properties;
+    this.targetVectors = args.targetVectors;
     this.fusionType = args.fusionType;
   }
 
@@ -38,8 +41,11 @@ export default class GraphQLHybrid {
     }
 
     if (this.properties && this.properties.length > 0) {
-      const props = this.properties.join('","');
-      args = [...args, `properties:["${props}"]`];
+      args = [...args, `properties:${JSON.stringify(this.properties)}`];
+    }
+
+    if (this.targetVectors && this.targetVectors.length > 0) {
+      args = [...args, `targetVectors:${JSON.stringify(this.targetVectors)}`];
     }
 
     if (this.fusionType !== undefined) {

--- a/src/graphql/journey.test.ts
+++ b/src/graphql/journey.test.ts
@@ -2254,7 +2254,7 @@ describe('named vectors test', () => {
       .withFields('rating')
       .do()
       .then((res) => {
-        expect(res.data.Get.NamedVectorTest).toHaveLength(3);
+        expect(res.data.Get.NamedVectorTest).toHaveLength(1);
         expect(res.data.Get.NamedVectorTest[0].rating).toBe('Best');
       });
   });

--- a/src/graphql/journey.test.ts
+++ b/src/graphql/journey.test.ts
@@ -2243,6 +2243,22 @@ describe('named vectors test', () => {
       });
   });
 
+  it('should perform a hybrid query on the rating vector', () => {
+    return client.graphql
+      .get()
+      .withClassName(className)
+      .withHybrid({
+        query: 'Best',
+        targetVectors: ['rating'],
+      })
+      .withFields('rating')
+      .do()
+      .then((res) => {
+        expect(res.data.Get.NamedVectorTest).toHaveLength(3);
+        expect(res.data.Get.NamedVectorTest[0].rating).toBe('Best');
+      });
+  });
+
   describe('destroy', () => {
     it('tears down NamedVectorTest class', () => {
       return client.schema.classDeleter().withClassName(className).do();


### PR DESCRIPTION
Fixes [113](https://github.com/weaviate/typescript-client/issues/113).