### PR TITLE
Make changes in response to beta feedback

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NEW_WEAVIATE_VERSION: 1.25.0-raft-8f2b428
+  NEW_WEAVIATE_VERSION: 1.24.10
 
 jobs:
   checks:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NEW_WEAVIATE_VERSION: 1.24.7
+  NEW_WEAVIATE_VERSION: 1.24.10
 
 jobs:
   checks:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NEW_WEAVIATE_VERSION: 1.24.10
+  NEW_WEAVIATE_VERSION: 1.25.0-raft-8f2b428
 
 jobs:
   checks:

--- a/ci/compose.sh
+++ b/ci/compose.sh
@@ -21,5 +21,5 @@ function compose_down_all {
 }
 
 function all_weaviate_ports {
-  echo "8080 8081 8082 8083 8085 8086 8087 8088"
+  echo "8079 8080 8081 8082 8083 8085 8086 8087 8088"
 }

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -100,7 +100,7 @@ describe('Testing of the collection.aggregate methods', () => {
           // },
         ],
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(async () => {

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -99,7 +99,7 @@ describe('Testing of the collection.aggregate methods', () => {
           //   dataType: [collectionName],
           // },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
           vectorizeClassName: false,
         }),
       })
@@ -294,9 +294,9 @@ describe('Testing of the collection.aggregate methods', () => {
 
 describe('Testing of the collection.aggregate methods with named vectors', () => {
   let client: WeaviateClient;
-  let collection: Collection<TestCollectionAggregateNamedVectors, 'TestCollectionAggregateNamedVectors'>;
-  const collectionName = 'TestCollectionAggregateNamedVectors';
-  type TestCollectionAggregateNamedVectors = {
+  let collection: Collection<TestCollectionAggregateVectors, 'TestCollectionAggregateVectors'>;
+  const collectionName = 'TestCollectionAggregateVectors';
+  type TestCollectionAggregateVectors = {
     text: string;
   };
 
@@ -321,7 +321,7 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
       },
     });
     collection = client.collections.use(collectionName);
-    return client.collections.create<TestCollectionAggregateNamedVectors>({
+    return client.collections.create<TestCollectionAggregateVectors>({
       name: collectionName,
       properties: [
         {
@@ -330,7 +330,7 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
         },
       ],
       vectorizers: [
-        weaviate.configure.namedVectorizer.text2VecContextionary('text', {
+        weaviate.configure.vectorizer.text2VecContextionary('text', {
           sourceProperties: ['text'],
           vectorIndexConfig: weaviate.configure.vectorIndex.hnsw(),
         }),

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -143,14 +143,15 @@ describe('Testing of the collection.aggregate methods', () => {
     expect(result.totalCount).toEqual(100);
   });
 
-  it('should aggregate grouped by data without a search and no property metrics', async () => {
-    const result = await collection.aggregate.groupBy.overAll({ groupBy: 'text' });
-    expect(result.length).toEqual(1);
-    expect(result[0].totalCount).toEqual(100);
-    expect(result[0].groupedBy.prop).toEqual('text');
-    expect(result[0].groupedBy.value).toEqual('test');
-    expect(result[0].properties).toBeUndefined();
-  });
+  // Skip until fixed in 1.24.11
+  // it('should aggregate grouped by data without a search and no property metrics', async () => {
+  //   const result = await collection.aggregate.groupBy.overAll({ groupBy: 'text' });
+  //   expect(result.length).toEqual(1);
+  //   expect(result[0].totalCount).toEqual(100);
+  //   expect(result[0].groupedBy.prop).toEqual('text');
+  //   expect(result[0].groupedBy.value).toEqual('test');
+  //   expect(result[0].properties).toBeUndefined();
+  // });
 
   it('should aggregate grouped by data with a near text search and no property metrics', async () => {
     const result = await collection.aggregate.groupBy.nearText('test', {

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -49,7 +49,7 @@ describe('Testing of the collection.aggregate methods', () => {
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     return client.collections
       .create({
         name: collectionName,
@@ -172,7 +172,7 @@ describe('Testing of the collection.aggregate methods', () => {
   });
 
   it('should aggregate data without a search and one non-generic property metric', async () => {
-    const result = await (await client).collections.get(collectionName).aggregate.overAll({
+    const result = await (await client).collections.use(collectionName).aggregate.overAll({
       returnMetrics: collection.metrics
         .aggregate('text')
         .text(['count', 'topOccurrencesOccurs', 'topOccurrencesValue']),
@@ -314,7 +314,7 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     return client.collections.create<TestCollectionAggregateNamedVectors>({
       name: collectionName,
       properties: [

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -323,10 +323,11 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
           dataType: 'text',
         },
       ],
-      vectorizer: [
+      vectorizers: [
         weaviate.configure.namedVectorizer('text', {
           properties: ['text'],
           vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
+          vectorIndexConfig: weaviate.configure.vectorIndex.hnsw(),
         }),
       ],
     });

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -99,7 +99,9 @@ describe('Testing of the collection.aggregate methods', () => {
           //   dataType: [collectionName],
           // },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(async () => {
         const data: DataObject<TestCollectionAggregate>[] = [];
@@ -151,7 +153,11 @@ describe('Testing of the collection.aggregate methods', () => {
   });
 
   it('should aggregate grouped by data with a near text search and no property metrics', async () => {
-    const result = await collection.aggregate.groupBy.nearText('test', { groupBy: 'text', certainty: 0.1 });
+    const result = await collection.aggregate.groupBy.nearText('test', {
+      groupBy: 'text',
+      certainty: 0.1,
+      targetVector: 'vector',
+    });
     expect(result.length).toEqual(1);
     expect(result[0].totalCount).toEqual(100);
     expect(result[0].groupedBy.prop).toEqual('text');
@@ -324,9 +330,8 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
         },
       ],
       vectorizers: [
-        weaviate.configure.namedVectorizer('text', {
-          properties: ['text'],
-          vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
+        weaviate.configure.namedVectorizer.text2VecContextionary('text', {
+          sourceProperties: ['text'],
           vectorIndexConfig: weaviate.configure.vectorIndex.hnsw(),
         }),
       ],

--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -49,7 +49,7 @@ describe('Testing of the collection.aggregate methods', () => {
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     return client.collections
       .create({
         name: collectionName,
@@ -179,7 +179,7 @@ describe('Testing of the collection.aggregate methods', () => {
   });
 
   it('should aggregate data without a search and one non-generic property metric', async () => {
-    const result = await (await client).collections.use(collectionName).aggregate.overAll({
+    const result = await (await client).collections.get(collectionName).aggregate.overAll({
       returnMetrics: collection.metrics
         .aggregate('text')
         .text(['count', 'topOccurrencesOccurs', 'topOccurrencesValue']),
@@ -321,7 +321,7 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     return client.collections.create<TestCollectionAggregateVectors>({
       name: collectionName,
       properties: [

--- a/src/collections/backup/collection.ts
+++ b/src/collections/backup/collection.ts
@@ -1,6 +1,10 @@
 import { Backend, BackupStatus } from '../../backup/index.js';
 import Connection from '../../connection/index.js';
-import { BackupCreateResponse, BackupRestoreStatusResponse } from '../../openapi/types.js';
+import {
+  BackupCreateResponse,
+  BackupCreateStatusResponse,
+  BackupRestoreStatusResponse,
+} from '../../openapi/types.js';
 import { BackupStatusArgs, backup } from './client.js';
 
 /** The arguments required to create and restore backups. */
@@ -45,14 +49,14 @@ export interface BackupCollection {
    * @param {BackupStatusArgs} args The arguments for the request.
    * @returns {Promise<BackupStatus>} The status of the backup.
    */
-  getCreateStatus(args: BackupStatusArgs): Promise<BackupStatus>;
+  getCreateStatus(args: BackupStatusArgs): Promise<BackupCreateStatusResponse>;
   /**
    * Get the status of a restore.
    *
    * @param {BackupStatusArgs} args The arguments for the request.
    * @returns {Promise<BackupStatus>} The status of the restore.
    */
-  getRestoreStatus(args: BackupStatusArgs): Promise<BackupStatus>;
+  getRestoreStatus(args: BackupStatusArgs): Promise<BackupRestoreStatusResponse>;
   /**
    * Restore a backup of this collection.
    *

--- a/src/collections/collection/index.ts
+++ b/src/collections/collection/index.ts
@@ -1,5 +1,6 @@
 import Connection from '../../connection/grpc.js';
 import { ConsistencyLevel } from '../../data/index.js';
+import { WeaviateInvalidInputError } from '../../errors.js';
 import ClassExists from '../../schema/classExists.js';
 import { DbVersionSupport } from '../../utils/dbVersion.js';
 
@@ -103,7 +104,7 @@ const collection = <T, N>(
   tenant?: Tenant
 ) => {
   if (!isString(name)) {
-    throw new Error(`The collection name must be a string, got: ${typeof name}`);
+    throw new WeaviateInvalidInputError(`The collection name must be a string, got: ${typeof name}`);
   }
   const capitalizedName = capitalizeCollectionName(name);
   const queryCollection = query<T>(

--- a/src/collections/config/classes.ts
+++ b/src/collections/config/classes.ts
@@ -9,7 +9,7 @@ import {
 import { CollectionConfigUpdate, VectorIndexType } from './types/index.js';
 import {
   InvertedIndexConfigUpdate,
-  NamedVectorConfigUpdate,
+  VectorConfigUpdate,
   ReplicationConfigUpdate,
   VectorIndexConfigFlatUpdate,
   VectorIndexConfigHNSWUpdate,
@@ -74,7 +74,7 @@ export class MergeWithExisting {
 
   static vectors(
     current: WeaviateVectorsConfig,
-    update?: NamedVectorConfigUpdate<string, VectorIndexType>[]
+    update?: VectorConfigUpdate<string, VectorIndexType>[]
   ): WeaviateVectorsConfig {
     if (current === undefined) throw Error('Vector index config is missing from the class schema.');
     if (update === undefined) return current;

--- a/src/collections/config/classes.ts
+++ b/src/collections/config/classes.ts
@@ -115,8 +115,8 @@ export class MergeWithExisting {
   ): WeaviateVectorIndexConfig {
     if (update === undefined) return current;
     if (
-      (QuantizerGuards.isBQUpdate(update.quantizer) && (current?.bq as any).enabled) ||
-      (QuantizerGuards.isPQUpdate(update.quantizer) && (current?.pq as any).enabled)
+      (QuantizerGuards.isBQUpdate(update.quantizer) && ((current?.bq as any) || {}).enabled) ||
+      (QuantizerGuards.isPQUpdate(update.quantizer) && ((current?.pq as any) || {}).enabled)
     )
       throw Error(`Cannot update the quantizer type of an enabled vector index.`);
     const { quantizer, ...rest } = update;

--- a/src/collections/config/classes.ts
+++ b/src/collections/config/classes.ts
@@ -30,8 +30,22 @@ export class MergeWithExisting {
         current.replicationConfig!,
         update.replication
       );
-    if (update.vectorizer !== undefined && Array.isArray(update.vectorizer)) {
-      current.vectorConfig = MergeWithExisting.vectors(current.vectorConfig, update.vectorizer);
+    if (update.vectorizer !== undefined) {
+      if (Array.isArray(update.vectorizer)) {
+        current.vectorConfig = MergeWithExisting.vectors(current.vectorConfig, update.vectorizer);
+      } else if (update.vectorizer.name === 'hnsw') {
+        current.vectorIndexConfig = MergeWithExisting.hnsw(
+          current.vectorIndexConfig,
+          update.vectorizer.config
+        );
+      } else if (update.vectorizer.name === 'flat') {
+        current.vectorIndexConfig = MergeWithExisting.flat(
+          current.vectorIndexConfig,
+          update.vectorizer.config
+        );
+      } else {
+        throw Error(`Cannot update vector index config with unknown type ${update.vectorizer.name}`);
+      }
     }
     return current;
   }

--- a/src/collections/config/index.ts
+++ b/src/collections/config/index.ts
@@ -11,6 +11,7 @@ import {
 import { classToCollection, resolveProperty, resolveReference } from './utils.js';
 import ClassUpdater from '../../schema/classUpdater.js';
 import { MergeWithExisting } from './classes.js';
+import { WeaviateDeserializationError } from '../../errors.js';
 
 const config = <T>(connection: Connection, name: string, tenant?: string): Config<T> => {
   const getRaw = new ClassGetter(connection).withClassName(name).do;
@@ -37,10 +38,12 @@ const config = <T>(connection: Connection, name: string, tenant?: string): Confi
       }
       return builder.do().then((shards) =>
         shards.map((shard) => {
-          if (shard.name === undefined) throw new Error('Shard name was not returned by Weaviate');
-          if (shard.status === undefined) throw new Error('Shard status was not returned by Weaviate');
+          if (shard.name === undefined)
+            throw new WeaviateDeserializationError('Shard name was not returned by Weaviate');
+          if (shard.status === undefined)
+            throw new WeaviateDeserializationError('Shard status was not returned by Weaviate');
           if (shard.vectorQueueSize === undefined)
-            throw new Error('Shard vector queue size was not returned by Weaviate');
+            throw new WeaviateDeserializationError('Shard vector queue size was not returned by Weaviate');
           return { name: shard.name, status: shard.status, vectorQueueSize: shard.vectorQueueSize };
         })
       );

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -143,7 +143,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'int',
         },
       ],
-      vectorizer: [
+      vectorizers: [
         weaviate.configure.namedVectorizer('title', {
           properties: ['title'],
           vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
@@ -349,7 +349,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizer: [weaviate.configure.namedVectorizer('text')],
+      vectorizers: [weaviate.configure.namedVectorizer('text')],
     });
     const config = await collection.config
       .update({

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -37,7 +37,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizer: weaviate.configure.vectorizer.none(),
+      vectorizers: weaviate.configure.namedVectorizer.none('default'),
     });
     const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
@@ -89,7 +89,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizer: weaviate.configure.vectorizer.none(),
+      vectorizers: weaviate.configure.namedVectorizer.none('default'),
     });
     const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
@@ -144,13 +144,11 @@ describe('Testing of the collection.config namespace', () => {
         },
       ],
       vectorizers: [
-        weaviate.configure.namedVectorizer('title', {
-          properties: ['title'],
-          vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
+        weaviate.configure.namedVectorizer.text2VecContextionary('title', {
+          sourceProperties: ['title'],
         }),
-        weaviate.configure.namedVectorizer('age', {
-          properties: ['age'],
-          vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
+        weaviate.configure.namedVectorizer.text2VecContextionary('age', {
+          sourceProperties: ['age'],
         }),
       ],
     });
@@ -235,7 +233,7 @@ describe('Testing of the collection.config namespace', () => {
     const collectionName = 'TestCollectionConfigAddProperty';
     const collection = await client.collections.create({
       name: collectionName,
-      vectorizer: weaviate.configure.vectorizer.none(),
+      vectorizers: weaviate.configure.namedVectorizer.none('default'),
     });
     const config = await collection.config
       .addProperty({
@@ -262,7 +260,7 @@ describe('Testing of the collection.config namespace', () => {
     const collectionName = 'TestCollectionConfigAddReference' as const;
     const collection = await client.collections.create({
       name: collectionName,
-      vectorizer: weaviate.configure.vectorizer.none(),
+      vectorizers: weaviate.configure.namedVectorizer.none('default'),
     });
     const config = await collection.config
       .addReference({
@@ -349,7 +347,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizers: [weaviate.configure.namedVectorizer('text')],
+      vectorizers: [weaviate.configure.namedVectorizer.none('text')],
     });
     const config = await collection.config
       .update({
@@ -418,7 +416,10 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizer: weaviate.configure.vectorizer.none(),
+      vectorizer: {
+        name: 'none',
+        config: {},
+      },
     });
     const config = await collection.config
       .update({

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -39,7 +39,7 @@ describe('Testing of the collection.config namespace', () => {
       ],
       vectorizers: weaviate.configure.vectorizer.none('default'),
     });
-    const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
+    const collection = client.collections.get<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
 
     expect(config.name).toEqual(collectionName);
@@ -91,7 +91,7 @@ describe('Testing of the collection.config namespace', () => {
       ],
       vectorizers: weaviate.configure.vectorizer.none('default'),
     });
-    const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
+    const collection = client.collections.get<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
 
     expect(config.name).toEqual(collectionName);

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -37,7 +37,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizers: weaviate.configure.namedVectorizer.none('default'),
+      vectorizers: weaviate.configure.vectorizer.none('default'),
     });
     const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
@@ -89,7 +89,7 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizers: weaviate.configure.namedVectorizer.none('default'),
+      vectorizers: weaviate.configure.vectorizer.none('default'),
     });
     const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
@@ -129,7 +129,7 @@ describe('Testing of the collection.config namespace', () => {
   });
 
   it('should be able to get a collection with named vectors', async () => {
-    const collectionName = 'TestCollectionConfigGetNamedVectors';
+    const collectionName = 'TestCollectionConfigGetVectors';
     const collection = await client.collections.create({
       name: collectionName,
       properties: [
@@ -144,10 +144,10 @@ describe('Testing of the collection.config namespace', () => {
         },
       ],
       vectorizers: [
-        weaviate.configure.namedVectorizer.text2VecContextionary('title', {
+        weaviate.configure.vectorizer.text2VecContextionary('title', {
           sourceProperties: ['title'],
         }),
-        weaviate.configure.namedVectorizer.text2VecContextionary('age', {
+        weaviate.configure.vectorizer.text2VecContextionary('age', {
           sourceProperties: ['age'],
         }),
       ],
@@ -233,7 +233,7 @@ describe('Testing of the collection.config namespace', () => {
     const collectionName = 'TestCollectionConfigAddProperty';
     const collection = await client.collections.create({
       name: collectionName,
-      vectorizers: weaviate.configure.namedVectorizer.none('default'),
+      vectorizers: weaviate.configure.vectorizer.none('default'),
     });
     const config = await collection.config
       .addProperty({
@@ -260,7 +260,7 @@ describe('Testing of the collection.config namespace', () => {
     const collectionName = 'TestCollectionConfigAddReference' as const;
     const collection = await client.collections.create({
       name: collectionName,
-      vectorizers: weaviate.configure.namedVectorizer.none('default'),
+      vectorizers: weaviate.configure.vectorizer.none('default'),
     });
     const config = await collection.config
       .addReference({
@@ -347,12 +347,12 @@ describe('Testing of the collection.config namespace', () => {
           dataType: 'text',
         },
       ],
-      vectorizers: [weaviate.configure.namedVectorizer.none('text')],
+      vectorizers: [weaviate.configure.vectorizer.none('text')],
     });
     const config = await collection.config
       .update({
         vectorizer: [
-          weaviate.reconfigure.namedVectorizer('text', {
+          weaviate.reconfigure.vectorizer.update('text', {
             vectorIndexConfig: weaviate.reconfigure.vectorIndex.hnsw({
               quantizer: weaviate.reconfigure.vectorIndex.quantizer.pq(),
               ef: 4,

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -39,7 +39,7 @@ describe('Testing of the collection.config namespace', () => {
       ],
       vectorizer: weaviate.configure.vectorizer.none(),
     });
-    const collection = client.collections.get<TestCollectionConfigGet>(collectionName);
+    const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
 
     expect(config.name).toEqual(collectionName);
@@ -91,7 +91,7 @@ describe('Testing of the collection.config namespace', () => {
       ],
       vectorizer: weaviate.configure.vectorizer.none(),
     });
-    const collection = client.collections.get<TestCollectionConfigGet>(collectionName);
+    const collection = client.collections.use<TestCollectionConfigGet>(collectionName);
     const config = await collection.config.get();
 
     expect(config.name).toEqual(collectionName);

--- a/src/collections/config/types/generative.ts
+++ b/src/collections/config/types/generative.ts
@@ -38,7 +38,8 @@ export type GenerativeConfig =
   | GenerativeOpenAIConfig
   | GenerativeCohereConfig
   | GenerativePaLMConfig
-  | Record<string, any>;
+  | Record<string, any>
+  | undefined;
 
 export type GenerativeConfigType<G> = G extends 'generative-openai'
   ? GenerativeOpenAIConfig

--- a/src/collections/config/types/index.ts
+++ b/src/collections/config/types/index.ts
@@ -14,9 +14,9 @@ import { RerankerConfig } from './reranker.js';
 import { VectorConfig } from './vectorizer.js';
 import { VectorIndexType } from './vectorIndex.js';
 
-export type ModuleConfig<N, C = Record<string, any>> = {
+export type ModuleConfig<N, C = undefined> = {
   name: N;
-  config?: C;
+  config: C;
 };
 
 export type InvertedIndexConfig = {

--- a/src/collections/config/types/index.ts
+++ b/src/collections/config/types/index.ts
@@ -5,9 +5,9 @@ export * from './vectorizer.js';
 
 import {
   InvertedIndexConfigUpdate,
+  LegacyVectorizerConfigUpdate,
   NamedVectorConfigUpdate,
   ReplicationConfigUpdate,
-  VectorIndexConfigUpdate,
 } from '../../configure/types/index.js';
 import { GenerativeConfig } from './generative.js';
 import { RerankerConfig } from './reranker.js';
@@ -98,5 +98,5 @@ export type CollectionConfigUpdate = {
   description?: string;
   invertedIndex?: InvertedIndexConfigUpdate;
   replication?: ReplicationConfigUpdate;
-  vectorizer?: VectorIndexConfigUpdate | NamedVectorConfigUpdate<string, VectorIndexType>[];
+  vectorizer?: LegacyVectorizerConfigUpdate | NamedVectorConfigUpdate<string, VectorIndexType>[];
 };

--- a/src/collections/config/types/index.ts
+++ b/src/collections/config/types/index.ts
@@ -6,7 +6,7 @@ export * from './vectorizer.js';
 import {
   InvertedIndexConfigUpdate,
   LegacyVectorizerConfigUpdate,
-  NamedVectorConfigUpdate,
+  VectorConfigUpdate,
   ReplicationConfigUpdate,
 } from '../../configure/types/index.js';
 import { GenerativeConfig } from './generative.js';
@@ -98,5 +98,5 @@ export type CollectionConfigUpdate = {
   description?: string;
   invertedIndex?: InvertedIndexConfigUpdate;
   replication?: ReplicationConfigUpdate;
-  vectorizer?: LegacyVectorizerConfigUpdate | NamedVectorConfigUpdate<string, VectorIndexType>[];
+  vectorizer?: LegacyVectorizerConfigUpdate | VectorConfigUpdate<string, VectorIndexType>[];
 };

--- a/src/collections/config/types/reranker.ts
+++ b/src/collections/config/types/reranker.ts
@@ -4,7 +4,11 @@ export type RerankerCohereConfig = {
   model?: 'rerank-english-v2.0' | 'rerank-multilingual-v2.0' | string;
 };
 
-export type RerankerConfig = RerankerCohereConfig | RerankerTransformersConfig | Record<string, any>;
+export type RerankerConfig =
+  | RerankerCohereConfig
+  | RerankerTransformersConfig
+  | Record<string, any>
+  | undefined;
 
 export type Reranker = 'reranker-cohere' | 'reranker-transformers' | 'none' | string;
 

--- a/src/collections/config/types/reranker.ts
+++ b/src/collections/config/types/reranker.ts
@@ -4,18 +4,25 @@ export type RerankerCohereConfig = {
   model?: 'rerank-english-v2.0' | 'rerank-multilingual-v2.0' | string;
 };
 
+export type RerankerVoyageAIConfig = {
+  model?: 'rerank-lite-1' | string;
+};
+
 export type RerankerConfig =
   | RerankerCohereConfig
   | RerankerTransformersConfig
+  | RerankerVoyageAIConfig
   | Record<string, any>
   | undefined;
 
-export type Reranker = 'reranker-cohere' | 'reranker-transformers' | 'none' | string;
+export type Reranker = 'reranker-cohere' | 'reranker-transformers' | 'reranker-voyageai' | 'none' | string;
 
 export type RerankerConfigType<R> = R extends 'reranker-cohere'
   ? RerankerCohereConfig
   : R extends 'reranker-transformers'
   ? RerankerTransformersConfig
+  : R extends 'reranker-voyageai'
+  ? RerankerVoyageAIConfig
   : R extends 'none'
   ? undefined
   : Record<string, any> | undefined;

--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -37,7 +37,7 @@ export type Img2VecNeuralConfig = {
 export type Multi2VecClipConfig = {
   imageFields?: string[];
   textFields?: string[];
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Multi2VecBindConfig = {
@@ -48,7 +48,7 @@ export type Multi2VecBindConfig = {
   textFields?: string[];
   thermalFields?: string[];
   videoFields?: string[];
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Multi2VecPalmConfig = {
@@ -56,7 +56,7 @@ export type Multi2VecPalmConfig = {
   location?: string;
   modelId?: string;
   dimensions?: number;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Ref2VecCentroidConfig = {
@@ -69,29 +69,29 @@ export type Text2VecAWSConfig = {
   model?: string;
   region: string;
   service: string;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecAzureOpenAIConfig = {
   baseURL?: string;
   deploymentID: string;
   resourceName: string;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecCohereConfig = {
   baseURL?: string;
   model?: string;
   truncate?: boolean;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecContextionaryConfig = {
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecGPT4AllConfig = {
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecHuggingFaceConfig = {
@@ -102,12 +102,12 @@ export type Text2VecHuggingFaceConfig = {
   useCache?: boolean;
   useGPU?: boolean;
   waitForModel?: boolean;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecJinaConfig = {
   model?: string;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecOpenAIConfig = {
@@ -116,26 +116,26 @@ export type Text2VecOpenAIConfig = {
   model?: string;
   modelVersion?: string;
   type?: string;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecPalmConfig = {
   apiEndpoint?: string;
   modelId?: string;
   projectId: string;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecTransformersConfig = {
   poolingStrategy?: string;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type Text2VecVoyageAIConfig = {
   baseURL?: string;
   model?: string;
   truncate?: boolean;
-  vectorizeClassName?: boolean;
+  vectorizeCollectionName?: boolean;
 };
 
 export type NoVectorizerConfig = {};

--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -18,6 +18,7 @@ export type Vectorizer =
   | 'multi2vec-palm'
   | 'ref2vec-centroid'
   | 'text2vec-aws'
+  | 'text2vec-azure-openai'
   | 'text2vec-cohere'
   | 'text2vec-contextionary'
   | 'text2vec-gpt4all'
@@ -130,7 +131,7 @@ export type Text2VecTransformersConfig = {
   vectorizeClassName?: boolean;
 };
 
-export type Text2VecVoyageConfig = {
+export type Text2VecVoyageAIConfig = {
   baseURL?: string;
   model?: string;
   truncate?: boolean;
@@ -140,11 +141,11 @@ export type Text2VecVoyageConfig = {
 export type NoVectorizerConfig = {};
 
 export type VectorizerConfigType<V> = V extends 'img2vec-neural'
-  ? Img2VecNeuralConfig
+  ? Img2VecNeuralConfig | undefined
   : V extends 'multi2vec-clip'
-  ? Multi2VecClipConfig
+  ? Multi2VecClipConfig | undefined
   : V extends 'multi2vec-bind'
-  ? Multi2VecBindConfig
+  ? Multi2VecBindConfig | undefined
   : V extends 'multi2vec-palm'
   ? Multi2VecPalmConfig
   : V extends 'ref2vec-centroid'
@@ -152,24 +153,28 @@ export type VectorizerConfigType<V> = V extends 'img2vec-neural'
   : V extends 'text2vec-aws'
   ? Text2VecAWSConfig
   : V extends 'text2vec-contextionary'
-  ? Text2VecContextionaryConfig
+  ? Text2VecContextionaryConfig | undefined
   : V extends 'text2vec-cohere'
-  ? Text2VecCohereConfig
+  ? Text2VecCohereConfig | undefined
   : V extends 'text2vec-gpt4all'
-  ? Text2VecGPT4AllConfig
+  ? Text2VecGPT4AllConfig | undefined
   : V extends 'text2vec-huggingface'
-  ? Text2VecHuggingFaceConfig
+  ? Text2VecHuggingFaceConfig | undefined
   : V extends 'text2vec-jina'
-  ? Text2VecJinaConfig
+  ? Text2VecJinaConfig | undefined
   : V extends 'text2vec-openai'
-  ? Text2VecOpenAIConfig
+  ? Text2VecOpenAIConfig | undefined
+  : V extends 'text2vec-azure-openai'
+  ? Text2VecAzureOpenAIConfig
   : V extends 'text2vec-palm'
   ? Text2VecPalmConfig
   : V extends 'text2vec-transformers'
-  ? Text2VecTransformersConfig
+  ? Text2VecTransformersConfig | undefined
   : V extends 'text2vec-voyageai'
-  ? Text2VecVoyageConfig
+  ? Text2VecVoyageAIConfig | undefined
   : V extends 'none'
+  ? {}
+  : V extends undefined
   ? undefined
   : never;
 
@@ -189,5 +194,5 @@ export type VectorizerConfig =
   | Text2VecOpenAIConfig
   | Text2VecPalmConfig
   | Text2VecTransformersConfig
-  | Text2VecVoyageConfig
+  | Text2VecVoyageAIConfig
   | NoVectorizerConfig;

--- a/src/collections/config/unit.test.ts
+++ b/src/collections/config/unit.test.ts
@@ -48,7 +48,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
       vectorizer: {
         'text2vec-contextionary': {
           properties: ['name'],
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         },
       },
     },
@@ -103,7 +103,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
       vectorizer: {
         'text2vec-contextionary': {
           properties: ['name'],
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         },
       },
     },
@@ -188,7 +188,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
         vectorizer: {
           'text2vec-contextionary': {
             properties: ['name'],
-            vectorizeClassName: false,
+            vectorizeCollectionName: false,
           },
         },
       },
@@ -250,7 +250,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
         vectorizer: {
           'text2vec-contextionary': {
             properties: ['name'],
-            vectorizeClassName: false,
+            vectorizeCollectionName: false,
           },
         },
       },
@@ -285,7 +285,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
         vectorizer: {
           'text2vec-contextionary': {
             properties: ['name'],
-            vectorizeClassName: false,
+            vectorizeCollectionName: false,
           },
         },
       },
@@ -321,7 +321,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
         vectorizer: {
           'text2vec-contextionary': {
             properties: ['name'],
-            vectorizeClassName: false,
+            vectorizeCollectionName: false,
           },
         },
       },

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -41,6 +41,7 @@ import {
   ReferenceMultiTargetConfigCreate,
   ReferenceSingleTargetConfigCreate,
 } from '../configure/types/index.js';
+import { WeaviateDeserializationError } from '../../errors.js';
 
 export class ReferenceTypeGuards {
   static isSingleTarget<T>(ref: ReferenceConfigCreate<T>): ref is ReferenceSingleTargetConfigCreate<T> {
@@ -126,20 +127,21 @@ function exists<T>(v: any): v is T {
 
 class ConfigGuards {
   static _name(v?: string): string {
-    if (v === undefined) throw new Error('Collection name was not returned by Weaviate');
+    if (v === undefined)
+      throw new WeaviateDeserializationError('Collection name was not returned by Weaviate');
     return v;
   }
   static bm25(v?: WeaviateBM25Config): InvertedIndexConfig['bm25'] {
-    if (v === undefined) throw new Error('BM25 was not returned by Weaviate');
-    if (!populated(v.b)) throw new Error('BM25 b was not returned by Weaviate');
-    if (!populated(v.k1)) throw new Error('BM25 k1 was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('BM25 was not returned by Weaviate');
+    if (!populated(v.b)) throw new WeaviateDeserializationError('BM25 b was not returned by Weaviate');
+    if (!populated(v.k1)) throw new WeaviateDeserializationError('BM25 k1 was not returned by Weaviate');
     return {
       b: v.b,
       k1: v.k1,
     };
   }
   static stopwords(v?: WeaviateStopwordConfig): InvertedIndexConfig['stopwords'] {
-    if (v === undefined) throw new Error('Stopwords were not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Stopwords were not returned by Weaviate');
     return {
       additions: v.additions ? v.additions : [],
       preset: v.preset ? v.preset : 'none',
@@ -150,7 +152,8 @@ class ConfigGuards {
     if (!populated(v)) return undefined;
     const generativeKey = Object.keys(v).find((k) => k.includes('generative'));
     if (generativeKey === undefined) return undefined;
-    if (!generativeKey) throw new Error('Generative config was not returned by Weaviate');
+    if (!generativeKey)
+      throw new WeaviateDeserializationError('Generative config was not returned by Weaviate');
     return v[generativeKey] as GenerativeConfig;
   }
   static reranker(v?: WeaviateModuleConfig): RerankerConfig | undefined {
@@ -160,15 +163,17 @@ class ConfigGuards {
     return v[rerankerKey] as RerankerConfig;
   }
   private static namedVectors(v: WeaviateVectorsConfig): VectorConfig {
-    if (!populated(v)) throw new Error('Vector config was not returned by Weaviate');
+    if (!populated(v)) throw new WeaviateDeserializationError('Vector config was not returned by Weaviate');
     const out: VectorConfig = {};
     Object.keys(v).forEach((key) => {
       const vectorizer = v[key].vectorizer;
       if (!populated(vectorizer))
-        throw new Error(`Vectorizer was not returned by Weaviate for ${key} named vector`);
+        throw new WeaviateDeserializationError(
+          `Vectorizer was not returned by Weaviate for ${key} named vector`
+        );
       const vectorizerNames = Object.keys(vectorizer);
       if (vectorizerNames.length !== 1)
-        throw new Error(
+        throw new WeaviateDeserializationError(
           `Expected exactly one vectorizer for ${key} named vector, got ${vectorizerNames.length}`
         );
       const vectorizerName = vectorizerNames[0];
@@ -190,11 +195,12 @@ class ConfigGuards {
     return out;
   }
   static vectorizer(v?: WeaviateClass): VectorConfig {
-    if (!populated(v)) throw new Error('Schema was not returned by Weaviate');
+    if (!populated(v)) throw new WeaviateDeserializationError('Schema was not returned by Weaviate');
     if (populated(v.vectorConfig)) {
       return ConfigGuards.namedVectors(v.vectorConfig);
     }
-    if (!populated(v.vectorizer)) throw new Error('Vectorizer was not returned by Weaviate');
+    if (!populated(v.vectorizer))
+      throw new WeaviateDeserializationError('Vectorizer was not returned by Weaviate');
     return {
       default: {
         vectorizer:
@@ -213,9 +219,10 @@ class ConfigGuards {
     };
   }
   static invertedIndex(v?: WeaviateInvertedIndexConfig): InvertedIndexConfig {
-    if (v === undefined) throw new Error('Inverted index was not returned by Weaviate');
+    if (v === undefined)
+      throw new WeaviateDeserializationError('Inverted index was not returned by Weaviate');
     if (!populated(v.cleanupIntervalSeconds))
-      throw new Error('Inverted index cleanup interval was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Inverted index cleanup interval was not returned by Weaviate');
     return {
       bm25: ConfigGuards.bm25(v.bm25),
       cleanupIntervalSeconds: v.cleanupIntervalSeconds,
@@ -226,32 +233,37 @@ class ConfigGuards {
     };
   }
   static multiTenancy(v?: WeaviateMultiTenancyConfig): MultiTenancyConfig {
-    if (v === undefined) throw new Error('Multi tenancy was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Multi tenancy was not returned by Weaviate');
     return {
       enabled: v.enabled ? v.enabled : false,
     };
   }
   static replication(v?: WeaviateReplicationConfig): ReplicationConfig {
-    if (v === undefined) throw new Error('Replication was not returned by Weaviate');
-    if (!populated(v.factor)) throw new Error('Replication factor was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Replication was not returned by Weaviate');
+    if (!populated(v.factor))
+      throw new WeaviateDeserializationError('Replication factor was not returned by Weaviate');
     return {
       factor: v.factor,
     };
   }
   static sharding(v?: WeaviateShardingConfig): ShardingConfig {
-    if (v === undefined) throw new Error('Sharding was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Sharding was not returned by Weaviate');
     if (!exists<number>(v.virtualPerPhysical))
-      throw new Error('Sharding enabled was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Sharding enabled was not returned by Weaviate');
     if (!exists<number>(v.desiredCount))
-      throw new Error('Sharding desired count was not returned by Weaviate');
-    if (!exists<number>(v.actualCount)) throw new Error('Sharding actual count was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Sharding desired count was not returned by Weaviate');
+    if (!exists<number>(v.actualCount))
+      throw new WeaviateDeserializationError('Sharding actual count was not returned by Weaviate');
     if (!exists<number>(v.desiredVirtualCount))
-      throw new Error('Sharding desired virtual count was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Sharding desired virtual count was not returned by Weaviate');
     if (!exists<number>(v.actualVirtualCount))
-      throw new Error('Sharding actual virtual count was not returned by Weaviate');
-    if (!exists<'_id'>(v.key)) throw new Error('Sharding key was not returned by Weaviate');
-    if (!exists<'hash'>(v.strategy)) throw new Error('Sharding strategy was not returned by Weaviate');
-    if (!exists<'murmur3'>(v.function)) throw new Error('Sharding function was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Sharding actual virtual count was not returned by Weaviate');
+    if (!exists<'_id'>(v.key))
+      throw new WeaviateDeserializationError('Sharding key was not returned by Weaviate');
+    if (!exists<'hash'>(v.strategy))
+      throw new WeaviateDeserializationError('Sharding strategy was not returned by Weaviate');
+    if (!exists<'murmur3'>(v.function))
+      throw new WeaviateDeserializationError('Sharding function was not returned by Weaviate');
     return {
       virtualPerPhysical: v.virtualPerPhysical,
       desiredCount: v.desiredCount,
@@ -264,26 +276,31 @@ class ConfigGuards {
     };
   }
   static pqEncoder(v?: Record<string, unknown>): PQEncoderConfig {
-    if (v === undefined) throw new Error('PQ encoder was not returned by Weaviate');
-    if (!exists<PQEncoderType>(v.type)) throw new Error('PQ encoder name was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('PQ encoder was not returned by Weaviate');
+    if (!exists<PQEncoderType>(v.type))
+      throw new WeaviateDeserializationError('PQ encoder name was not returned by Weaviate');
     if (!exists<PQEncoderDistribution>(v.distribution))
-      throw new Error('PQ encoder distribution was not returned by Weaviate');
+      throw new WeaviateDeserializationError('PQ encoder distribution was not returned by Weaviate');
     return {
       type: v.type,
       distribution: v.distribution,
     };
   }
   static pq(v?: Record<string, unknown>): PQConfig | undefined {
-    if (v === undefined) throw new Error('PQ was not returned by Weaviate');
-    if (!exists<boolean>(v.enabled)) throw new Error('PQ enabled was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('PQ was not returned by Weaviate');
+    if (!exists<boolean>(v.enabled))
+      throw new WeaviateDeserializationError('PQ enabled was not returned by Weaviate');
     if (v.enabled === false) return undefined;
     if (!exists<boolean>(v.bitCompression))
-      throw new Error('PQ bit compression was not returned by Weaviate');
-    if (!exists<number>(v.segments)) throw new Error('PQ segments was not returned by Weaviate');
-    if (!exists<number>(v.trainingLimit)) throw new Error('PQ training limit was not returned by Weaviate');
-    if (!exists<number>(v.centroids)) throw new Error('PQ centroids was not returned by Weaviate');
+      throw new WeaviateDeserializationError('PQ bit compression was not returned by Weaviate');
+    if (!exists<number>(v.segments))
+      throw new WeaviateDeserializationError('PQ segments was not returned by Weaviate');
+    if (!exists<number>(v.trainingLimit))
+      throw new WeaviateDeserializationError('PQ training limit was not returned by Weaviate');
+    if (!exists<number>(v.centroids))
+      throw new WeaviateDeserializationError('PQ centroids was not returned by Weaviate');
     if (!exists<Record<string, unknown>>(v.encoder))
-      throw new Error('PQ encoder was not returned by Weaviate');
+      throw new WeaviateDeserializationError('PQ encoder was not returned by Weaviate');
     return {
       bitCompression: v.bitCompression,
       segments: v.segments,
@@ -294,27 +311,31 @@ class ConfigGuards {
     };
   }
   static vectorIndexHNSW(v: WeaviateVectorIndexConfig): VectorIndexConfigHNSW {
-    if (v === undefined) throw new Error('Vector index was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Vector index was not returned by Weaviate');
     if (!exists<number>(v.cleanupIntervalSeconds))
-      throw new Error('Vector index cleanup interval was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index cleanup interval was not returned by Weaviate');
     if (!exists<VectorDistance>(v.distance))
-      throw new Error('Vector index distance was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index distance was not returned by Weaviate');
     if (!exists<number>(v.dynamicEfMin))
-      throw new Error('Vector index dynamic ef min was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index dynamic ef min was not returned by Weaviate');
     if (!exists<number>(v.dynamicEfMax))
-      throw new Error('Vector index dynamic ef max was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index dynamic ef max was not returned by Weaviate');
     if (!exists<number>(v.dynamicEfFactor))
-      throw new Error('Vector index dynamic ef factor was not returned by Weaviate');
-    if (!exists<number>(v.ef)) throw new Error('Vector index ef was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index dynamic ef factor was not returned by Weaviate');
+    if (!exists<number>(v.ef))
+      throw new WeaviateDeserializationError('Vector index ef was not returned by Weaviate');
     if (!exists<number>(v.efConstruction))
-      throw new Error('Vector index ef construction was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index ef construction was not returned by Weaviate');
     if (!exists<number>(v.flatSearchCutoff))
-      throw new Error('Vector index flat search cut off was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index flat search cut off was not returned by Weaviate');
     if (!exists<number>(v.maxConnections))
-      throw new Error('Vector index max connections was not returned by Weaviate');
-    if (!exists<boolean>(v.skip)) throw new Error('Vector index skip was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index max connections was not returned by Weaviate');
+    if (!exists<boolean>(v.skip))
+      throw new WeaviateDeserializationError('Vector index skip was not returned by Weaviate');
     if (!exists<number>(v.vectorCacheMaxObjects))
-      throw new Error('Vector index vector cache max objects was not returned by Weaviate');
+      throw new WeaviateDeserializationError(
+        'Vector index vector cache max objects was not returned by Weaviate'
+      );
     let quantizer: PQConfig | BQConfig | undefined;
     if (exists<Record<string, any>>(v.pq) && v.pq.enabled === true) {
       quantizer = ConfigGuards.pq(v.pq);
@@ -339,8 +360,9 @@ class ConfigGuards {
     };
   }
   static bq(v?: Record<string, unknown>): BQConfig | undefined {
-    if (v === undefined) throw new Error('BQ was not returned by Weaviate');
-    if (!exists<boolean>(v.enabled)) throw new Error('BQ enabled was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('BQ was not returned by Weaviate');
+    if (!exists<boolean>(v.enabled))
+      throw new WeaviateDeserializationError('BQ enabled was not returned by Weaviate');
     if (v.enabled === false) return undefined;
     const cache = v.cache === undefined ? false : (v.cache as boolean);
     const rescoreLimit = v.rescoreLimit === undefined ? 1000 : (v.rescoreLimit as number);
@@ -351,13 +373,15 @@ class ConfigGuards {
     };
   }
   static vectorIndexFlat(v: WeaviateVectorIndexConfig): VectorIndexConfigFlat {
-    if (v === undefined) throw new Error('Vector index was not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Vector index was not returned by Weaviate');
     if (!exists<number>(v.vectorCacheMaxObjects))
-      throw new Error('Vector index vector cache max objects was not returned by Weaviate');
+      throw new WeaviateDeserializationError(
+        'Vector index vector cache max objects was not returned by Weaviate'
+      );
     if (!exists<VectorDistance>(v.distance))
-      throw new Error('Vector index distance was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index distance was not returned by Weaviate');
     if (!exists<Record<string, unknown>>(v.bq))
-      throw new Error('Vector index bq was not returned by Weaviate');
+      throw new WeaviateDeserializationError('Vector index bq was not returned by Weaviate');
     return {
       vectorCacheMaxObjects: v.vectorCacheMaxObjects,
       distance: v.distance,
@@ -374,20 +398,24 @@ class ConfigGuards {
     }
   }
   static vectorIndexType<I>(v?: string): I {
-    if (!populated(v)) throw new Error('Vector index type was not returned by Weaviate');
+    if (!populated(v))
+      throw new WeaviateDeserializationError('Vector index type was not returned by Weaviate');
     return v as I;
   }
   static properties(v?: WeaviateProperty[]): PropertyConfig[] {
-    if (v === undefined) throw new Error('Properties were not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Properties were not returned by Weaviate');
     if (v === null) return [];
     return v
       .filter((prop) => {
-        if (!populated(prop.dataType)) throw new Error('Property data type was not returned by Weaviate');
+        if (!populated(prop.dataType))
+          throw new WeaviateDeserializationError('Property data type was not returned by Weaviate');
         return prop.dataType[0][0].toLowerCase() === prop.dataType[0][0]; // primitive property, e.g. text
       })
       .map((prop) => {
-        if (!populated(prop.name)) throw new Error('Property name was not returned by Weaviate');
-        if (!populated(prop.dataType)) throw new Error('Property data type was not returned by Weaviate');
+        if (!populated(prop.name))
+          throw new WeaviateDeserializationError('Property name was not returned by Weaviate');
+        if (!populated(prop.dataType))
+          throw new WeaviateDeserializationError('Property data type was not returned by Weaviate');
         return {
           name: prop.name,
           dataType: prop.dataType[0],
@@ -408,16 +436,19 @@ class ConfigGuards {
       });
   }
   static references(v?: WeaviateProperty[]): ReferenceConfig[] {
-    if (v === undefined) throw new Error('Properties were not returned by Weaviate');
+    if (v === undefined) throw new WeaviateDeserializationError('Properties were not returned by Weaviate');
     if (v === null) return [];
     return v
       .filter((prop) => {
-        if (!populated(prop.dataType)) throw new Error('Reference data type was not returned by Weaviate');
+        if (!populated(prop.dataType))
+          throw new WeaviateDeserializationError('Reference data type was not returned by Weaviate');
         return prop.dataType[0][0].toLowerCase() !== prop.dataType[0][0]; // reference property, e.g. Myclass
       })
       .map((prop) => {
-        if (!populated(prop.name)) throw new Error('Reference name was not returned by Weaviate');
-        if (!populated(prop.dataType)) throw new Error('Reference data type was not returned by Weaviate');
+        if (!populated(prop.name))
+          throw new WeaviateDeserializationError('Reference name was not returned by Weaviate');
+        if (!populated(prop.dataType))
+          throw new WeaviateDeserializationError('Reference data type was not returned by Weaviate');
         return {
           name: prop.name,
           description: prop.description,

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -56,11 +56,10 @@ export const resolveProperty = <T>(
   prop: PropertyConfigCreate<T>,
   vectorizers?: string[]
 ): WeaviateProperty => {
-  const { dataType, nestedProperties, skipVectorisation, vectorizePropertyName, ...rest } = prop;
+  const { dataType, nestedProperties, vectorizePropertyName, ...rest } = prop;
   const moduleConfig: any = {};
   vectorizers?.forEach((vectorizer) => {
     moduleConfig[vectorizer] = {
-      skip: skipVectorisation === undefined ? false : skipVectorisation,
       vectorizePropertyName: vectorizePropertyName === undefined ? true : vectorizePropertyName,
     };
   });

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -172,11 +172,15 @@ class ConfigGuards {
           `Expected exactly one vectorizer for ${key} named vector, got ${vectorizerNames.length}`
         );
       const vectorizerName = vectorizerNames[0];
-      const { properties, ...rest } = vectorizer[vectorizerName] as any;
+      const { properties, ...restA } = vectorizer[vectorizerName] as any;
+      const { vectorizeClassName, ...restB } = restA;
       out[key] = {
         vectorizer: {
           name: vectorizerName,
-          config: rest,
+          config: {
+            vectorizeCollectionName: vectorizeClassName,
+            ...restB,
+          },
         },
         properties: properties,
         indexConfig: ConfigGuards.vectorIndex(v[key].vectorIndexConfig, v[key].vectorIndexType),

--- a/src/collections/configure/generative.ts
+++ b/src/collections/configure/generative.ts
@@ -31,7 +31,9 @@ export default {
    * @param {GenerativeCohereConfig} [config] The configuration for the `generative-cohere` module.
    * @returns {ModuleConfig<'generative-cohere', GenerativeCohereConfig>} The configuration object.
    */
-  cohere: (config?: GenerativeCohereConfig): ModuleConfig<'generative-cohere', GenerativeCohereConfig> => {
+  cohere: (
+    config?: GenerativeCohereConfig
+  ): ModuleConfig<'generative-cohere', GenerativeCohereConfig | undefined> => {
     return {
       name: 'generative-cohere',
       config: config,
@@ -45,7 +47,9 @@ export default {
    * @param {GenerativeOpenAIConfig} [config] The configuration for the `generative-openai` module.
    * @returns {ModuleConfig<'generative-openai', GenerativeOpenAIConfig>} The configuration object.
    */
-  openAI: (config?: GenerativeOpenAIConfig): ModuleConfig<'generative-openai', GenerativeOpenAIConfig> => {
+  openAI: (
+    config?: GenerativeOpenAIConfig
+  ): ModuleConfig<'generative-openai', GenerativeOpenAIConfig | undefined> => {
     return {
       name: 'generative-openai',
       config: config,

--- a/src/collections/configure/index.ts
+++ b/src/collections/configure/index.ts
@@ -2,10 +2,10 @@ import {
   InvertedIndexConfigCreate,
   InvertedIndexConfigUpdate,
   MultiTenancyConfigCreate,
-  NamedVectorConfigCreate,
-  NamedVectorConfigUpdate,
-  NamedVectorizerCreateOptions,
-  NamedVectorizerUpdateOptions,
+  VectorConfigCreate,
+  VectorConfigUpdate,
+  VectorizerCreateOptions,
+  VectorizerUpdateOptions,
   ReplicationConfigCreate,
   ShardingConfigCreate,
   VectorIndexType,
@@ -15,7 +15,7 @@ import {
 import generative from './generative.js';
 import reranker from './reranker.js';
 import { configure as configureVectorIndex, reconfigure as reconfigureVectorIndex } from './vectorIndex.js';
-import { namedVectorizer } from './vectorizer.js';
+import { vectorizer } from './vectorizer.js';
 
 import { parseWithDefault } from './parsing.js';
 import { PrimitiveKeys } from '../types/internal.js';
@@ -59,7 +59,7 @@ const vectorDistances = {
 const configure = {
   generative,
   reranker,
-  namedVectorizer,
+  vectorizer,
   vectorIndex: configureVectorIndex,
   dataType,
   tokenization,
@@ -114,23 +114,6 @@ const configure = {
   multiTenancy: (options?: { enabled?: boolean }): MultiTenancyConfigCreate => {
     return options ? { enabled: parseWithDefault(options.enabled, true) } : { enabled: true };
   },
-  /**
-   * Create a `NamedVectorConfigCreate` object to be used when defining one of the named vectors configuration of your collection.
-   *
-   * @param {string} name The name of the vector.
-   * @param {NamedVectorizerOptions} [options] The options for the named vector.
-   */
-  // namedVectorizer: <T, N extends string, I extends VectorIndexType = 'hnsw', V extends Vectorizer = 'none'>(
-  //   name: N,
-  //   options?: NamedVectorizerCreateOptions<PrimitiveKeys<T>[], I, V>
-  // ): NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, V> => {
-  //   return {
-  //     vectorName: name,
-  //     properties: options?.properties,
-  //     vectorIndex: options?.vectorIndexConfig ? options.vectorIndexConfig : { name: 'hnsw' as I },
-  //     vectorizer: options?.vectorizerConfig ? options.vectorizerConfig : { name: 'none' as V },
-  //   };
-  // },
   /**
    * Create a `ReplicationConfigCreate` object to be used when defining the replication configuration of your collection.
    *
@@ -202,20 +185,22 @@ const reconfigure = {
       },
     };
   },
-  /**
-   * Create a `NamedVectorConfigUpdate` object to be used when updating the named vector configuration of Weaviate.
-   *
-   * @param {string} name The name of the vector.
-   * @param {NamedVectorizerOptions} [options] The options for the named vector.
-   */
-  namedVectorizer: <N extends string, I extends VectorIndexType = 'hnsw'>(
-    name: N,
-    options: NamedVectorizerUpdateOptions<I>
-  ): NamedVectorConfigUpdate<N, I> => {
-    return {
-      vectorName: name,
-      vectorIndex: options.vectorIndexConfig,
-    };
+  vectorizer: {
+    /**
+     * Create a `VectorConfigUpdate` object to be used when updating the named vector configuration of Weaviate.
+     *
+     * @param {string} name The name of the vector.
+     * @param {VectorizerOptions} [options] The options for the named vector.
+     */
+    update: <N extends string, I extends VectorIndexType>(
+      name: N,
+      options: VectorizerUpdateOptions<I>
+    ): VectorConfigUpdate<N, I> => {
+      return {
+        vectorName: name,
+        vectorIndex: options.vectorIndexConfig,
+      };
+    },
   },
   /**
    * Create a `ReplicationConfigUpdate` object to be used when defining the replication configuration of Weaviate.

--- a/src/collections/configure/index.ts
+++ b/src/collections/configure/index.ts
@@ -15,7 +15,7 @@ import {
 import generative from './generative.js';
 import reranker from './reranker.js';
 import { configure as configureVectorIndex, reconfigure as reconfigureVectorIndex } from './vectorIndex.js';
-import { vectorizer } from './vectorizer.js';
+import { namedVectorizer } from './vectorizer.js';
 
 import { parseWithDefault } from './parsing.js';
 import { PrimitiveKeys } from '../types/internal.js';
@@ -59,7 +59,7 @@ const vectorDistances = {
 const configure = {
   generative,
   reranker,
-  vectorizer,
+  namedVectorizer,
   vectorIndex: configureVectorIndex,
   dataType,
   tokenization,
@@ -120,17 +120,17 @@ const configure = {
    * @param {string} name The name of the vector.
    * @param {NamedVectorizerOptions} [options] The options for the named vector.
    */
-  namedVectorizer: <T, N extends string, I extends VectorIndexType = 'hnsw', V extends Vectorizer = 'none'>(
-    name: N,
-    options?: NamedVectorizerCreateOptions<PrimitiveKeys<T>[], I, V>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, V> => {
-    return {
-      vectorName: name,
-      properties: options?.properties,
-      vectorIndex: options?.vectorIndexConfig ? options.vectorIndexConfig : { name: 'hnsw' as I },
-      vectorizer: options?.vectorizerConfig ? options.vectorizerConfig : { name: 'none' as V },
-    };
-  },
+  // namedVectorizer: <T, N extends string, I extends VectorIndexType = 'hnsw', V extends Vectorizer = 'none'>(
+  //   name: N,
+  //   options?: NamedVectorizerCreateOptions<PrimitiveKeys<T>[], I, V>
+  // ): NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, V> => {
+  //   return {
+  //     vectorName: name,
+  //     properties: options?.properties,
+  //     vectorIndex: options?.vectorIndexConfig ? options.vectorIndexConfig : { name: 'hnsw' as I },
+  //     vectorizer: options?.vectorizerConfig ? options.vectorizerConfig : { name: 'none' as V },
+  //   };
+  // },
   /**
    * Create a `ReplicationConfigCreate` object to be used when defining the replication configuration of your collection.
    *

--- a/src/collections/configure/index.ts
+++ b/src/collections/configure/index.ts
@@ -65,7 +65,7 @@ const configure = {
   tokenization,
   vectorDistances,
   /**
-   * Create an `InvertedIndexConfigCreate` object to be used when defining the configuration of the keyword searching algorithm of Weaviate.
+   * Create an `InvertedIndexConfigCreate` object to be used when defining the configuration of the keyword searching algorithm of your collection.
    *
    * See [the docs](https://weaviate.io/developers/weaviate/configuration/indexes#configure-the-inverted-index) for details!
    *
@@ -107,7 +107,7 @@ const configure = {
     };
   },
   /**
-   * Create a `MultiTenancyConfigCreate` object to be used when defining the multi-tenancy configuration of Weaviate.
+   * Create a `MultiTenancyConfigCreate` object to be used when defining the multi-tenancy configuration of your collection.
    *
    * @param {boolean} config.enabled Whether multi-tenancy is enabled. Default is true.
    */
@@ -115,7 +115,7 @@ const configure = {
     return options ? { enabled: parseWithDefault(options.enabled, true) } : { enabled: true };
   },
   /**
-   * Create a `NamedVectorConfigCreate` object to be used when defining the named vector configuration of Weaviate.
+   * Create a `NamedVectorConfigCreate` object to be used when defining one of the named vectors configuration of your collection.
    *
    * @param {string} name The name of the vector.
    * @param {NamedVectorizerOptions} [options] The options for the named vector.
@@ -132,7 +132,7 @@ const configure = {
     };
   },
   /**
-   * Create a `ReplicationConfigCreate` object to be used when defining the replication configuration of Weaviate.
+   * Create a `ReplicationConfigCreate` object to be used when defining the replication configuration of your collection.
    *
    * NOTE: You can only use one of Sharding or Replication, not both.
    *
@@ -144,7 +144,7 @@ const configure = {
     return config ? { factor: parseWithDefault(config.factor, 1) } : { factor: 1 };
   },
   /**
-   * Create a `ShardingConfigCreate` object to be used when defining the sharding configuration of Weaviate.
+   * Create a `ShardingConfigCreate` object to be used when defining the sharding configuration of your collection.
    *
    * NOTE: You can only use one of Sharding or Replication, not both.
    *
@@ -170,7 +170,7 @@ const configure = {
 const reconfigure = {
   vectorIndex: reconfigureVectorIndex,
   /**
-   * Create an `InvertedIndexConfigUpdate` object to be used when updating the configuration of the keyword searching algorithm of Weaviate.
+   * Create an `InvertedIndexConfigUpdate` object to be used when updating the configuration of the keyword searching algorithm of your collection.
    *
    * See [the docs](https://weaviate.io/developers/weaviate/configuration/indexes#configure-the-inverted-index) for details!
    *

--- a/src/collections/configure/reranker.ts
+++ b/src/collections/configure/reranker.ts
@@ -9,7 +9,9 @@ export default {
    * @param {RerankerCohereConfig} [config] The configuration for the `reranker-cohere` module.
    * @returns {ModuleConfig<'reranker-cohere', RerankerCohereConfig>} The configuration object.
    */
-  cohere: (config?: RerankerCohereConfig): ModuleConfig<'reranker-cohere', RerankerCohereConfig> => {
+  cohere: (
+    config?: RerankerCohereConfig
+  ): ModuleConfig<'reranker-cohere', RerankerCohereConfig | undefined> => {
     return {
       name: 'reranker-cohere',
       config: config,

--- a/src/collections/configure/reranker.ts
+++ b/src/collections/configure/reranker.ts
@@ -1,4 +1,4 @@
-import { ModuleConfig, RerankerCohereConfig } from '../config/types/index.js';
+import { ModuleConfig, RerankerCohereConfig, RerankerVoyageAIConfig } from '../config/types/index.js';
 
 export default {
   /**
@@ -28,6 +28,22 @@ export default {
     return {
       name: 'reranker-transformers',
       config: {},
+    };
+  },
+  /**
+   * Create a `ModuleConfig<'reranker-voyageai', RerankerVoyageAIConfig>` object for use when reranking using the `reranker-voyageai` module.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/reranker-voyageai) for detailed usage.
+   *
+   * @param {RerankerVoyageAIConfig} [config] The configuration for the `reranker-voyage-ai` module.
+   * @returns {ModuleConfig<'reranker-voyage-ai', RerankerVoyageAIConfig | undefined>} The configuration object.
+   */
+  voyageAI: (
+    config?: RerankerVoyageAIConfig
+  ): ModuleConfig<'reranker-voyageai', RerankerVoyageAIConfig | undefined> => {
+    return {
+      name: 'reranker-voyageai',
+      config: config,
     };
   },
 };

--- a/src/collections/configure/types/base.ts
+++ b/src/collections/configure/types/base.ts
@@ -38,7 +38,6 @@ type NestedPropertyCreate<T = undefined> = T extends undefined
       indexInverted?: boolean;
       indexFilterable?: boolean;
       indexSearchable?: boolean;
-      skipVectorisation?: boolean;
       tokenization?: WeaviateNestedProperty['tokenization'];
       vectorizePropertyName?: boolean;
     }
@@ -69,7 +68,6 @@ type PropertyConfigCreateBase = {
   indexInverted?: boolean;
   indexFilterable?: boolean;
   indexSearchable?: boolean;
-  skipVectorisation?: boolean;
   tokenization?: WeaviateProperty['tokenization'];
   vectorizePropertyName?: boolean;
 };
@@ -91,7 +89,6 @@ export type PropertyConfigCreate<T> = T extends undefined
       indexInverted?: boolean;
       indexFilterable?: boolean;
       indexSearchable?: boolean;
-      skipVectorisation?: boolean;
       tokenization?: WeaviateProperty['tokenization'];
       vectorizePropertyName?: boolean;
     }

--- a/src/collections/configure/types/vectorIndex.ts
+++ b/src/collections/configure/types/vectorIndex.ts
@@ -1,5 +1,6 @@
 import {
   BQConfig,
+  ModuleConfig,
   PQConfig,
   PQEncoderDistribution,
   PQEncoderType,
@@ -77,3 +78,8 @@ export type VectorIndexConfigUpdateType<I> = I extends 'hnsw'
   : I extends string
   ? Record<string, any>
   : never;
+
+export type LegacyVectorizerConfigUpdate =
+  | ModuleConfig<'flat', VectorIndexConfigFlatUpdate>
+  | ModuleConfig<'hnsw', VectorIndexConfigHNSWUpdate>
+  | ModuleConfig<string, Record<string, any>>;

--- a/src/collections/configure/types/vectorIndex.ts
+++ b/src/collections/configure/types/vectorIndex.ts
@@ -47,9 +47,9 @@ export type VectorIndexConfigHNSWUpdate = {
 };
 
 export type VectorIndexConfigCreateType<I> = I extends 'hnsw'
-  ? VectorIndexConfigHNSWCreate
+  ? VectorIndexConfigHNSWCreate | undefined
   : I extends 'flat'
-  ? VectorIndexConfigFlatCreate
+  ? VectorIndexConfigFlatCreate | undefined
   : I extends string
   ? Record<string, any>
   : never;
@@ -68,7 +68,9 @@ export type VectorIndexConfigCreate =
 
 export type VectorIndexConfigUpdate =
   | VectorIndexConfigFlatUpdate
+  | undefined
   | VectorIndexConfigHNSWUpdate
+  | undefined
   | Record<string, any>;
 
 export type VectorIndexConfigUpdateType<I> = I extends 'hnsw'

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -15,31 +15,31 @@ import {
 } from '../../config/types/index.js';
 import { PrimitiveKeys } from '../../types/internal.js';
 
-export type NamedVectorizerCreateOptions<P, I, V> = {
+export type VectorizerCreateOptions<P, I, V> = {
   sourceProperties?: P;
   vectorIndexConfig?: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
   vectorizerConfig?: ModuleConfig<V, VectorizerConfigType<V>>;
 };
 
-export type NamedVectorizerUpdateOptions<I> = {
+export type VectorizerUpdateOptions<I> = {
   vectorIndexConfig: ModuleConfig<I, VectorIndexConfigUpdateType<I>>;
 };
 
-export type NamedVectorConfigCreate<P, N extends string, I extends VectorIndexType, V extends Vectorizer> = {
+export type VectorConfigCreate<P, N extends string, I extends VectorIndexType, V extends Vectorizer> = {
   vectorName: N;
   properties?: P[];
   vectorizer: ModuleConfig<V, VectorizerConfigType<V>>;
   vectorIndex: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
 };
 
-export type NamedVectorConfigUpdate<N extends string, I extends VectorIndexType> = {
+export type VectorConfigUpdate<N extends string, I extends VectorIndexType> = {
   vectorName: N;
   vectorIndex: ModuleConfig<I, VectorIndexConfigUpdateType<I>>;
 };
 
 export type VectorizersConfigCreate<T> =
-  | NamedVectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>
-  | NamedVectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>[];
+  | VectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>
+  | VectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>[];
 
 export type ConfigureNonTextVectorizerOptions<
   I extends VectorIndexType,

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -1,9 +1,22 @@
 import { VectorIndexConfigCreateType, VectorIndexConfigUpdateType } from './vectorIndex.js';
-import { ModuleConfig, VectorIndexType, Vectorizer, VectorizerConfigType } from '../../config/types/index.js';
+import {
+  Img2VecNeuralConfig,
+  ModuleConfig,
+  Multi2VecBindConfig,
+  Multi2VecClipConfig,
+  Multi2VecPalmConfig,
+  Ref2VecCentroidConfig,
+  Text2VecAWSConfig,
+  Text2VecAzureOpenAIConfig,
+  Text2VecCohereConfig,
+  VectorIndexType,
+  Vectorizer,
+  VectorizerConfigType,
+} from '../../config/types/index.js';
 import { PrimitiveKeys } from '../../types/internal.js';
 
 export type NamedVectorizerCreateOptions<P, I, V> = {
-  properties?: P;
+  sourceProperties?: P;
   vectorIndexConfig?: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
   vectorizerConfig?: ModuleConfig<V, VectorizerConfigType<V>>;
 };
@@ -14,8 +27,8 @@ export type NamedVectorizerUpdateOptions<I> = {
 
 export type NamedVectorConfigCreate<P, N extends string, I extends VectorIndexType, V extends Vectorizer> = {
   vectorName: N;
-  properties?: P;
-  vectorizer: ModuleConfig<V, VectorizerConfigType<V> | undefined>;
+  properties?: P[];
+  vectorizer: ModuleConfig<V, VectorizerConfigType<V>>;
   vectorIndex: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
 };
 
@@ -25,5 +38,21 @@ export type NamedVectorConfigUpdate<N extends string, I extends VectorIndexType>
 };
 
 export type VectorizersConfigCreate<T> =
-  | NamedVectorConfigCreate<PrimitiveKeys<T>[], string, VectorIndexType, Vectorizer>
-  | NamedVectorConfigCreate<PrimitiveKeys<T>[], string, VectorIndexType, Vectorizer>[];
+  | NamedVectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>
+  | NamedVectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>[];
+
+export type ConfigureNonTextVectorizerOptions<
+  I extends VectorIndexType,
+  V extends Vectorizer
+> = VectorizerConfigType<V> & {
+  vectorIndexConfig?: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
+};
+
+export type ConfigureTextVectorizerOptions<
+  T,
+  I extends VectorIndexType,
+  V extends Vectorizer
+> = VectorizerConfigType<V> & {
+  sourceProperties?: PrimitiveKeys<T>[];
+  vectorIndexConfig?: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
+};

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -1,5 +1,6 @@
 import { VectorIndexConfigCreateType, VectorIndexConfigUpdateType } from './vectorIndex.js';
 import { ModuleConfig, VectorIndexType, Vectorizer, VectorizerConfigType } from '../../config/types/index.js';
+import { PrimitiveKeys } from '../../types/internal.js';
 
 export type NamedVectorizerCreateOptions<P, I, V> = {
   properties?: P;
@@ -22,3 +23,7 @@ export type NamedVectorConfigUpdate<N extends string, I extends VectorIndexType>
   vectorName: N;
   vectorIndex: ModuleConfig<I, VectorIndexConfigUpdateType<I>>;
 };
+
+export type VectorizersConfigCreate<T> =
+  | NamedVectorConfigCreate<PrimitiveKeys<T>[], 'default', VectorIndexType, Vectorizer>
+  | NamedVectorConfigCreate<PrimitiveKeys<T>[], string, VectorIndexType, Vectorizer>[];

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -25,5 +25,5 @@ export type NamedVectorConfigUpdate<N extends string, I extends VectorIndexType>
 };
 
 export type VectorizersConfigCreate<T> =
-  | NamedVectorConfigCreate<PrimitiveKeys<T>[], 'default', VectorIndexType, Vectorizer>
+  | NamedVectorConfigCreate<PrimitiveKeys<T>[], string, VectorIndexType, Vectorizer>
   | NamedVectorConfigCreate<PrimitiveKeys<T>[], string, VectorIndexType, Vectorizer>[];

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -265,7 +265,7 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectorizer.multi2VecClip('test', {
       imageFields: ['field1', 'field2'],
       textFields: ['field3', 'field4'],
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
       vectorName: 'test',
@@ -278,7 +278,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         config: {
           imageFields: ['field1', 'field2'],
           textFields: ['field3', 'field4'],
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -308,7 +308,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       textFields: ['field9', 'field10'],
       thermalFields: ['field11', 'field12'],
       videoFields: ['field13', 'field14'],
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
       vectorName: 'test',
@@ -326,7 +326,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           textFields: ['field9', 'field10'],
           thermalFields: ['field11', 'field12'],
           videoFields: ['field13', 'field14'],
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -357,7 +357,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       location: 'location',
       modelId: 'model-id',
       dimensions: 256,
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
       vectorName: 'test',
@@ -372,7 +372,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           location: 'location',
           modelId: 'model-id',
           dimensions: 256,
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -405,7 +405,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       model: 'model',
       region: 'region',
       service: 'service',
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
       vectorName: 'test',
@@ -420,7 +420,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           model: 'model',
           region: 'region',
           service: 'service',
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -452,7 +452,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       baseURL: 'base-url',
       deploymentID: 'deployment-id',
       resourceName: 'resource-name',
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
       vectorName: 'test',
@@ -466,7 +466,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           baseURL: 'base-url',
           deploymentID: 'deployment-id',
           resourceName: 'resource-name',
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -492,7 +492,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       baseURL: 'base-url',
       model: 'model',
       truncate: true,
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
       vectorName: 'test',
@@ -506,7 +506,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           baseURL: 'base-url',
           model: 'model',
           truncate: true,
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -529,7 +529,7 @@ describe('Unit testing of the vectorizer factory class', () => {
 
   it('should create the correct Text2VecContextionaryConfig type with custom values', () => {
     const config = configure.vectorizer.text2VecContextionary('test', {
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
       vectorName: 'test',
@@ -540,7 +540,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       vectorizer: {
         name: 'text2vec-contextionary',
         config: {
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -563,7 +563,7 @@ describe('Unit testing of the vectorizer factory class', () => {
 
   it('should create the correct Text2VecGPT4AllConfig type with custom values', () => {
     const config = configure.vectorizer.text2VecGPT4All('test', {
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
       vectorName: 'test',
@@ -574,7 +574,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       vectorizer: {
         name: 'text2vec-gpt4all',
         config: {
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -604,7 +604,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       useCache: true,
       useGPU: true,
       waitForModel: true,
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
       vectorName: 'test',
@@ -622,7 +622,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           useCache: true,
           useGPU: true,
           waitForModel: true,
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -646,7 +646,7 @@ describe('Unit testing of the vectorizer factory class', () => {
   it('should create the correct Text2VecJinaConfig type with custom values', () => {
     const config = configure.vectorizer.text2VecJina('test', {
       model: 'model',
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
       vectorName: 'test',
@@ -658,7 +658,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         name: 'text2vec-jina',
         config: {
           model: 'model',
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -686,7 +686,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       model: 'model',
       modelVersion: 'model-version',
       type: 'type',
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
       vectorName: 'test',
@@ -702,7 +702,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           model: 'model',
           modelVersion: 'model-version',
           type: 'type',
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -732,7 +732,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       apiEndpoint: 'api-endpoint',
       modelId: 'model-id',
       projectId: 'project-id',
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
       vectorName: 'test',
@@ -746,7 +746,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           apiEndpoint: 'api-endpoint',
           modelId: 'model-id',
           projectId: 'project-id',
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -770,7 +770,7 @@ describe('Unit testing of the vectorizer factory class', () => {
   it('should create the correct Text2VecTransformersConfig type with custom values', () => {
     const config = configure.vectorizer.text2VecTransformers('test', {
       poolingStrategy: 'pooling-strategy',
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
       vectorName: 'test',
@@ -782,7 +782,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         name: 'text2vec-transformers',
         config: {
           poolingStrategy: 'pooling-strategy',
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });
@@ -808,7 +808,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       baseURL: 'base-url',
       model: 'model',
       truncate: true,
-      vectorizeClassName: true,
+      vectorizeCollectionName: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
       vectorName: 'test',
@@ -822,7 +822,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           baseURL: 'base-url',
           model: 'model',
           truncate: true,
-          vectorizeClassName: true,
+          vectorizeCollectionName: true,
         },
       },
     });

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1,24 +1,5 @@
 import { configure } from './index.js';
-import {
-  Img2VecNeuralConfig,
-  ModuleConfig,
-  Multi2VecBindConfig,
-  Multi2VecClipConfig,
-  Multi2VecPalmConfig,
-  NamedVectorConfigCreate,
-  Properties,
-  Text2VecAWSConfig,
-  Text2VecAzureOpenAIConfig,
-  Text2VecCohereConfig,
-  Text2VecContextionaryConfig,
-  Text2VecGPT4AllConfig,
-  Text2VecHuggingFaceConfig,
-  Text2VecJinaConfig,
-  Text2VecOpenAIConfig,
-  Text2VecPalmConfig,
-  Text2VecTransformersConfig,
-  Text2VecVoyageConfig,
-} from '../types/index.js';
+import { ModuleConfig, NamedVectorConfigCreate } from '../types/index.js';
 import {
   InvertedIndexConfigCreate,
   MultiTenancyConfigCreate,
@@ -230,58 +211,96 @@ describe('Unit testing of the configure factory class', () => {
   });
 });
 
-describe('Unit testing of the vectorizer factory class', () => {
+describe('Unit testing of the namedVectorizer factory class', () => {
   it('should create the correct Img2VecNeuralConfig type with defaults', () => {
-    const config = configure.vectorizer.img2VecNeural();
-    expect(config).toEqual<ModuleConfig<'img2vec-neural', Img2VecNeuralConfig>>({
-      name: 'img2vec-neural',
+    const config = configure.namedVectorizer.img2VecNeural('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'img2vec-neural',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Img2VecNeuralConfig type with custom values', () => {
-    const config = configure.vectorizer.img2VecNeural({
+    const config = configure.namedVectorizer.img2VecNeural('test', {
       imageFields: ['field1', 'field2'],
     });
-    expect(config).toEqual<ModuleConfig<'img2vec-neural', Img2VecNeuralConfig>>({
-      name: 'img2vec-neural',
-      config: {
-        imageFields: ['field1', 'field2'],
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'img2vec-neural',
+        config: {
+          imageFields: ['field1', 'field2'],
+        },
       },
     });
   });
 
   it('should create the correct Multi2VecClipConfig type with defaults', () => {
-    const config = configure.vectorizer.multi2VecClip();
-    expect(config).toEqual<ModuleConfig<'multi2vec-clip', Img2VecNeuralConfig>>({
-      name: 'multi2vec-clip',
+    const config = configure.namedVectorizer.multi2VecClip('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2vec-clip',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Multi2VecClipConfig type with custom values', () => {
-    const config = configure.vectorizer.multi2VecClip({
+    const config = configure.namedVectorizer.multi2VecClip('test', {
       imageFields: ['field1', 'field2'],
       textFields: ['field3', 'field4'],
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'multi2vec-clip', Multi2VecClipConfig>>({
-      name: 'multi2vec-clip',
-      config: {
-        imageFields: ['field1', 'field2'],
-        textFields: ['field3', 'field4'],
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2vec-clip',
+        config: {
+          imageFields: ['field1', 'field2'],
+          textFields: ['field3', 'field4'],
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Multi2VecBindConfig type with defaults', () => {
-    const config = configure.vectorizer.multi2VecBind();
-    expect(config).toEqual<ModuleConfig<'multi2vec-bind', Multi2VecBindConfig>>({
-      name: 'multi2vec-bind',
+    const config = configure.namedVectorizer.multi2VecBind('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2vec-bind',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Multi2VecBindConfig type with custom values', () => {
-    const config = configure.vectorizer.multi2VecBind({
+    const config = configure.namedVectorizer.multi2VecBind('test', {
       audioFields: ['field1', 'field2'],
       depthFields: ['field3', 'field4'],
       imageFields: ['field5', 'field6'],
@@ -291,191 +310,293 @@ describe('Unit testing of the vectorizer factory class', () => {
       videoFields: ['field13', 'field14'],
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'multi2vec-bind', Multi2VecBindConfig>>({
-      name: 'multi2vec-bind',
-      config: {
-        audioFields: ['field1', 'field2'],
-        depthFields: ['field3', 'field4'],
-        imageFields: ['field5', 'field6'],
-        IMUFields: ['field7', 'field8'],
-        textFields: ['field9', 'field10'],
-        thermalFields: ['field11', 'field12'],
-        videoFields: ['field13', 'field14'],
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2vec-bind',
+        config: {
+          audioFields: ['field1', 'field2'],
+          depthFields: ['field3', 'field4'],
+          imageFields: ['field5', 'field6'],
+          IMUFields: ['field7', 'field8'],
+          textFields: ['field9', 'field10'],
+          thermalFields: ['field11', 'field12'],
+          videoFields: ['field13', 'field14'],
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Multi2VecPalmConfig type with defaults', () => {
-    const config = configure.vectorizer.multi2VecPalm({
+    const config = configure.namedVectorizer.multi2VecPalm('test', {
       projectId: 'project-id',
     });
-    expect(config).toEqual<ModuleConfig<'multi2vec-palm', Multi2VecPalmConfig>>({
-      name: 'multi2vec-palm',
-      config: {
-        projectId: 'project-id',
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2vec-palm',
+        config: {
+          projectId: 'project-id',
+        },
       },
     });
   });
 
   it('should create the correct Multi2VecPalmConfig type with custom values', () => {
-    const config = configure.vectorizer.multi2VecPalm({
+    const config = configure.namedVectorizer.multi2VecPalm('test', {
       projectId: 'project-id',
       location: 'location',
       modelId: 'model-id',
       dimensions: 256,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'multi2vec-palm', Multi2VecPalmConfig>>({
-      name: 'multi2vec-palm',
-      config: {
-        projectId: 'project-id',
-        location: 'location',
-        modelId: 'model-id',
-        dimensions: 256,
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2vec-palm',
+        config: {
+          projectId: 'project-id',
+          location: 'location',
+          modelId: 'model-id',
+          dimensions: 256,
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecAWSConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecAWS({
+    const config = configure.namedVectorizer.text2VecAWS('test', {
       region: 'region',
       service: 'service',
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-aws', Text2VecAWSConfig>>({
-      name: 'text2vec-aws',
-      config: {
-        region: 'region',
-        service: 'service',
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-aws',
+        config: {
+          region: 'region',
+          service: 'service',
+        },
       },
     });
   });
 
   it('should create the correct Text2VecAWSConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecAWS({
+    const config = configure.namedVectorizer.text2VecAWS('test', {
       endpoint: 'endpoint',
       model: 'model',
       region: 'region',
       service: 'service',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-aws', Text2VecAWSConfig>>({
-      name: 'text2vec-aws',
-      config: {
-        endpoint: 'endpoint',
-        model: 'model',
-        region: 'region',
-        service: 'service',
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-aws',
+        config: {
+          endpoint: 'endpoint',
+          model: 'model',
+          region: 'region',
+          service: 'service',
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecAzureOpenAIConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecAzureOpenAI({
+    const config = configure.namedVectorizer.text2VecAzureOpenAI('test', {
       deploymentID: 'deployment-id',
       resourceName: 'resource-name',
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-openai', Text2VecAzureOpenAIConfig>>({
-      name: 'text2vec-openai',
-      config: {
-        deploymentID: 'deployment-id',
-        resourceName: 'resource-name',
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-azure-openai',
+        config: {
+          deploymentID: 'deployment-id',
+          resourceName: 'resource-name',
+        },
       },
     });
   });
 
   it('should create the correct Text2VecAzureOpenAIConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecAzureOpenAI({
+    const config = configure.namedVectorizer.text2VecAzureOpenAI('test', {
       baseURL: 'base-url',
       deploymentID: 'deployment-id',
       resourceName: 'resource-name',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-openai', Text2VecAzureOpenAIConfig>>({
-      name: 'text2vec-openai',
-      config: {
-        baseURL: 'base-url',
-        deploymentID: 'deployment-id',
-        resourceName: 'resource-name',
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-azure-openai',
+        config: {
+          baseURL: 'base-url',
+          deploymentID: 'deployment-id',
+          resourceName: 'resource-name',
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecCohereConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecCohere();
-    expect(config).toEqual<ModuleConfig<'text2vec-cohere', Text2VecCohereConfig>>({
-      name: 'text2vec-cohere',
+    const config = configure.namedVectorizer.text2VecCohere('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-cohere',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecCohereConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecCohere({
+    const config = configure.namedVectorizer.text2VecCohere('test', {
       baseURL: 'base-url',
       model: 'model',
       truncate: true,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-cohere', Text2VecCohereConfig>>({
-      name: 'text2vec-cohere',
-      config: {
-        baseURL: 'base-url',
-        model: 'model',
-        truncate: true,
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-cohere',
+        config: {
+          baseURL: 'base-url',
+          model: 'model',
+          truncate: true,
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecContextionaryConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecContextionary();
-    expect(config).toEqual<ModuleConfig<'text2vec-contextionary', Text2VecContextionaryConfig>>({
-      name: 'text2vec-contextionary',
+    const config = configure.namedVectorizer.text2VecContextionary('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-contextionary',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecContextionaryConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecContextionary({
+    const config = configure.namedVectorizer.text2VecContextionary('test', {
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-contextionary', Text2VecContextionaryConfig>>({
-      name: 'text2vec-contextionary',
-      config: {
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-contextionary',
+        config: {
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecGPT4AllConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecGPT4All();
-    expect(config).toEqual<ModuleConfig<'text2vec-gpt4all', Text2VecGPT4AllConfig>>({
-      name: 'text2vec-gpt4all',
+    const config = configure.namedVectorizer.text2VecGPT4All('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-gpt4all',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecGPT4AllConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecGPT4All({
+    const config = configure.namedVectorizer.text2VecGPT4All('test', {
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-gpt4all', Text2VecGPT4AllConfig>>({
-      name: 'text2vec-gpt4all',
-      config: {
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-gpt4all',
+        config: {
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecHuggingFaceConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecHuggingFace();
-    expect(config).toEqual<ModuleConfig<'text2vec-huggingface', Text2VecHuggingFaceConfig>>({
-      name: 'text2vec-huggingface',
+    const config = configure.namedVectorizer.text2VecHuggingFace('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-huggingface',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecHuggingFaceConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecHuggingFace({
+    const config = configure.namedVectorizer.text2VecHuggingFace('test', {
       endpointURL: 'endpoint-url',
       model: 'model',
       passageModel: 'passage-model',
@@ -485,51 +606,81 @@ describe('Unit testing of the vectorizer factory class', () => {
       waitForModel: true,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-huggingface', Text2VecHuggingFaceConfig>>({
-      name: 'text2vec-huggingface',
-      config: {
-        endpointURL: 'endpoint-url',
-        model: 'model',
-        passageModel: 'passage-model',
-        queryModel: 'query-model',
-        useCache: true,
-        useGPU: true,
-        waitForModel: true,
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-huggingface',
+        config: {
+          endpointURL: 'endpoint-url',
+          model: 'model',
+          passageModel: 'passage-model',
+          queryModel: 'query-model',
+          useCache: true,
+          useGPU: true,
+          waitForModel: true,
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecJinaConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecJina();
-    expect(config).toEqual<ModuleConfig<'text2vec-jina', Text2VecJinaConfig>>({
-      name: 'text2vec-jina',
+    const config = configure.namedVectorizer.text2VecJina('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-jina',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecJinaConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecJina({
+    const config = configure.namedVectorizer.text2VecJina('test', {
       model: 'model',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-jina', Text2VecJinaConfig>>({
-      name: 'text2vec-jina',
-      config: {
-        model: 'model',
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-jina',
+        config: {
+          model: 'model',
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecOpenAIConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecOpenAI();
-    expect(config).toEqual<ModuleConfig<'text2vec-openai', Text2VecOpenAIConfig>>({
-      name: 'text2vec-openai',
+    const config = configure.namedVectorizer.text2VecOpenAI('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-openai',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecOpenAIConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecOpenAI({
+    const config = configure.namedVectorizer.text2VecOpenAI('test', {
       baseURL: 'base-url',
       dimensions: 256,
       model: 'model',
@@ -537,155 +688,142 @@ describe('Unit testing of the vectorizer factory class', () => {
       type: 'type',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-openai', Text2VecOpenAIConfig>>({
-      name: 'text2vec-openai',
-      config: {
-        baseURL: 'base-url',
-        dimensions: 256,
-        model: 'model',
-        modelVersion: 'model-version',
-        type: 'type',
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-openai',
+        config: {
+          baseURL: 'base-url',
+          dimensions: 256,
+          model: 'model',
+          modelVersion: 'model-version',
+          type: 'type',
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecPalmConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecPalm({
+    const config = configure.namedVectorizer.text2VecPalm('test', {
       projectId: 'project-id',
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-palm', Text2VecPalmConfig>>({
-      name: 'text2vec-palm',
-      config: {
-        projectId: 'project-id',
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-palm',
+        config: {
+          projectId: 'project-id',
+        },
       },
     });
   });
 
   it('should create the correct Text2VecPalmConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecPalm({
+    const config = configure.namedVectorizer.text2VecPalm('test', {
       apiEndpoint: 'api-endpoint',
       modelId: 'model-id',
       projectId: 'project-id',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-palm', Text2VecPalmConfig>>({
-      name: 'text2vec-palm',
-      config: {
-        apiEndpoint: 'api-endpoint',
-        modelId: 'model-id',
-        projectId: 'project-id',
-        vectorizeClassName: true,
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-palm',
+        config: {
+          apiEndpoint: 'api-endpoint',
+          modelId: 'model-id',
+          projectId: 'project-id',
+          vectorizeClassName: true,
+        },
       },
     });
   });
 
   it('should create the correct Text2VecTransformersConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecTransformers();
-    expect(config).toEqual<ModuleConfig<'text2vec-transformers', Text2VecTransformersConfig>>({
-      name: 'text2vec-transformers',
-    });
-  });
-
-  it('should create the correct Text2VecTransformersConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecTransformers({
-      poolingStrategy: 'pooling-strategy',
-      vectorizeClassName: true,
-    });
-    expect(config).toEqual<ModuleConfig<'text2vec-transformers', Text2VecTransformersConfig>>({
-      name: 'text2vec-transformers',
-      config: {
-        poolingStrategy: 'pooling-strategy',
-        vectorizeClassName: true,
+    const config = configure.namedVectorizer.text2VecTransformers('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-transformers',
+        config: undefined,
       },
     });
   });
 
-  it('should create the correct Text2VecVoyageConfig type with defaults', () => {
-    const config = configure.vectorizer.text2VecVoyage();
-    expect(config).toEqual<ModuleConfig<'text2vec-voyageai', Text2VecVoyageConfig>>({
-      name: 'text2vec-voyageai',
+  it('should create the correct Text2VecTransformersConfig type with custom values', () => {
+    const config = configure.namedVectorizer.text2VecTransformers('test', {
+      poolingStrategy: 'pooling-strategy',
+      vectorizeClassName: true,
+    });
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-transformers',
+        config: {
+          poolingStrategy: 'pooling-strategy',
+          vectorizeClassName: true,
+        },
+      },
+    });
+  });
+
+  it('should create the correct Text2VecVoyageAIConfig type with defaults', () => {
+    const config = configure.namedVectorizer.text2VecVoyageAI('test');
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
+      vectorName: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-voyageai',
+        config: undefined,
+      },
     });
   });
 
   it('should create the correct Text2VecVoyageConfig type with custom values', () => {
-    const config = configure.vectorizer.text2VecVoyage({
+    const config = configure.namedVectorizer.text2VecVoyageAI('test', {
       baseURL: 'base-url',
       model: 'model',
       truncate: true,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<ModuleConfig<'text2vec-voyageai', Text2VecVoyageConfig>>({
-      name: 'text2vec-voyageai',
-      config: {
-        baseURL: 'base-url',
-        model: 'model',
-        truncate: true,
-        vectorizeClassName: true,
-      },
-    });
-  });
-});
-
-describe('Unit testing of the namedVectorizer factory class', () => {
-  it('should create a NamedVectorConfigCreate type with no vectorizer and a default vector index', () => {
-    const config = configure.namedVectorizer('vector');
-    expect(config).toEqual<NamedVectorConfigCreate<Properties, 'vector', 'hnsw', 'none'>>({
-      vectorName: 'vector',
+    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
+      vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
+        config: undefined,
       },
       vectorizer: {
-        name: 'none',
-      },
-    });
-  });
-
-  it('should create a NamedVectorConfigCreate type with no vectorizer and a custom vector index', () => {
-    const config = configure.namedVectorizer('vector', { vectorIndexConfig: configure.vectorIndex.flat() });
-    expect(config).toEqual<NamedVectorConfigCreate<Properties, 'vector', 'flat', 'none'>>({
-      vectorName: 'vector',
-      vectorIndex: {
-        name: 'flat',
+        name: 'text2vec-voyageai',
         config: {
-          distance: 'cosine',
-          quantizer: undefined,
-          vectorCacheMaxObjects: 1000000000000,
+          baseURL: 'base-url',
+          model: 'model',
+          truncate: true,
+          vectorizeClassName: true,
         },
-      },
-      vectorizer: {
-        name: 'none',
-      },
-    });
-  });
-
-  it('should create a NamedVectorConfigCreate type with a vectorizer and a vector index', () => {
-    const config = configure.namedVectorizer('vector', {
-      vectorIndexConfig: configure.vectorIndex.hnsw({
-        efConstruction: 256,
-      }),
-      vectorizerConfig: configure.vectorizer.img2VecNeural(),
-    });
-    expect(config).toEqual<NamedVectorConfigCreate<Properties, 'vector', 'hnsw', 'img2vec-neural'>>({
-      vectorName: 'vector',
-      vectorIndex: {
-        name: 'hnsw',
-        config: {
-          cleanupIntervalSeconds: 300,
-          distance: 'cosine',
-          dynamicEfFactor: 8,
-          dynamicEfMax: 500,
-          dynamicEfMin: 100,
-          ef: -1,
-          efConstruction: 256,
-          flatSearchCutoff: 40000,
-          maxConnections: 64,
-          skip: false,
-          vectorCacheMaxObjects: 1000000000000,
-        },
-      },
-      vectorizer: {
-        name: 'img2vec-neural',
       },
     });
   });

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1,5 +1,5 @@
 import { configure } from './index.js';
-import { ModuleConfig, NamedVectorConfigCreate } from '../types/index.js';
+import { ModuleConfig, VectorConfigCreate } from '../types/index.js';
 import {
   InvertedIndexConfigCreate,
   MultiTenancyConfigCreate,
@@ -211,10 +211,10 @@ describe('Unit testing of the configure factory class', () => {
   });
 });
 
-describe('Unit testing of the namedVectorizer factory class', () => {
+describe('Unit testing of the vectorizer factory class', () => {
   it('should create the correct Img2VecNeuralConfig type with defaults', () => {
-    const config = configure.namedVectorizer.img2VecNeural('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
+    const config = configure.vectorizer.img2VecNeural('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -228,10 +228,10 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Img2VecNeuralConfig type with custom values', () => {
-    const config = configure.namedVectorizer.img2VecNeural('test', {
+    const config = configure.vectorizer.img2VecNeural('test', {
       imageFields: ['field1', 'field2'],
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -247,8 +247,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Multi2VecClipConfig type with defaults', () => {
-    const config = configure.namedVectorizer.multi2VecClip('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
+    const config = configure.vectorizer.multi2VecClip('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -262,12 +262,12 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Multi2VecClipConfig type with custom values', () => {
-    const config = configure.namedVectorizer.multi2VecClip('test', {
+    const config = configure.vectorizer.multi2VecClip('test', {
       imageFields: ['field1', 'field2'],
       textFields: ['field3', 'field4'],
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -285,8 +285,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Multi2VecBindConfig type with defaults', () => {
-    const config = configure.namedVectorizer.multi2VecBind('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
+    const config = configure.vectorizer.multi2VecBind('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -300,7 +300,7 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Multi2VecBindConfig type with custom values', () => {
-    const config = configure.namedVectorizer.multi2VecBind('test', {
+    const config = configure.vectorizer.multi2VecBind('test', {
       audioFields: ['field1', 'field2'],
       depthFields: ['field3', 'field4'],
       imageFields: ['field5', 'field6'],
@@ -310,7 +310,7 @@ describe('Unit testing of the namedVectorizer factory class', () => {
       videoFields: ['field13', 'field14'],
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -333,10 +333,10 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Multi2VecPalmConfig type with defaults', () => {
-    const config = configure.namedVectorizer.multi2VecPalm('test', {
+    const config = configure.vectorizer.multi2VecPalm('test', {
       projectId: 'project-id',
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -352,14 +352,14 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Multi2VecPalmConfig type with custom values', () => {
-    const config = configure.namedVectorizer.multi2VecPalm('test', {
+    const config = configure.vectorizer.multi2VecPalm('test', {
       projectId: 'project-id',
       location: 'location',
       modelId: 'model-id',
       dimensions: 256,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -379,11 +379,11 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecAWSConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecAWS('test', {
+    const config = configure.vectorizer.text2VecAWS('test', {
       region: 'region',
       service: 'service',
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -400,14 +400,14 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecAWSConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecAWS('test', {
+    const config = configure.vectorizer.text2VecAWS('test', {
       endpoint: 'endpoint',
       model: 'model',
       region: 'region',
       service: 'service',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -427,11 +427,11 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecAzureOpenAIConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecAzureOpenAI('test', {
+    const config = configure.vectorizer.text2VecAzureOpenAI('test', {
       deploymentID: 'deployment-id',
       resourceName: 'resource-name',
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -448,13 +448,13 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecAzureOpenAIConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecAzureOpenAI('test', {
+    const config = configure.vectorizer.text2VecAzureOpenAI('test', {
       baseURL: 'base-url',
       deploymentID: 'deployment-id',
       resourceName: 'resource-name',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -473,8 +473,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecCohereConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecCohere('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
+    const config = configure.vectorizer.text2VecCohere('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -488,13 +488,13 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecCohereConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecCohere('test', {
+    const config = configure.vectorizer.text2VecCohere('test', {
       baseURL: 'base-url',
       model: 'model',
       truncate: true,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -513,8 +513,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecContextionaryConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecContextionary('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
+    const config = configure.vectorizer.text2VecContextionary('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -528,10 +528,10 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecContextionaryConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecContextionary('test', {
+    const config = configure.vectorizer.text2VecContextionary('test', {
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -547,8 +547,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecGPT4AllConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecGPT4All('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
+    const config = configure.vectorizer.text2VecGPT4All('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -562,10 +562,10 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecGPT4AllConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecGPT4All('test', {
+    const config = configure.vectorizer.text2VecGPT4All('test', {
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -581,8 +581,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecHuggingFaceConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecHuggingFace('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
+    const config = configure.vectorizer.text2VecHuggingFace('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -596,7 +596,7 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecHuggingFaceConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecHuggingFace('test', {
+    const config = configure.vectorizer.text2VecHuggingFace('test', {
       endpointURL: 'endpoint-url',
       model: 'model',
       passageModel: 'passage-model',
@@ -606,7 +606,7 @@ describe('Unit testing of the namedVectorizer factory class', () => {
       waitForModel: true,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -629,8 +629,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecJinaConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecJina('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
+    const config = configure.vectorizer.text2VecJina('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -644,11 +644,11 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecJinaConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecJina('test', {
+    const config = configure.vectorizer.text2VecJina('test', {
       model: 'model',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jina'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -665,8 +665,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecOpenAIConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecOpenAI('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
+    const config = configure.vectorizer.text2VecOpenAI('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -680,7 +680,7 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecOpenAIConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecOpenAI('test', {
+    const config = configure.vectorizer.text2VecOpenAI('test', {
       baseURL: 'base-url',
       dimensions: 256,
       model: 'model',
@@ -688,7 +688,7 @@ describe('Unit testing of the namedVectorizer factory class', () => {
       type: 'type',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -709,10 +709,10 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecPalmConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecPalm('test', {
+    const config = configure.vectorizer.text2VecPalm('test', {
       projectId: 'project-id',
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -728,13 +728,13 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecPalmConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecPalm('test', {
+    const config = configure.vectorizer.text2VecPalm('test', {
       apiEndpoint: 'api-endpoint',
       modelId: 'model-id',
       projectId: 'project-id',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -753,8 +753,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecTransformersConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecTransformers('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
+    const config = configure.vectorizer.text2VecTransformers('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -768,11 +768,11 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecTransformersConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecTransformers('test', {
+    const config = configure.vectorizer.text2VecTransformers('test', {
       poolingStrategy: 'pooling-strategy',
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -789,8 +789,8 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecVoyageAIConfig type with defaults', () => {
-    const config = configure.namedVectorizer.text2VecVoyageAI('test');
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
+    const config = configure.vectorizer.text2VecVoyageAI('test');
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',
@@ -804,13 +804,13 @@ describe('Unit testing of the namedVectorizer factory class', () => {
   });
 
   it('should create the correct Text2VecVoyageConfig type with custom values', () => {
-    const config = configure.namedVectorizer.text2VecVoyageAI('test', {
+    const config = configure.vectorizer.text2VecVoyageAI('test', {
       baseURL: 'base-url',
       model: 'model',
       truncate: true,
       vectorizeClassName: true,
     });
-    expect(config).toEqual<NamedVectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
       vectorName: 'test',
       vectorIndex: {
         name: 'hnsw',

--- a/src/collections/configure/vectorIndex.ts
+++ b/src/collections/configure/vectorIndex.ts
@@ -159,15 +159,15 @@ const reconfigure = {
    * @param {BQConfigCreate} [options.quantizer] The quantizer configuration to use. Default is `bq`.
    * @returns {ModuleConfig<'flat', VectorIndexConfigFlatCreate>} The configuration object.
    */
-  flat: (options?: {
+  flat: (options: {
     vectorCacheMaxObjects?: number;
     quantizer?: BQConfigUpdate;
   }): ModuleConfig<'flat', VectorIndexConfigFlatUpdate> => {
     return {
       name: 'flat',
       config: {
-        vectorCacheMaxObjects: options?.vectorCacheMaxObjects,
-        quantizer: parseQuantizer(options?.quantizer),
+        vectorCacheMaxObjects: options.vectorCacheMaxObjects,
+        quantizer: parseQuantizer(options.quantizer),
       },
     };
   },
@@ -185,7 +185,7 @@ const reconfigure = {
    * @param {number} [options.vectorCacheMaxObjects] The maximum number of objects to cache in the vector cache. Default is 1000000000000.
    * @returns {ModuleConfig<'hnsw', VectorIndexConfigHNSWUpdate>} The configuration object.
    */
-  hnsw: (options?: {
+  hnsw: (options: {
     dynamicEfFactor?: number;
     dynamicEfMax?: number;
     dynamicEfMin?: number;

--- a/src/collections/configure/vectorIndex.ts
+++ b/src/collections/configure/vectorIndex.ts
@@ -17,7 +17,7 @@ const configure = {
   /**
    * Create a `ModuleConfig<'flat', VectorIndexConfigFlatCreate>` object when defining the configuration of the FLAT vector index.
    *
-   * Use this method when defining the `options.vectorIndexConfig` argument of the `configure.namedVectorizer` method.
+   * Use this method when defining the `options.vectorIndexConfig` argument of the `configure.vectorizer` method.
    *
    * @param {VectorDistance} [config.distanceMetric] The distance metric to use. Default is 'cosine'.
    * @param {number} [config.vectorCacheMaxObjects] The maximum number of objects to cache in the vector cache. Default is 1000000000000.
@@ -41,7 +41,7 @@ const configure = {
   /**
    * Create a `ModuleConfig<'hnsw', VectorIndexConfigHNSWCreate>` object when defining the configuration of the HNSW vector index.
    *
-   * Use this method when defining the `options.vectorIndexConfig` argument of the `configure.namedVectorizer` method.
+   * Use this method when defining the `options.vectorIndexConfig` argument of the `configure.vectorizer` method.
    *
    * @param {number} [config.cleanupIntervalSeconds] The interval in seconds at which to clean up the index. Default is 300.
    * @param {VectorDistance} [config.distanceMetric] The distance metric to use. Default is 'cosine'.
@@ -152,7 +152,7 @@ const reconfigure = {
   /**
    * Create a `ModuleConfig<'flat', VectorIndexConfigFlatUpdate>` object to update the configuration of the FLAT vector index.
    *
-   * Use this method when defining the `options.vectorIndexConfig` argument of the `reconfigure.namedVectorizer` method.
+   * Use this method when defining the `options.vectorIndexConfig` argument of the `reconfigure.vectorizer` method.
    *
    * @param {VectorDistance} [options.distanceMetric] The distance metric to use. Default is 'cosine'.
    * @param {number} [options.vectorCacheMaxObjects] The maximum number of objects to cache in the vector cache. Default is 1000000000000.
@@ -174,7 +174,7 @@ const reconfigure = {
   /**
    * Create a `ModuleConfig<'hnsw', VectorIndexConfigHNSWCreate>` object to update the configuration of the HNSW vector index.
    *
-   * Use this method when defining the `options.vectorIndexConfig` argument of the `reconfigure.namedVectorizer` method.
+   * Use this method when defining the `options.vectorIndexConfig` argument of the `reconfigure.vectorizer` method.
    *
    * @param {number} [options.dynamicEfFactor] The dynamic ef factor. Default is 8.
    * @param {number} [options.dynamicEfMax] The dynamic ef max. Default is 500.

--- a/src/collections/configure/vectorIndex.ts
+++ b/src/collections/configure/vectorIndex.ts
@@ -3,6 +3,7 @@ import {
   BQConfigUpdate,
   PQConfigCreate,
   PQConfigUpdate,
+  VectorIndexConfigCreate,
   VectorIndexConfigFlatCreate,
   VectorIndexConfigFlatUpdate,
   VectorIndexConfigHNSWCreate,

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -1,38 +1,12 @@
-import {
-  Img2VecNeuralConfig,
-  ModuleConfig,
-  Multi2VecBindConfig,
-  Multi2VecClipConfig,
-  Multi2VecPalmConfig,
-  Ref2VecCentroidConfig,
-  Text2VecAWSConfig,
-  Text2VecAzureOpenAIConfig,
-  Text2VecCohereConfig,
-  Text2VecContextionaryConfig,
-  Text2VecGPT4AllConfig,
-  Text2VecHuggingFaceConfig,
-  Text2VecJinaConfig,
-  Text2VecOpenAIConfig,
-  Text2VecPalmConfig,
-  Text2VecTransformersConfig,
-  Text2VecVoyageAIConfig,
-  VectorIndexType,
-  Vectorizer,
-  VectorizerConfig,
-  VectorizerConfigType,
-} from '../config/types/index.js';
+import { VectorIndexType, Vectorizer, VectorizerConfigType } from '../config/types/index.js';
 import { ConfigureNonTextVectorizerOptions, ConfigureTextVectorizerOptions } from './types/index.js';
-import {
-  NamedVectorConfigCreate,
-  NamedVectorizerCreateOptions,
-  VectorIndexConfigCreateType,
-} from '../index.js';
+import { VectorConfigCreate, VectorizerCreateOptions, VectorIndexConfigCreateType } from '../index.js';
 import { PrimitiveKeys } from '../types/internal.js';
 
-const makeNamedVectorizer = <T, N extends string, I extends VectorIndexType, V extends Vectorizer>(
+const makeVectorizer = <T, N extends string, I extends VectorIndexType, V extends Vectorizer>(
   name: N,
-  options?: NamedVectorizerCreateOptions<PrimitiveKeys<T>[], I, V>
-): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, V> => {
+  options?: VectorizerCreateOptions<PrimitiveKeys<T>[], I, V>
+): VectorConfigCreate<PrimitiveKeys<T>, N, I, V> => {
   return {
     vectorName: name,
     properties: options?.sourceProperties,
@@ -45,34 +19,34 @@ const makeNamedVectorizer = <T, N extends string, I extends VectorIndexType, V e
   };
 };
 
-export const namedVectorizer = {
+export const vectorizer = {
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'none'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'none'`.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureNonTextVectorizerOptions<I, 'none'>} [opts] The configuration options for the `none` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'none'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'none'>} The configuration object.
    */
   none: <N extends string, I extends VectorIndexType>(
     name: N,
     opts?: ConfigureNonTextVectorizerOptions<I, 'none'>
-  ): NamedVectorConfigCreate<never, N, I, 'none'> =>
-    makeNamedVectorizer(name, { vectorIndexConfig: opts?.vectorIndexConfig }),
+  ): VectorConfigCreate<never, N, I, 'none'> =>
+    makeVectorizer(name, { vectorIndexConfig: opts?.vectorIndexConfig }),
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'img2vec-neural'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'img2vec-neural'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureNonTextVectorizerOptions<I, 'img2vec-neural'>} [opts] The configuration options for the `img2vec-neural` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'img2vec-neural'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'img2vec-neural'>} The configuration object.
    */
   img2VecNeural: <N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureNonTextVectorizerOptions<I, 'img2vec-neural'>
-  ): NamedVectorConfigCreate<never, N, I, 'img2vec-neural'> => {
+  ): VectorConfigCreate<never, N, I, 'img2vec-neural'> => {
     const { vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       vectorIndexConfig,
       vectorizerConfig: {
         name: 'img2vec-neural',
@@ -81,20 +55,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'multi2vec-bind'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'multi2vec-bind'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureNonTextVectorizerOptions<I, 'multi2vec-bind'>} [opts] The configuration options for the `multi2vec-bind` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-bind'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-bind'>} The configuration object.
    */
   multi2VecBind: <N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureNonTextVectorizerOptions<I, 'multi2vec-bind'>
-  ): NamedVectorConfigCreate<never, N, I, 'multi2vec-bind'> => {
+  ): VectorConfigCreate<never, N, I, 'multi2vec-bind'> => {
     const { vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       vectorIndexConfig,
       vectorizerConfig: {
         name: 'multi2vec-bind',
@@ -103,20 +77,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'multi2vec-clip'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'multi2vec-clip'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureNonTextVectorizerOptions<I, 'multi2vec-clip'>} [opts] The configuration options for the `multi2vec-clip` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-clip'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-clip'>} The configuration object.
    */
   multi2VecClip: <N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureNonTextVectorizerOptions<I, 'multi2vec-clip'>
-  ): NamedVectorConfigCreate<never, N, I, 'multi2vec-clip'> => {
+  ): VectorConfigCreate<never, N, I, 'multi2vec-clip'> => {
     const { vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       vectorIndexConfig,
       vectorizerConfig: {
         name: 'multi2vec-clip',
@@ -125,20 +99,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'multi2vec-palm'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'multi2vec-palm'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-palm) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureNonTextVectorizerOptions<I, 'multi2vec-palm'>} opts The configuration options for the `multi2vec-palm` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-palm'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-palm'>} The configuration object.
    */
   multi2VecPalm: <N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts: ConfigureNonTextVectorizerOptions<I, 'multi2vec-palm'>
-  ): NamedVectorConfigCreate<never, N, I, 'multi2vec-palm'> => {
+  ): VectorConfigCreate<never, N, I, 'multi2vec-palm'> => {
     const { vectorIndexConfig, ...config } = opts;
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       vectorIndexConfig,
       vectorizerConfig: {
         name: 'multi2vec-palm',
@@ -147,20 +121,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'ref2vec-centroid'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'ref2vec-centroid'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureNonTextVectorizerOptions<I, 'ref2vec-centroid'>} opts The configuration options for the `ref2vec-centroid` vectorizer.
-   * @returns {NamedVectorConfigCreate<never, N, I, 'ref2vec-centroid'>} The configuration object.
+   * @returns {VectorConfigCreate<never, N, I, 'ref2vec-centroid'>} The configuration object.
    */
   ref2VecCentroid: <N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts: ConfigureNonTextVectorizerOptions<I, 'ref2vec-centroid'>
-  ): NamedVectorConfigCreate<never, N, I, 'ref2vec-centroid'> => {
+  ): VectorConfigCreate<never, N, I, 'ref2vec-centroid'> => {
     const { vectorIndexConfig, ...config } = opts;
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       vectorIndexConfig,
       vectorizerConfig: {
         name: 'ref2vec-centroid',
@@ -169,20 +143,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-aws'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-aws'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-aws) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-aws'>} opts The configuration options for the `text2vec-aws` vectorizer.
-   * @returns { NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-aws'>} The configuration object.
+   * @returns { VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-aws'>} The configuration object.
    */
   text2VecAWS: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts: ConfigureTextVectorizerOptions<T, I, 'text2vec-aws'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-aws'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-aws'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts;
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -192,20 +166,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-azure-openai'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-azure-openai'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-azure-openai'>} opts The configuration options for the `text2vec-azure-openai` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-azure-openai'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-azure-openai'>} The configuration object.
    */
   text2VecAzureOpenAI: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts: ConfigureTextVectorizerOptions<T, I, 'text2vec-azure-openai'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-azure-openai'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-azure-openai'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts;
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -215,20 +189,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-cohere'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-cohere'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-cohere'>} [opts] The configuration options for the `text2vec-cohere` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-cohere'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-cohere'>} The configuration object.
    */
   text2VecCohere: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-cohere'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-cohere'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-cohere'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -238,20 +212,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-contextionary'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-contextionary'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-contextionary'>} [opts] The configuration for the `text2vec-contextionary` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-contextionary'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-contextionary'>} The configuration object.
    */
   text2VecContextionary: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-contextionary'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-contextionary'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-contextionary'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -261,20 +235,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-gpt4all'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-gpt4all'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-gpt4all'>} [opts] The configuration for the `text2vec-contextionary` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-gpt4all'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-gpt4all'>} The configuration object.
    */
   text2VecGPT4All: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-gpt4all'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-gpt4all'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-gpt4all'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -284,20 +258,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-huggingface'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-huggingface'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-huggingface'>} [opts] The configuration for the `text2vec-contextionary` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-huggingface'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-huggingface'>} The configuration object.
    */
   text2VecHuggingFace: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-huggingface'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-huggingface'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-huggingface'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -307,20 +281,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-jina'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-jina'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-jina) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-jina'>} [opts] The configuration for the `text2vec-jina` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-jina'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-jina'>} The configuration object.
    */
   text2VecJina: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-jina'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-jina'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-jina'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -330,20 +304,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-openai'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-openai'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-openai'>} [opts] The configuration for the `text2vec-openai` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-openai'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-openai'>} The configuration object.
    */
   text2VecOpenAI: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-openai'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-openai'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-openai'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -353,20 +327,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-palm'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-palm'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-palm'>} opts The configuration for the `text2vec-palm` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-palm'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-palm'>} The configuration object.
    */
   text2VecPalm: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts: ConfigureTextVectorizerOptions<T, I, 'text2vec-palm'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-palm'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-palm'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts;
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -376,20 +350,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-transformers'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-transformers'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-transformers'>} [opts] The configuration for the `text2vec-transformers` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-transformers'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-transformers'>} The configuration object.
    */
   text2VecTransformers: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-transformers'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-transformers'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-transformers'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {
@@ -399,20 +373,20 @@ export const namedVectorizer = {
     });
   },
   /**
-   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-voyageai'`.
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-voyageai'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-voyageai) for detailed usage.
    *
    * @param {string} name The name of the vector.
    * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-voyageai'>} [opts] The configuration for the `text2vec-voyageai` vectorizer.
-   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-voyageai'>} The configuration object.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-voyageai'>} The configuration object.
    */
   text2VecVoyageAI: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
     name: N,
     opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-voyageai'>
-  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-voyageai'> => {
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-voyageai'> => {
     const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
-    return makeNamedVectorizer(name, {
+    return makeVectorizer(name, {
       sourceProperties,
       vectorIndexConfig,
       vectorizerConfig: {

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -15,168 +15,410 @@ import {
   Text2VecOpenAIConfig,
   Text2VecPalmConfig,
   Text2VecTransformersConfig,
-  Text2VecVoyageConfig,
+  Text2VecVoyageAIConfig,
+  VectorIndexType,
   Vectorizer,
   VectorizerConfig,
+  VectorizerConfigType,
 } from '../config/types/index.js';
+import { ConfigureNonTextVectorizerOptions, ConfigureTextVectorizerOptions } from './types/index.js';
+import {
+  NamedVectorConfigCreate,
+  NamedVectorizerCreateOptions,
+  VectorIndexConfigCreateType,
+} from '../index.js';
+import { PrimitiveKeys } from '../types/internal.js';
 
-const makeVectorizer = <N extends Vectorizer, C extends VectorizerConfig>(
+const makeNamedVectorizer = <T, N extends string, I extends VectorIndexType, V extends Vectorizer>(
   name: N,
-  config?: C
-): ModuleConfig<N, C> => {
-  return { name, config };
+  options?: NamedVectorizerCreateOptions<PrimitiveKeys<T>[], I, V>
+): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, V> => {
+  return {
+    vectorName: name,
+    properties: options?.sourceProperties,
+    vectorIndex: options?.vectorIndexConfig
+      ? options.vectorIndexConfig
+      : { name: 'hnsw' as I, config: undefined as VectorIndexConfigCreateType<I> },
+    vectorizer: options?.vectorizerConfig
+      ? options.vectorizerConfig
+      : { name: 'none' as V, config: undefined as VectorizerConfigType<V> },
+  };
 };
 
-export const vectorizer = {
+export const namedVectorizer = {
   /**
-   * Create a `ModuleConfig<'none', {}>` object with the vectorizer set to `'none'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'none'`.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureNonTextVectorizerOptions<I, 'none'>} [opts] The configuration options for the `none` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'none'>} The configuration object.
    */
-  none: () => makeVectorizer('none', {}),
+  none: <N extends string, I extends VectorIndexType>(
+    name: N,
+    opts?: ConfigureNonTextVectorizerOptions<I, 'none'>
+  ): NamedVectorConfigCreate<never, N, I, 'none'> =>
+    makeNamedVectorizer(name, { vectorIndexConfig: opts?.vectorIndexConfig }),
   /**
-   * Create a `ModuleConfig<'img2vec-neural', Img2VecNeuralConfig>` object with the vectorizer set to `'img2vec-neural'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'img2vec-neural'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/img2vec-neural) for detailed usage.
    *
-   * @param {Img2VecNeuralConfig} [config] The configuration for the `img2vec-neural` vectorizer.
-   * @returns {ModuleConfig<'img2vec-neural', Img2VecNeuralConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureNonTextVectorizerOptions<I, 'img2vec-neural'>} [opts] The configuration options for the `img2vec-neural` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'img2vec-neural'>} The configuration object.
    */
-  img2VecNeural: (config?: Img2VecNeuralConfig | undefined) => makeVectorizer('img2vec-neural', config),
+  img2VecNeural: <N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureNonTextVectorizerOptions<I, 'img2vec-neural'>
+  ): NamedVectorConfigCreate<never, N, I, 'img2vec-neural'> => {
+    const { vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'img2vec-neural',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'multi2vec-bind', Multi2VecBindConfig>` object with the vectorizer set to `'multi2vec-bind'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'multi2vec-bind'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-bind) for detailed usage.
    *
-   * @param {Multi2VecBindConfig} [config] The configuration for the `multi2vec-bind` vectorizer.
-   * @returns {ModuleConfig<'multi2vec-bind', Multi2VecBindConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureNonTextVectorizerOptions<I, 'multi2vec-bind'>} [opts] The configuration options for the `multi2vec-bind` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-bind'>} The configuration object.
    */
-  multi2VecBind: (config?: Multi2VecBindConfig | undefined) => makeVectorizer('multi2vec-bind', config),
+  multi2VecBind: <N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureNonTextVectorizerOptions<I, 'multi2vec-bind'>
+  ): NamedVectorConfigCreate<never, N, I, 'multi2vec-bind'> => {
+    const { vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'multi2vec-bind',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'multi2vec-clip', Multi2VecClipConfig>` object with the vectorizer set to `'multi2vec-clip'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'multi2vec-clip'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-clip) for detailed usage.
    *
-   * @param {Multi2VecClipConfig} [config] The configuration for the `multi2vec-clip` vectorizer.
-   * @returns {ModuleConfig<'multi2vec-clip', Multi2VecClipConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureNonTextVectorizerOptions<I, 'multi2vec-clip'>} [opts] The configuration options for the `multi2vec-clip` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-clip'>} The configuration object.
    */
-  multi2VecClip: (config?: Multi2VecClipConfig | undefined) => makeVectorizer('multi2vec-clip', config),
+  multi2VecClip: <N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureNonTextVectorizerOptions<I, 'multi2vec-clip'>
+  ): NamedVectorConfigCreate<never, N, I, 'multi2vec-clip'> => {
+    const { vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'multi2vec-clip',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'multi2vec-palm', Multi2VecPalmConfig>` object with the vectorizer set to `'multi2vec-palm'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'multi2vec-palm'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/multi2vec-palm) for detailed usage.
    *
-   * @param {Multi2VecPalmConfig} config The configuration for the `multi2vec-palm` vectorizer.
-   * @returns {ModuleConfig<'multi2vec-palm', Multi2VecPalmConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureNonTextVectorizerOptions<I, 'multi2vec-palm'>} opts The configuration options for the `multi2vec-palm` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-palm'>} The configuration object.
    */
-  multi2VecPalm: (config: Multi2VecPalmConfig) => makeVectorizer('multi2vec-palm', config),
+  multi2VecPalm: <N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts: ConfigureNonTextVectorizerOptions<I, 'multi2vec-palm'>
+  ): NamedVectorConfigCreate<never, N, I, 'multi2vec-palm'> => {
+    const { vectorIndexConfig, ...config } = opts;
+    return makeNamedVectorizer(name, {
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'multi2vec-palm',
+        config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'ref2vec-centroid', Ref2VecCentroidConfig>` object with the vectorizer set to `'ref2vec-centroid'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'ref2vec-centroid'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/ref2vec-centroid) for detailed usage.
    *
-   * @param {Ref2VecCentroidConfig} config The configuration for the `ref2vec-centroid` vectorizer.
-   * @returns {ModuleConfig<'ref2vec-centroid', Ref2VecCentroidConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureNonTextVectorizerOptions<I, 'ref2vec-centroid'>} opts The configuration options for the `ref2vec-centroid` vectorizer.
+   * @returns {NamedVectorConfigCreate<never, N, I, 'ref2vec-centroid'>} The configuration object.
    */
-  ref2VecCentroid: (config: Ref2VecCentroidConfig) => makeVectorizer('ref2vec-centroid', config),
+  ref2VecCentroid: <N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts: ConfigureNonTextVectorizerOptions<I, 'ref2vec-centroid'>
+  ): NamedVectorConfigCreate<never, N, I, 'ref2vec-centroid'> => {
+    const { vectorIndexConfig, ...config } = opts;
+    return makeNamedVectorizer(name, {
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'ref2vec-centroid',
+        config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'text2vec-aws', Text2VecAWSConfig>` object with the vectorizer set to `'text2vec-aws'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-aws'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-aws) for detailed usage.
    *
-   * @param {Text2VecAWSConfig} config The configuration for the `text2vec-aws` vectorizer.
-   * @returns {ModuleConfig<'text2vec-aws', Text2VecAWSConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-aws'>} opts The configuration options for the `text2vec-aws` vectorizer.
+   * @returns { NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-aws'>} The configuration object.
    */
-  text2VecAWS: (config: Text2VecAWSConfig) => makeVectorizer('text2vec-aws', config),
+  text2VecAWS: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts: ConfigureTextVectorizerOptions<T, I, 'text2vec-aws'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-aws'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts;
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-aws',
+        config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'text2vec-openai', Text2VecAzureOpenAIConfig>` object with the vectorizer set to `'text2vec-openai'`.
-   *
-   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-azure-openai) for detailed usage.
-   *
-   * @param {Text2VecAzureOpenAIConfig} config The configuration for the `text2vec-azure-openai` vectorizer.
-   * @returns {ModuleConfig<'text2vec-openai', Text2VecAzureOpenAIConfig>} The configuration object.
-   */
-  text2VecAzureOpenAI: (config: Text2VecAzureOpenAIConfig) => makeVectorizer('text2vec-openai', config),
-  /**
-   * Create a `ModuleConfig<'text2vec-cohere', Text2VecCohereConfig>` object with the vectorizer set to `'text2vec-cohere'`.
-   *
-   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere) for detailed usage.
-   *
-   * @param {Text2VecCohereConfig} [config] The configuration for the `text2vec-cohere` vectorizer.
-   * @returns {ModuleConfig<'text2vec-cohere', Text2VecCohereConfig>} The configuration object.
-   */
-  text2VecCohere: (config?: Text2VecCohereConfig | undefined) => makeVectorizer('text2vec-cohere', config),
-  /**
-   * Create a `ModuleConfig<'text2vec-contextionary', Text2VecContextionaryConfig>` object with the vectorizer set to `'text2vec-contextionary'`.
-   *
-   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary) for detailed usage.
-   *
-   * @param {Text2VecContextionaryConfig} [config] The configuration for the `text2vec-contextionary` vectorizer.
-   * @returns {ModuleConfig<'text2vec-contextionary', Text2VecContextionaryConfig>} The configuration object.
-   */
-  text2VecContextionary: (config?: Text2VecContextionaryConfig) =>
-    makeVectorizer('text2vec-contextionary', config),
-  /**
-   * Create a `ModuleConfig<'text2vec-gpt4all', Text2VecGPT4AllConfig>` object with the vectorizer set to `'text2vec-gpt4all'`.
-   *
-   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all) for detailed usage.
-   *
-   * @param {Text2VecGPT4AllConfig} [config] The configuration for the `text2vec-gpt4all` vectorizer.
-   * @returns {ModuleConfig<'text2vec-gpt4all', Text2VecGPT4AllConfig>} The configuration object.
-   */
-  text2VecGPT4All: (config?: Text2VecGPT4AllConfig | undefined) => makeVectorizer('text2vec-gpt4all', config),
-  /**
-   * Create a `ModuleConfig<'text2vec-huggingface', Text2VecHuggingFaceConfig>` object with the vectorizer set to `'text2vec-huggingface'`.
-   *
-   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface) for detailed usage.
-   *
-   * @param {Text2VecHuggingFaceConfig} [config] The configuration for the `text2vec-huggingface` vectorizer.
-   * @returns {ModuleConfig<'text2vec-huggingface', Text2VecHuggingFaceConfig>} The configuration object.
-   */
-  text2VecHuggingFace: (config?: Text2VecHuggingFaceConfig | undefined) =>
-    makeVectorizer('text2vec-huggingface', config),
-  /**
-   * Create a `ModuleConfig<'text2vec-jina', Text2VecJinaConfig>` object with the vectorizer set to `'text2vec-jina'`.
-   *
-   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-jina) for detailed usage.
-   *
-   * @param {Text2VecJinaConfig} [config] The configuration for the `text2vec-jina` vectorizer.
-   * @returns {ModuleConfig<'text2vec-jina', Text2VecJinaConfig>} The configuration object.
-   */
-  text2VecJina: (config?: Text2VecJinaConfig | undefined) => makeVectorizer('text2vec-jina', config),
-  /**
-   * Create a `ModuleConfig<'text2vec-openai', Text2VecOpenAIConfig>` object with the vectorizer set to `'text2vec-openai'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-azure-openai'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai) for detailed usage.
    *
-   * @param {Text2VecOpenAIConfig} [config] The configuration for the `text2vec-openai` vectorizer.
-   * @returns {ModuleConfig<'text2vec-openai', Text2VecOpenAIConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-azure-openai'>} opts The configuration options for the `text2vec-azure-openai` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-azure-openai'>} The configuration object.
    */
-  text2VecOpenAI: (config?: Text2VecOpenAIConfig | undefined) => makeVectorizer('text2vec-openai', config),
+  text2VecAzureOpenAI: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts: ConfigureTextVectorizerOptions<T, I, 'text2vec-azure-openai'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-azure-openai'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts;
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-azure-openai',
+        config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'text2vec-palm', Text2VecPalmConfig>` object with the vectorizer set to `'text2vec-palm'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-cohere'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-cohere) for detailed usage.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-cohere'>} [opts] The configuration options for the `text2vec-cohere` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-cohere'>} The configuration object.
+   */
+  text2VecCohere: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-cohere'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-cohere'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-cohere',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-contextionary'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-contextionary) for detailed usage.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-contextionary'>} [opts] The configuration for the `text2vec-contextionary` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-contextionary'>} The configuration object.
+   */
+  text2VecContextionary: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-contextionary'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-contextionary'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-contextionary',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-gpt4all'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-gpt4all) for detailed usage.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-gpt4all'>} [opts] The configuration for the `text2vec-contextionary` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-gpt4all'>} The configuration object.
+   */
+  text2VecGPT4All: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-gpt4all'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-gpt4all'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-gpt4all',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-huggingface'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-huggingface) for detailed usage.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-huggingface'>} [opts] The configuration for the `text2vec-contextionary` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-huggingface'>} The configuration object.
+   */
+  text2VecHuggingFace: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-huggingface'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-huggingface'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-huggingface',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-jina'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-jina) for detailed usage.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-jina'>} [opts] The configuration for the `text2vec-jina` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-jina'>} The configuration object.
+   */
+  text2VecJina: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-jina'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-jina'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-jina',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-openai'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-openai) for detailed usage.
+   *
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-openai'>} [opts] The configuration for the `text2vec-openai` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-openai'>} The configuration object.
+   */
+  text2VecOpenAI: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-openai'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-openai'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-openai',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-palm'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-palm) for detailed usage.
    *
-   * @param {Text2VecPalmConfig} config The configuration for the `text2vec-palm` vectorizer.
-   * @returns {ModuleConfig<'text2vec-palm', Text2VecPalmConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-palm'>} opts The configuration for the `text2vec-palm` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-palm'>} The configuration object.
    */
-  text2VecPalm: (config: Text2VecPalmConfig) => makeVectorizer('text2vec-palm', config),
+  text2VecPalm: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts: ConfigureTextVectorizerOptions<T, I, 'text2vec-palm'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-palm'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts;
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-palm',
+        config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'text2vec-transformers', Text2VecTransformersConfig>` object with the vectorizer set to `'text2vec-transformers'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-transformers'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-transformers) for detailed usage.
    *
-   * @param {Text2VecTransformersConfig} [config] The configuration for the `text2vec-transformers` vectorizer.
-   * @returns {ModuleConfig<'text2vec-transformers', Text2VecTransformersConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-transformers'>} [opts] The configuration for the `text2vec-transformers` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-transformers'>} The configuration object.
    */
-  text2VecTransformers: (config?: Text2VecTransformersConfig | undefined) =>
-    makeVectorizer('text2vec-transformers', config),
+  text2VecTransformers: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-transformers'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-transformers'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-transformers',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
   /**
-   * Create a `ModuleConfig<'text2vec-voyageai', Text2VecVoyageConfig>` object with the vectorizer set to `'text2vec-voyageai'`.
+   * Create a `NamedVectorConfigCreate` object with the vectorizer set to `'text2vec-voyageai'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/modules/retriever-vectorizer-modules/text2vec-voyageai) for detailed usage.
    *
-   * @param {Text2VecVoyageConfig} [config] The configuration for the `text2vec-voyageai` vectorizer.
-   * @returns {ModuleConfig<'text2vec-voyageai', Text2VecVoyageConfig>} The configuration object.
+   * @param {string} name The name of the vector.
+   * @param {ConfigureTextVectorizerOptions<T, I, 'text2vec-voyageai'>} [opts] The configuration for the `text2vec-voyageai` vectorizer.
+   * @returns {NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-voyageai'>} The configuration object.
    */
-  text2VecVoyage: (config?: Text2VecVoyageConfig | undefined) => makeVectorizer('text2vec-voyageai', config),
+  text2VecVoyageAI: <T, N extends string, I extends VectorIndexType = 'hnsw'>(
+    name: N,
+    opts?: ConfigureTextVectorizerOptions<T, I, 'text2vec-voyageai'>
+  ): NamedVectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-voyageai'> => {
+    const { sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeNamedVectorizer(name, {
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-voyageai',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
 };

--- a/src/collections/data/integration.test.ts
+++ b/src/collections/data/integration.test.ts
@@ -50,7 +50,7 @@ describe('Testing of the collection.data methods with a single target reference'
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     await client.collections
       .create<undefined>({
         name: collectionName,
@@ -513,8 +513,8 @@ describe('Testing of the collection.data methods with a multi target reference',
         port: 50051,
       },
     });
-    collectionOne = client.collections.get(classNameOne);
-    collectionTwo = client.collections.get(classNameTwo);
+    collectionOne = client.collections.use(classNameOne);
+    collectionTwo = client.collections.use(classNameTwo);
     oneId = await client.collections
       .create({
         name: classNameOne,

--- a/src/collections/data/integration.test.ts
+++ b/src/collections/data/integration.test.ts
@@ -50,7 +50,7 @@ describe('Testing of the collection.data methods with a single target reference'
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     await client.collections
       .create<undefined>({
         name: collectionName,
@@ -513,8 +513,8 @@ describe('Testing of the collection.data methods with a multi target reference',
         port: 50051,
       },
     });
-    collectionOne = client.collections.use(classNameOne);
-    collectionTwo = client.collections.use(classNameTwo);
+    collectionOne = client.collections.get(classNameOne);
+    collectionTwo = client.collections.get(classNameTwo);
     oneId = await client.collections
       .create({
         name: classNameOne,

--- a/src/collections/deserialize/index.ts
+++ b/src/collections/deserialize/index.ts
@@ -18,6 +18,7 @@ import {
 import { BatchObject as BatchObjectGRPC, BatchObjectsReply } from '../../proto/v1/batch.js';
 import { Properties as PropertiesGrpc, Value } from '../../proto/v1/properties.js';
 import { BatchDeleteReply } from '../../proto/v1/batch_delete.js';
+import { WeaviateDeserializationError } from '../../errors.js';
 
 export class Deserialize {
   public static query<T>(reply: SearchReply): WeaviateReturn<T> {
@@ -154,7 +155,7 @@ export class Deserialize {
     if (value.geoValue !== undefined) return value.geoValue;
     if (value.phoneValue !== undefined) return value.phoneValue;
     if (value.nullValue !== undefined) return undefined;
-    throw new Error(`Unknown value type: ${JSON.stringify(value, null, 2)}`);
+    throw new WeaviateDeserializationError(`Unknown value type: ${JSON.stringify(value, null, 2)}`);
   }
 
   private static objectProperties(properties?: PropertiesGrpc): Properties {
@@ -182,7 +183,8 @@ export class Deserialize {
   }
 
   private static uuid(metadata?: MetadataResult) {
-    if (!metadata || !(metadata.id.length > 0)) throw new Error('No uuid returned from server');
+    if (!metadata || !(metadata.id.length > 0))
+      throw new WeaviateDeserializationError('No uuid returned from server');
     return metadata.id;
   }
 

--- a/src/collections/filters/classes.ts
+++ b/src/collections/filters/classes.ts
@@ -1,3 +1,4 @@
+import { WeaviateInvalidInputError } from '../../errors.js';
 import {
   FilterTarget,
   FilterReferenceCount,
@@ -86,7 +87,7 @@ export class FilterBase {
       if (TargetGuards.isTargetRef(target.target)) {
         target = target.target;
       } else {
-        throw new Error('Invalid target reference');
+        throw new WeaviateInvalidInputError('Invalid target reference');
       }
     }
     target.target = this.property;

--- a/src/collections/filters/integration.test.ts
+++ b/src/collections/filters/integration.test.ts
@@ -43,7 +43,7 @@ describe('Testing of the filter class with a simple collection', () => {
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     ids = await client.collections
       .create({
         name: collectionName,
@@ -120,8 +120,8 @@ describe('Testing of the filter class with a simple collection', () => {
   });
 
   it('should filter a fetch objects query with a single filter and non-generic collection', async () => {
-    const res = await client.collections.get(collectionName).query.fetchObjects({
-      filters: client.collections.get(collectionName).filter.byProperty('text').equal('two'),
+    const res = await client.collections.use(collectionName).query.fetchObjects({
+      filters: client.collections.use(collectionName).filter.byProperty('text').equal('two'),
     });
     expect(res.objects.length).toEqual(1);
     const obj = res.objects[0];
@@ -312,7 +312,7 @@ describe('Testing of the filter class with complex data type', () => {
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     await client.collections
       .create<TestCollectionFilterComplex>({
         name: collectionName,

--- a/src/collections/filters/integration.test.ts
+++ b/src/collections/filters/integration.test.ts
@@ -69,7 +69,7 @@ describe('Testing of the filter class with a simple collection', () => {
         ],
         invertedIndex: weaviate.configure.invertedIndex({ indexTimestamps: true }),
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('default', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(() =>

--- a/src/collections/filters/integration.test.ts
+++ b/src/collections/filters/integration.test.ts
@@ -68,7 +68,9 @@ describe('Testing of the filter class with a simple collection', () => {
           },
         ],
         invertedIndex: weaviate.configure.invertedIndex({ indexTimestamps: true }),
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('default', {
+          vectorizeClassName: false,
+        }),
       })
       .then(() =>
         collection.data.insertMany([
@@ -322,7 +324,6 @@ describe('Testing of the filter class with complex data type', () => {
             dataType: 'geoCoordinates',
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.none(),
       })
       .then(() =>
         collection.data.insertMany([

--- a/src/collections/filters/integration.test.ts
+++ b/src/collections/filters/integration.test.ts
@@ -68,7 +68,7 @@ describe('Testing of the filter class with a simple collection', () => {
           },
         ],
         invertedIndex: weaviate.configure.invertedIndex({ indexTimestamps: true }),
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('default', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('default', {
           vectorizeClassName: false,
         }),
       })

--- a/src/collections/filters/integration.test.ts
+++ b/src/collections/filters/integration.test.ts
@@ -43,7 +43,7 @@ describe('Testing of the filter class with a simple collection', () => {
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     ids = await client.collections
       .create({
         name: collectionName,
@@ -122,8 +122,8 @@ describe('Testing of the filter class with a simple collection', () => {
   });
 
   it('should filter a fetch objects query with a single filter and non-generic collection', async () => {
-    const res = await client.collections.use(collectionName).query.fetchObjects({
-      filters: client.collections.use(collectionName).filter.byProperty('text').equal('two'),
+    const res = await client.collections.get(collectionName).query.fetchObjects({
+      filters: client.collections.get(collectionName).filter.byProperty('text').equal('two'),
     });
     expect(res.objects.length).toEqual(1);
     const obj = res.objects[0];
@@ -314,7 +314,7 @@ describe('Testing of the filter class with complex data type', () => {
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     await client.collections
       .create<TestCollectionFilterComplex>({
         name: collectionName,

--- a/src/collections/generate/index.ts
+++ b/src/collections/generate/index.ts
@@ -19,6 +19,7 @@ import {
 } from '../query/types.js';
 import { GenerativeReturn, GenerativeGroupByReturn } from '../types/index.js';
 import { SearchReply } from '../../proto/v1/search_get.js';
+import { WeaviateInvalidInputError } from '../../errors.js';
 
 export type GenerateOptions<T> = {
   singlePrompt?: string;
@@ -298,7 +299,7 @@ class GenerateManager<T> implements Generate<T> {
           });
           break;
         default:
-          throw new Error(`Invalid media type: ${type}`);
+          throw new WeaviateInvalidInputError(`Invalid media type: ${type}`);
       }
       return reply.then((reply) =>
         groupBy ? Deserialize.generateGroupBy<T>(reply) : Deserialize.generate<T>(reply)

--- a/src/collections/generate/integration.test.ts
+++ b/src/collections/generate/integration.test.ts
@@ -47,7 +47,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     id = await client.collections
       .create({
         name: collectionName,
@@ -75,7 +75,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
 
   describe('using a non-generic collection', () => {
     it('should generate without search', async () => {
-      const ret = await client.collections.use(collectionName).generate.fetchObjects({
+      const ret = await client.collections.get(collectionName).generate.fetchObjects({
         singlePrompt: 'Write a haiku about ducks for {testProp}',
         groupedTask: 'What is the value of testProp here?',
         groupedProperties: ['testProp'],
@@ -202,7 +202,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     id = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/generate/integration.test.ts
+++ b/src/collections/generate/integration.test.ts
@@ -58,7 +58,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
           },
         ],
         generative: weaviate.configure.generative.openAI(),
-        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('vector', {
           vectorizeClassName: false,
         }),
       })
@@ -213,7 +213,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
           },
         ],
         generative: weaviate.configure.generative.openAI(),
-        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('vector', {
           vectorizeClassName: false,
         }),
       })

--- a/src/collections/generate/integration.test.ts
+++ b/src/collections/generate/integration.test.ts
@@ -59,7 +59,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
         ],
         generative: weaviate.configure.generative.openAI(),
         vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(() => {
@@ -214,7 +214,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
         ],
         generative: weaviate.configure.generative.openAI(),
         vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(() => {

--- a/src/collections/generate/integration.test.ts
+++ b/src/collections/generate/integration.test.ts
@@ -58,7 +58,9 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
           },
         ],
         generative: weaviate.configure.generative.openAI(),
-        vectorizer: weaviate.configure.vectorizer.text2VecOpenAI({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(() => {
         return collection.data.insert({
@@ -117,7 +119,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
     });
 
     it('should generate with hybrid', async () => {
-      const ret = await collection.generate.hybrid('test', generateOpts);
+      const ret = await collection.generate.hybrid('test', generateOpts, { targetVector: 'vector' });
       expect(ret.objects.length).toEqual(1);
       expect(ret.generated).toBeDefined();
       expect(ret.objects[0].properties.testProp).toEqual('test');
@@ -126,7 +128,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
     });
 
     it('should generate with nearObject', async () => {
-      const ret = await collection.generate.nearObject(id, generateOpts);
+      const ret = await collection.generate.nearObject(id, generateOpts, { targetVector: 'vector' });
       expect(ret.objects.length).toEqual(1);
       expect(ret.generated).toBeDefined();
       expect(ret.objects[0].properties.testProp).toEqual('test');
@@ -135,7 +137,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
     });
 
     it('should generate with nearText', async () => {
-      const ret = await collection.generate.nearText(['test'], generateOpts);
+      const ret = await collection.generate.nearText(['test'], generateOpts, { targetVector: 'vector' });
       expect(ret.objects.length).toEqual(1);
       expect(ret.generated).toBeDefined();
       expect(ret.objects[0].properties.testProp).toEqual('test');
@@ -144,7 +146,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
     });
 
     it('should generate with nearVector', async () => {
-      const ret = await collection.generate.nearVector(vector, generateOpts);
+      const ret = await collection.generate.nearVector(vector, generateOpts, { targetVector: 'vector' });
       expect(ret.objects.length).toEqual(1);
       expect(ret.generated).toBeDefined();
       expect(ret.objects[0].properties.testProp).toEqual('test');
@@ -211,7 +213,9 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
           },
         ],
         generative: weaviate.configure.generative.openAI(),
-        vectorizer: weaviate.configure.vectorizer.text2VecOpenAI({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(() => {
         return collection.data.insert({
@@ -221,7 +225,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
         });
       });
     const res = await collection.query.fetchObjectById(id, { includeVector: true });
-    vector = res?.vectors.default!;
+    vector = res?.vectors.vector!;
   });
 
   // it('should groupBy without search', async () => {
@@ -278,6 +282,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
   it('should groupBy with nearObject', async () => {
     const ret = await collection.generate.nearObject(id, generateOpts, {
       groupBy: groupByArgs,
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();
@@ -292,6 +297,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
   it('should groupBy with nearText', async () => {
     const ret = await collection.generate.nearText(['test'], generateOpts, {
       groupBy: groupByArgs,
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();
@@ -306,6 +312,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
   it('should groupBy with nearVector', async () => {
     const ret = await collection.generate.nearVector(vector, generateOpts, {
       groupBy: groupByArgs,
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();

--- a/src/collections/generate/integration.test.ts
+++ b/src/collections/generate/integration.test.ts
@@ -47,7 +47,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     id = await client.collections
       .create({
         name: collectionName,
@@ -73,7 +73,7 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
 
   describe('using a non-generic collection', () => {
     it('should generate without search', async () => {
-      const ret = await client.collections.get(collectionName).generate.fetchObjects({
+      const ret = await client.collections.use(collectionName).generate.fetchObjects({
         singlePrompt: 'Write a haiku about ducks for {testProp}',
         groupedTask: 'What is the value of testProp here?',
         groupedProperties: ['testProp'],
@@ -200,7 +200,7 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     id = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -28,6 +28,7 @@ import { classToCollection, resolveProperty, resolveReference } from './config/u
 import { WeaviateClass } from '../openapi/types.js';
 import { QuantizerGuards } from './configure/parsing.js';
 import { PrimitiveKeys } from './types/internal.js';
+import { WeaviateInvalidInputError } from '../errors.js';
 
 export type CollectionConfigCreate<TProperties = undefined, N = string> = {
   name: N;
@@ -127,7 +128,7 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
           vectorsConfig![v.vectorName] = vectorConfig;
         });
       } else {
-        throw new Error('Either vectorizer or vectorizers can be defined, not both');
+        throw new WeaviateInvalidInputError('Either vectorizer or vectorizers can be defined, not both');
       }
 
       const properties = config.properties

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -165,16 +165,16 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
         .withClassName(name)
         .do()
         .then(classToCollection<TProperties>),
-    get: <TProperties extends Properties | undefined = undefined, TName extends string = string>(
-      name: TName
-    ) => {
-      console.warn(
-        'The method collections.get() is deprecated and will be removed in the next major version. Please use collections.use() instead.'
-      );
-      return collection<TProperties, TName>(connection, name, dbVersionSupport);
-    },
+    // get: <TProperties extends Properties | undefined = undefined, TName extends string = string>(
+    //   name: TName
+    // ) => {
+    //   console.warn(
+    //     'The method collections.get() is deprecated and will be removed in the next major version. Please use collections.use() instead.'
+    //   );
+    //   return collection<TProperties, TName>(connection, name, dbVersionSupport);
+    // },
     listAll: listAll,
-    use: <TProperties extends Properties | undefined = undefined, TName extends string = string>(
+    get: <TProperties extends Properties | undefined = undefined, TName extends string = string>(
       name: TName
     ) => collection<TProperties, TName>(connection, name, dbVersionSupport),
   };
@@ -193,9 +193,9 @@ export interface Collections {
     name: TName
   ): Collection<TProperties, TName>;
   listAll(): Promise<CollectionConfig[]>;
-  use<TProperties extends Properties | undefined = undefined, TName extends string = string>(
-    name: TName
-  ): Collection<TProperties, TName>;
+  // use<TProperties extends Properties | undefined = undefined, TName extends string = string>(
+  //   name: TName
+  // ): Collection<TProperties, TName>;
 }
 
 export default collections;

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -20,6 +20,8 @@ import {
   NamedVectorConfigCreate,
   VectorIndexConfigCreate,
   VectorizersConfigCreate,
+  GenerativeConfig,
+  RerankerConfig,
 } from './types/index.js';
 import ClassExists from '../schema/classExists.js';
 import { classToCollection, resolveProperty, resolveReference } from './config/utils.js';
@@ -30,13 +32,13 @@ import { PrimitiveKeys } from './types/internal.js';
 export type CollectionConfigCreate<TProperties = undefined, N = string> = {
   name: N;
   description?: string;
-  generative?: ModuleConfig<GenerativeSearch>;
+  generative?: ModuleConfig<GenerativeSearch, GenerativeConfig>;
   invertedIndex?: InvertedIndexConfigCreate;
   multiTenancy?: MultiTenancyConfigCreate;
   properties?: PropertyConfigCreate<TProperties>[];
   references?: ReferenceConfigCreate<TProperties>[];
   replication?: ReplicationConfigCreate;
-  reranker?: ModuleConfig<Reranker>;
+  reranker?: ModuleConfig<Reranker, RerankerConfig>;
   sharding?: ShardingConfigCreate;
   vectorIndex?: ModuleConfig<VectorIndexType, VectorIndexConfigCreate>;
   vectorizer?: ModuleConfig<Vectorizer, VectorizerConfig>;

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -160,8 +160,16 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
         .then(classToCollection<TProperties>),
     get: <TProperties extends Properties | undefined = undefined, TName extends string = string>(
       name: TName
-    ) => collection<TProperties, TName>(connection, name, dbVersionSupport),
+    ) => {
+      console.warn(
+        'The method collections.get() is deprecated and will be removed in the next major version. Please use collections.use() instead.'
+      );
+      return collection<TProperties, TName>(connection, name, dbVersionSupport);
+    },
     listAll: listAll,
+    use: <TProperties extends Properties | undefined = undefined, TName extends string = string>(
+      name: TName
+    ) => collection<TProperties, TName>(connection, name, dbVersionSupport),
   };
 };
 
@@ -178,6 +186,9 @@ export interface Collections {
     name: TName
   ): Collection<TProperties, TName>;
   listAll(): Promise<CollectionConfig[]>;
+  use<TProperties extends Properties | undefined = undefined, TName extends string = string>(
+    name: TName
+  ): Collection<TProperties, TName>;
 }
 
 export default collections;

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -17,7 +17,7 @@ import {
   VectorIndexType,
   Vectorizer,
   VectorizerConfig,
-  NamedVectorConfigCreate,
+  VectorConfigCreate,
   VectorIndexConfigCreate,
   VectorizersConfigCreate,
   GenerativeConfig,

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -97,7 +97,7 @@ describe('Testing of the collections.create method', () => {
           },
         ],
       })
-      .then(() => contextionary.collections.use(collectionName).config.get());
+      .then(() => contextionary.collections.get(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -123,7 +123,7 @@ describe('Testing of the collections.create method', () => {
     const response = await contextionary.collections
       .create(schema)
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.use(collectionName).config.get());
+      .then(() => contextionary.collections.get(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -469,7 +469,7 @@ describe('Testing of the collections.create method', () => {
         },
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => cluster.collections.use(collectionName).config.get());
+      .then(() => cluster.collections.get(collectionName).config.get());
 
     expect(response.name).toEqual(collectionName);
     expect(response.description).toEqual('A test collection');
@@ -567,7 +567,7 @@ describe('Testing of the collections.create method', () => {
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('default'),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.use(collectionName).config.get());
+      .then(() => contextionary.collections.get(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');
@@ -597,7 +597,7 @@ describe('Testing of the collections.create method', () => {
         vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('default'),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => openai.collections.use(collectionName).config.get());
+      .then(() => openai.collections.get(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');
@@ -627,7 +627,7 @@ describe('Testing of the collections.create method', () => {
         generative: weaviate.configure.generative.openAI(),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => openai.collections.use(collectionName).config.get());
+      .then(() => openai.collections.get(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -554,7 +554,7 @@ describe('Testing of the collections.create method', () => {
   });
 
   it('should be able to create a collection with the contextionary vectorizer using configure.vectorizer', async () => {
-    const collectionName = 'ThisOneIsATest'; // must include words in contextionary's vocabulary to pass since vectorizeClassName will be true
+    const collectionName = 'ThisOneIsATest'; // must include words in contextionary's vocabulary to pass since vectorizeCollectionName will be true
     const response = await contextionary.collections
       .create({
         name: collectionName,
@@ -577,7 +577,7 @@ describe('Testing of the collections.create method', () => {
     expect(response.vectorizer.default.indexType).toEqual('hnsw');
     expect(response.vectorizer.default.vectorizer.name).toEqual('text2vec-contextionary');
     expect(
-      (response.vectorizer.default.vectorizer.config as Text2VecContextionaryConfig).vectorizeClassName
+      (response.vectorizer.default.vectorizer.config as Text2VecContextionaryConfig).vectorizeCollectionName
     ).toEqual(true);
 
     await contextionary.collections.delete(collectionName);
@@ -607,7 +607,7 @@ describe('Testing of the collections.create method', () => {
     expect(response.vectorizer.default.indexType).toEqual('hnsw');
     expect(response.vectorizer.default.vectorizer.name).toEqual('text2vec-openai');
     expect(
-      (response.vectorizer.default.vectorizer.config as Text2VecOpenAIConfig).vectorizeClassName
+      (response.vectorizer.default.vectorizer.config as Text2VecOpenAIConfig).vectorizeCollectionName
     ).toEqual(true);
 
     await openai.collections.delete(collectionName);

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -550,40 +550,6 @@ describe('Testing of the collections.create method', () => {
     await cluster.collections.delete(collectionName);
   });
 
-  it('should be able to create a collection with the contextionary vectorizer', async () => {
-    const collectionName = 'TestCollectionContextionaryVectorizer';
-    const response = await contextionary.collections
-      .create({
-        name: collectionName,
-        properties: [
-          {
-            name: 'testProp',
-            dataType: 'text',
-          },
-        ],
-        vectorizer: {
-          name: 'text2vec-contextionary',
-          config: {
-            vectorizeClassName: false,
-          },
-        },
-      })
-      .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.use(collectionName).config.get());
-    expect(response.name).toEqual(collectionName);
-    expect(response.properties?.length).toEqual(1);
-    expect(response.properties?.[0].name).toEqual('testProp');
-    expect(response.properties?.[0].dataType).toEqual('text');
-    expect(response.vectorizer.default.indexConfig).toBeDefined();
-    expect(response.vectorizer.default.indexType).toEqual('hnsw');
-    expect(response.vectorizer.default.vectorizer.name).toEqual('text2vec-contextionary');
-    expect(
-      (response.vectorizer.default.vectorizer.config as Text2VecContextionaryConfig).vectorizeClassName
-    ).toEqual(false);
-
-    await contextionary.collections.delete(collectionName);
-  });
-
   it('should be able to create a collection with the contextionary vectorizer using configure.vectorizer', async () => {
     const collectionName = 'ThisOneIsATest'; // must include words in contextionary's vocabulary to pass since vectorizeClassName will be true
     const response = await contextionary.collections
@@ -614,41 +580,7 @@ describe('Testing of the collections.create method', () => {
     await contextionary.collections.delete(collectionName);
   });
 
-  it('should be able to create a collection with the openai vectorizer', async () => {
-    const collectionName = 'TestCollectionOpenAIVectorizer';
-    const response = await openai.collections
-      .create({
-        name: collectionName,
-        properties: [
-          {
-            name: 'testProp',
-            dataType: 'text',
-          },
-        ],
-        vectorizer: {
-          name: 'text2vec-openai',
-          config: {
-            vectorizeClassName: true,
-          },
-        },
-      })
-      .then(() => openai.collections.use(collectionName).config.get());
-    expect(response.name).toEqual(collectionName);
-    expect(response.properties?.length).toEqual(1);
-    expect(response.properties?.[0].name).toEqual('testProp');
-    expect(response.properties?.[0].dataType).toEqual('text');
-    expect(response.vectorizer.default.indexConfig).toBeDefined();
-    expect(response.vectorizer.default.indexConfig.quantizer).toBeUndefined();
-    expect(response.vectorizer.default.indexType).toEqual('hnsw');
-    expect(response.vectorizer.default.vectorizer.name).toEqual('text2vec-openai');
-    expect(
-      (response.vectorizer.default.vectorizer.config as Text2VecOpenAIConfig).vectorizeClassName
-    ).toEqual(true);
-
-    await openai.collections.delete(collectionName);
-  });
-
-  it('should be able to create a collection with the openai vectorizer with configure.vectorizer', async () => {
+  it('should be able to create a collection with an openai vectorizer with configure.namedVectorizer', async () => {
     const collectionName = 'TestCollectionOpenAIVectorizerWithConfigureVectorizer';
     const response = await openai.collections
       .create({

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -73,7 +73,7 @@ describe('Testing of the collections.create method', () => {
           },
         ],
       })
-      .then(() => contextionary.collections.use<TestCollectionSimple>(collectionName).config.get());
+      .then(() => contextionary.collections.get<TestCollectionSimple>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -152,7 +152,7 @@ describe('Testing of the collections.create method', () => {
     const response = await contextionary.collections
       .create<TestCollectionSimple>(schema)
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.use<TestCollectionSimple>(collectionName).config.get());
+      .then(() => contextionary.collections.get<TestCollectionSimple>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -181,7 +181,7 @@ describe('Testing of the collections.create method', () => {
     const response = await contextionary.collections
       .create<TestCollectionSimple>(schema)
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.use<TestCollectionSimple>(collectionName).config.get());
+      .then(() => contextionary.collections.get<TestCollectionSimple>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -217,7 +217,7 @@ describe('Testing of the collections.create method', () => {
         ],
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.use<TestCollectionNested>(collectionName).config.get());
+      .then(() => contextionary.collections.get<TestCollectionNested>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -73,7 +73,7 @@ describe('Testing of the collections.create method', () => {
           },
         ],
       })
-      .then(() => contextionary.collections.get<TestCollectionSimple>(collectionName).config.get());
+      .then(() => contextionary.collections.use<TestCollectionSimple>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -97,7 +97,7 @@ describe('Testing of the collections.create method', () => {
           },
         ],
       })
-      .then(() => contextionary.collections.get(collectionName).config.get());
+      .then(() => contextionary.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -123,7 +123,7 @@ describe('Testing of the collections.create method', () => {
     const response = await contextionary.collections
       .create(schema)
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.get(collectionName).config.get());
+      .then(() => contextionary.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -152,7 +152,7 @@ describe('Testing of the collections.create method', () => {
     const response = await contextionary.collections
       .create<TestCollectionSimple>(schema)
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.get<TestCollectionSimple>(collectionName).config.get());
+      .then(() => contextionary.collections.use<TestCollectionSimple>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -181,7 +181,7 @@ describe('Testing of the collections.create method', () => {
     const response = await contextionary.collections
       .create<TestCollectionSimple>(schema)
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.get<TestCollectionSimple>(collectionName).config.get());
+      .then(() => contextionary.collections.use<TestCollectionSimple>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -217,7 +217,7 @@ describe('Testing of the collections.create method', () => {
         ],
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.get<TestCollectionNested>(collectionName).config.get());
+      .then(() => contextionary.collections.use<TestCollectionNested>(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties.length).toEqual(1);
     expect(response.properties[0].name).toEqual('testProp');
@@ -466,7 +466,7 @@ describe('Testing of the collections.create method', () => {
         },
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => cluster.collections.get(collectionName).config.get());
+      .then(() => cluster.collections.use(collectionName).config.get());
 
     expect(response.name).toEqual(collectionName);
     expect(response.description).toEqual('A test collection');
@@ -569,7 +569,7 @@ describe('Testing of the collections.create method', () => {
         },
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.get(collectionName).config.get());
+      .then(() => contextionary.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');
@@ -598,7 +598,7 @@ describe('Testing of the collections.create method', () => {
         vectorizer: weaviate.configure.vectorizer.text2VecContextionary(),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => contextionary.collections.get(collectionName).config.get());
+      .then(() => contextionary.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');
@@ -632,7 +632,7 @@ describe('Testing of the collections.create method', () => {
           },
         },
       })
-      .then(() => openai.collections.get(collectionName).config.get());
+      .then(() => openai.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');
@@ -662,7 +662,7 @@ describe('Testing of the collections.create method', () => {
         vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => openai.collections.get(collectionName).config.get());
+      .then(() => openai.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');
@@ -692,7 +692,7 @@ describe('Testing of the collections.create method', () => {
         generative: weaviate.configure.generative.openAI(),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
-      .then(() => openai.collections.get(collectionName).config.get());
+      .then(() => openai.collections.use(collectionName).config.get());
     expect(response.name).toEqual(collectionName);
     expect(response.properties?.length).toEqual(1);
     expect(response.properties?.[0].name).toEqual('testProp');

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -436,7 +436,10 @@ describe('Testing of the collections.create method', () => {
         replication: {
           factor: 2,
         },
-        vectorizer: weaviate.configure.vectorizer.none(),
+        vectorizer: {
+          name: 'none',
+          config: {},
+        },
         vectorIndex: {
           name: 'hnsw',
           config: {
@@ -561,7 +564,7 @@ describe('Testing of the collections.create method', () => {
             dataType: 'text',
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary(),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('default'),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
       .then(() => contextionary.collections.use(collectionName).config.get());
@@ -591,7 +594,7 @@ describe('Testing of the collections.create method', () => {
             dataType: 'text',
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('default'),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
       .then(() => openai.collections.use(collectionName).config.get());

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -564,7 +564,7 @@ describe('Testing of the collections.create method', () => {
             dataType: 'text',
           },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('default'),
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('default'),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
       .then(() => contextionary.collections.use(collectionName).config.get());
@@ -583,7 +583,7 @@ describe('Testing of the collections.create method', () => {
     await contextionary.collections.delete(collectionName);
   });
 
-  it('should be able to create a collection with an openai vectorizer with configure.namedVectorizer', async () => {
+  it('should be able to create a collection with an openai vectorizer with configure.vectorizer', async () => {
     const collectionName = 'TestCollectionOpenAIVectorizerWithConfigureVectorizer';
     const response = await openai.collections
       .create({
@@ -594,7 +594,7 @@ describe('Testing of the collections.create method', () => {
             dataType: 'text',
           },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('default'),
+        vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('default'),
       })
       .then(async (collection) => expect(await collection.exists()).toEqual(true))
       .then(() => openai.collections.use(collectionName).config.get());

--- a/src/collections/iterator/index.ts
+++ b/src/collections/iterator/index.ts
@@ -1,3 +1,4 @@
+import { WeaviateDeserializationError } from '../../errors.js';
 import { WeaviateObject } from '../types/index.js';
 
 const ITERATOR_CACHE_SIZE = 100;
@@ -22,11 +23,11 @@ export class Iterator<T> {
         }
         const obj = this.cache.shift();
         if (obj === undefined) {
-          throw new Error('Object iterator returned an object that is undefined');
+          throw new WeaviateDeserializationError('Object iterator returned an object that is undefined');
         }
         this.last = obj?.uuid;
         if (this.last === undefined) {
-          throw new Error('Object iterator returned an object without a UUID');
+          throw new WeaviateDeserializationError('Object iterator returned an object without a UUID');
         }
         return {
           done: false,

--- a/src/collections/iterator/integration.test.ts
+++ b/src/collections/iterator/integration.test.ts
@@ -44,7 +44,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
             dataType: 'text',
           },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
           vectorizeClassName: false,
         }),
       })

--- a/src/collections/iterator/integration.test.ts
+++ b/src/collections/iterator/integration.test.ts
@@ -34,7 +34,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     id = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/iterator/integration.test.ts
+++ b/src/collections/iterator/integration.test.ts
@@ -34,7 +34,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     id = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/iterator/integration.test.ts
+++ b/src/collections/iterator/integration.test.ts
@@ -44,7 +44,9 @@ describe('Testing of the collection.iterator method with a simple collection', (
             dataType: 'text',
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(() => {
         return collection.data.insert({
@@ -54,7 +56,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
         });
       });
     const res = await collection.query.fetchObjectById(id, { includeVector: true });
-    vector = res?.vectors.default!;
+    vector = res?.vectors.vector!;
   });
 
   it('should iterate through the collection with no options returning the objects', async () => {
@@ -62,7 +64,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
     for await (const obj of collection.iterator()) {
       expect(obj.properties.testProp).toBe('test');
       expect(obj.uuid).toBe(id);
-      expect(obj.vectors.default).toBeUndefined();
+      expect(obj.vectors.vector).toBeUndefined();
       count++; // eslint-disable-line no-plusplus
     }
     expect(count).toBe(1);
@@ -73,7 +75,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
     for await (const obj of collection.iterator({ returnProperties: ['testProp'] })) {
       expect(obj.properties.testProp).toBe('test');
       expect(obj.uuid).toBe(id);
-      expect(obj.vectors.default).toBeUndefined();
+      expect(obj.vectors.vector).toBeUndefined();
       count++; // eslint-disable-line no-plusplus
     }
     expect(count).toBe(1);
@@ -84,7 +86,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
     for await (const obj of collection.iterator({ returnMetadata: ['creationTime'] })) {
       expect(obj.properties.testProp).toBe('test');
       expect(obj.uuid).toBe(id);
-      expect(obj.vectors.default).toBeUndefined();
+      expect(obj.vectors.vector).toBeUndefined();
       expect(obj.metadata?.creationTime).toBeDefined();
       count++; // eslint-disable-line no-plusplus
     }
@@ -96,7 +98,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
     for await (const obj of collection.iterator({ includeVector: true })) {
       expect(obj.properties.testProp).toBe('test');
       expect(obj.uuid).toBe(id);
-      expect(obj.vectors.default).toEqual(vector);
+      expect(obj.vectors.vector).toEqual(vector);
       count++; // eslint-disable-line no-plusplus
     }
     expect(count).toBe(1);

--- a/src/collections/iterator/integration.test.ts
+++ b/src/collections/iterator/integration.test.ts
@@ -45,7 +45,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
           },
         ],
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(() => {

--- a/src/collections/query/index.ts
+++ b/src/collections/query/index.ts
@@ -28,6 +28,7 @@ import {
   Query,
   QueryReturn,
 } from './types.js';
+import { WeaviateInvalidInputError } from '../../errors.js';
 
 class QueryManager<T> implements Query<T> {
   connection: Connection;
@@ -158,7 +159,7 @@ class QueryManager<T> implements Query<T> {
           );
           break;
         default:
-          throw new Error(`Invalid media type: ${type}`);
+          throw new WeaviateInvalidInputError(`Invalid media type: ${type}`);
       }
       return reply.then((reply) =>
         Serialize.isGroupBy(opts) ? Deserialize.groupBy<T>(reply) : Deserialize.query<T>(reply)

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -37,7 +37,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     id = await client.collections
       .create({
         name: collectionName,
@@ -170,7 +170,7 @@ describe('Testing of the collection.query methods with a collection with a refer
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     return client.collections
       .create({
         name: collectionName,
@@ -210,7 +210,7 @@ describe('Testing of the collection.query methods with a collection with a refer
 
   describe('using a non-generic collection', () => {
     it('should query without searching returning the referenced object', async () => {
-      const ret = await client.collections.use(collectionName).query.fetchObjects({
+      const ret = await client.collections.get(collectionName).query.fetchObjects({
         returnProperties: ['testProp'],
         returnReferences: [
           {
@@ -402,7 +402,7 @@ describe('Testing of the collection.query methods with a collection with a refer
           port: 50051,
         },
       });
-      collection = client.collections.use(collectionName);
+      collection = client.collections.get(collectionName);
       return client.collections
         .create<TestCollectionQueryWithNestedProps>({
           name: collectionName,
@@ -538,7 +538,7 @@ describe('Testing of the collection.query methods with a collection with a refer
           port: 50051,
         },
       });
-      collection = client.collections.use(collectionName);
+      collection = client.collections.get(collectionName);
       return client.collections
         .create<TestCollectionQueryWithMultiVector>({
           name: collectionName,
@@ -627,7 +627,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     id = await client.collections
       .create({
         name: collectionName,
@@ -743,7 +743,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
   });
 
   it('should groupBy with nearVector and a non-generic collection', async () => {
-    const ret = await client.collections.use(collectionName).query.nearVector(vector, {
+    const ret = await client.collections.get(collectionName).query.nearVector(vector, {
       groupBy: {
         numberOfGroups: 1,
         objectsPerGroup: 1,
@@ -783,7 +783,7 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
 
   beforeAll(async () => {
     client = await weaviate.connectToLocal();
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     [id1, id2] = await client.collections
       .create<TestCollectionMultiTenancy>({
         name: collectionName,
@@ -935,7 +935,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
         'X-OpenAI-Api-Key': process.env.OPENAI_APIKEY as string,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     [id1, id2] = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -52,7 +52,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
           },
         ],
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(async () => {
@@ -188,7 +188,7 @@ describe('Testing of the collection.query methods with a collection with a refer
           },
         ],
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(async () => {
@@ -638,7 +638,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
           },
         ],
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(() => {
@@ -795,7 +795,7 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
         ],
         multiTenancy: weaviate.configure.multiTenancy({ enabled: true }),
         vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
-          vectorizeClassName: false,
+          vectorizeCollectionName: false,
         }),
       })
       .then(async (col) => {

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -51,7 +51,9 @@ describe('Testing of the collection.query methods with a simple collection', () 
             dataType: 'text',
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(async () => {
         await collection.data.insert({
@@ -68,7 +70,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
         });
       });
     const res = await collection.query.fetchObjectById(id, { includeVector: true });
-    vector = res?.vectors.default!;
+    vector = res?.vectors.vector!;
   });
 
   it('should fetch an object by its id', async () => {
@@ -111,7 +113,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
   });
 
   it('should query with nearObject', async () => {
-    const ret = await collection.query.nearObject(id, { limit: 1 });
+    const ret = await collection.query.nearObject(id, { limit: 1, targetVector: 'vector' });
     expect(ret.objects.length).toEqual(1);
     expect(ret.objects[0].properties.testProp).toEqual('test');
     expect(ret.objects[0].properties.testProp2).toEqual('test2');
@@ -119,7 +121,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
   });
 
   it('should query with nearText', async () => {
-    const ret = await collection.query.nearText(['test'], { limit: 1 });
+    const ret = await collection.query.nearText(['test'], { limit: 1, targetVector: 'vector' });
     expect(ret.objects.length).toEqual(1);
     expect(ret.objects[0].properties.testProp).toEqual('test');
     expect(ret.objects[0].properties.testProp2).toEqual('test2');
@@ -127,7 +129,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
   });
 
   it('should query with nearVector', async () => {
-    const ret = await collection.query.nearVector(vector, { limit: 1 });
+    const ret = await collection.query.nearVector(vector, { limit: 1, targetVector: 'vector' });
     expect(ret.objects.length).toEqual(1);
     expect(ret.objects[0].properties.testProp).toEqual('test');
     expect(ret.objects[0].properties.testProp2).toEqual('test2');
@@ -185,7 +187,9 @@ describe('Testing of the collection.query methods with a collection with a refer
             targetCollection: collectionName,
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(async () => {
         id1 = await collection.data.insert({
@@ -282,6 +286,7 @@ describe('Testing of the collection.query methods with a collection with a refer
 
     it('should query with hybrid returning the referenced object', async () => {
       const ret = await collection.query.hybrid('other', {
+        targetVector: 'vector',
         returnProperties: ['testProp'],
         returnReferences: [
           {
@@ -303,6 +308,7 @@ describe('Testing of the collection.query methods with a collection with a refer
 
     it('should query with nearObject returning the referenced object', async () => {
       const ret = await collection.query.nearObject(id2, {
+        targetVector: 'vector',
         returnProperties: ['testProp'],
         returnReferences: [
           {
@@ -442,7 +448,7 @@ describe('Testing of the collection.query methods with a collection with a refer
               ],
             },
           ],
-          vectorizer: weaviate.configure.vectorizer.text2VecContextionary(),
+          vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector'),
         })
         .then(async () => {
           id1 = await collection.data.insert({
@@ -543,11 +549,7 @@ describe('Testing of the collection.query methods with a collection with a refer
               vectorizePropertyName: false,
             },
           ],
-          vectorizers: [
-            weaviate.configure.namedVectorizer('title', {
-              vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
-            }),
-          ],
+          vectorizers: [weaviate.configure.namedVectorizer.text2VecContextionary('title')],
         })
         .then(async () => {
           id1 = await collection.data.insert({
@@ -635,7 +637,9 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
             dataType: 'text',
           },
         ],
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(() => {
         return collection.data.insert({
@@ -702,6 +706,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
   it('should groupBy with nearObject', async () => {
     const ret = await collection.query.nearObject(id, {
       groupBy: groupByArgs,
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();
@@ -714,6 +719,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
   it('should groupBy with nearText', async () => {
     const ret = await collection.query.nearText(['test'], {
       groupBy: groupByArgs,
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();
@@ -726,6 +732,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
   it('should groupBy with nearVector', async () => {
     const ret = await collection.query.nearVector(vector, {
       groupBy: groupByArgs,
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();
@@ -742,6 +749,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
         objectsPerGroup: 1,
         property: 'testProp',
       },
+      targetVector: 'vector',
     });
     expect(ret.objects.length).toEqual(1);
     expect(ret.groups).toBeDefined();
@@ -786,7 +794,9 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
           },
         ],
         multiTenancy: weaviate.configure.multiTenancy({ enabled: true }),
-        vectorizer: weaviate.configure.vectorizer.text2VecContextionary({ vectorizeClassName: false }),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+          vectorizeClassName: false,
+        }),
       })
       .then(async (col) => {
         await col.tenants.create([tenantOne, tenantTwo]);
@@ -858,8 +868,8 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
   });
 
   it('should find the objects in their tenants by nearObject', async () => {
-    const obj1 = await collection.withTenant(tenantOne).query.nearObject(id1);
-    const obj2 = await collection.withTenant(tenantTwo).query.nearObject(id2);
+    const obj1 = await collection.withTenant(tenantOne).query.nearObject(id1, { targetVector: 'vector' });
+    const obj2 = await collection.withTenant(tenantTwo).query.nearObject(id2, { targetVector: 'vector' });
     expect(obj1.objects.length).toEqual(1);
     expect(obj1.objects[0].properties.testProp).toEqual('one');
     expect(obj1.objects[0].uuid).toEqual(id1);
@@ -869,8 +879,8 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
   });
 
   it('should find the objects in their tenants by nearText', async () => {
-    const obj1 = await collection.withTenant(tenantOne).query.nearText(['one']);
-    const obj2 = await collection.withTenant(tenantTwo).query.nearText(['two']);
+    const obj1 = await collection.withTenant(tenantOne).query.nearText(['one'], { targetVector: 'vector' });
+    const obj2 = await collection.withTenant(tenantTwo).query.nearText(['two'], { targetVector: 'vector' });
     expect(obj1.objects.length).toEqual(1);
     expect(obj1.objects[0].properties.testProp).toEqual('one');
     expect(obj1.objects[0].uuid).toEqual(id1);
@@ -886,8 +896,12 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
     const { vectors: vecs2 } = (await collection
       .withTenant(tenantTwo)
       .query.fetchObjectById(id2, { includeVector: true }))!;
-    const obj1 = await collection.withTenant(tenantOne).query.nearVector(vecs1.default);
-    const obj2 = await collection.withTenant(tenantTwo).query.nearVector(vecs2.default);
+    const obj1 = await collection
+      .withTenant(tenantOne)
+      .query.nearVector(vecs1.default, { targetVector: 'vector' });
+    const obj2 = await collection
+      .withTenant(tenantTwo)
+      .query.nearVector(vecs2.default, { targetVector: 'vector' });
     expect(obj1.objects.length).toEqual(1);
     expect(obj1.objects[0].properties.testProp).toEqual('one');
     expect(obj1.objects[0].uuid).toEqual(id1);
@@ -932,7 +946,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
           },
         ],
         reranker: weaviate.configure.reranker.transformers(),
-        vectorizer: weaviate.configure.vectorizer.text2VecOpenAI(),
+        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('vector'),
       })
       .then(() =>
         Promise.all([
@@ -971,6 +985,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
         property: 'text',
         query: 'another',
       },
+      targetVector: 'vector',
     });
     const objects = ret.objects;
     expect(objects.length).toEqual(2);
@@ -986,6 +1001,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
         property: 'text',
         query: 'another',
       },
+      targetVector: 'vector',
     });
     const objects = ret.objects;
     expect(objects.length).toEqual(2);
@@ -1001,6 +1017,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
         property: 'text',
         query: 'another',
       },
+      targetVector: 'vector',
     });
     const objects = ret.objects;
     expect(objects.length).toEqual(2);
@@ -1017,6 +1034,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
         property: 'text',
         query: 'another',
       },
+      targetVector: 'vector',
     });
     const objects = ret.objects;
     expect(objects.length).toEqual(2);

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -543,7 +543,7 @@ describe('Testing of the collection.query methods with a collection with a refer
               vectorizePropertyName: false,
             },
           ],
-          vectorizer: [
+          vectorizers: [
             weaviate.configure.namedVectorizer('title', {
               vectorizerConfig: weaviate.configure.vectorizer.text2VecContextionary(),
             }),

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -649,7 +649,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
         });
       });
     const res = await collection.query.fetchObjectById(id, { includeVector: true });
-    vector = res?.vectors.default!;
+    vector = res?.vectors.vector!;
   });
 
   // it('should groupBy without search', async () => {

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -51,7 +51,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
             dataType: 'text',
           },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
           vectorizeClassName: false,
         }),
       })
@@ -187,7 +187,7 @@ describe('Testing of the collection.query methods with a collection with a refer
             targetCollection: collectionName,
           },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
           vectorizeClassName: false,
         }),
       })
@@ -448,7 +448,7 @@ describe('Testing of the collection.query methods with a collection with a refer
               ],
             },
           ],
-          vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector'),
+          vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector'),
         })
         .then(async () => {
           id1 = await collection.data.insert({
@@ -549,7 +549,7 @@ describe('Testing of the collection.query methods with a collection with a refer
               vectorizePropertyName: false,
             },
           ],
-          vectorizers: [weaviate.configure.namedVectorizer.text2VecContextionary('title')],
+          vectorizers: [weaviate.configure.vectorizer.text2VecContextionary('title')],
         })
         .then(async () => {
           id1 = await collection.data.insert({
@@ -637,7 +637,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
             dataType: 'text',
           },
         ],
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
           vectorizeClassName: false,
         }),
       })
@@ -794,7 +794,7 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
           },
         ],
         multiTenancy: weaviate.configure.multiTenancy({ enabled: true }),
-        vectorizers: weaviate.configure.namedVectorizer.text2VecContextionary('vector', {
+        vectorizers: weaviate.configure.vectorizer.text2VecContextionary('vector', {
           vectorizeClassName: false,
         }),
       })
@@ -946,7 +946,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
           },
         ],
         reranker: weaviate.configure.reranker.transformers(),
-        vectorizers: weaviate.configure.namedVectorizer.text2VecOpenAI('vector'),
+        vectorizers: weaviate.configure.vectorizer.text2VecOpenAI('vector'),
       })
       .then(() =>
         Promise.all([

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -37,7 +37,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     id = await client.collections
       .create({
         name: collectionName,
@@ -168,7 +168,7 @@ describe('Testing of the collection.query methods with a collection with a refer
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     return client.collections
       .create({
         name: collectionName,
@@ -206,7 +206,7 @@ describe('Testing of the collection.query methods with a collection with a refer
 
   describe('using a non-generic collection', () => {
     it('should query without searching returning the referenced object', async () => {
-      const ret = await client.collections.get(collectionName).query.fetchObjects({
+      const ret = await client.collections.use(collectionName).query.fetchObjects({
         returnProperties: ['testProp'],
         returnReferences: [
           {
@@ -396,7 +396,7 @@ describe('Testing of the collection.query methods with a collection with a refer
           port: 50051,
         },
       });
-      collection = client.collections.get(collectionName);
+      collection = client.collections.use(collectionName);
       return client.collections
         .create<TestCollectionQueryWithNestedProps>({
           name: collectionName,
@@ -532,7 +532,7 @@ describe('Testing of the collection.query methods with a collection with a refer
           port: 50051,
         },
       });
-      collection = client.collections.get(collectionName);
+      collection = client.collections.use(collectionName);
       return client.collections
         .create<TestCollectionQueryWithMultiVector>({
           name: collectionName,
@@ -625,7 +625,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     id = await client.collections
       .create({
         name: collectionName,
@@ -736,7 +736,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
   });
 
   it('should groupBy with nearVector and a non-generic collection', async () => {
-    const ret = await client.collections.get(collectionName).query.nearVector(vector, {
+    const ret = await client.collections.use(collectionName).query.nearVector(vector, {
       groupBy: {
         numberOfGroups: 1,
         objectsPerGroup: 1,
@@ -775,7 +775,7 @@ describe('Testing of the collection.query methods with a multi-tenancy collectio
 
   beforeAll(async () => {
     client = await weaviate.connectToLocal();
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     [id1, id2] = await client.collections
       .create<TestCollectionMultiTenancy>({
         name: collectionName,
@@ -921,7 +921,7 @@ maybe('Testing of collection.query using rerank functionality', () => {
         'X-OpenAI-Api-Key': process.env.OPENAI_APIKEY as string,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     [id1, id2] = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -96,6 +96,7 @@ import {
 import { Beacon } from '../references/index.js';
 import { ReferenceGuards } from '../references/classes.js';
 import { uuidToBeacon } from '../references/utils.js';
+import { WeaviateInvalidInputError, WeaviateSerializationError } from '../../errors.js';
 
 class FilterGuards {
   static isFilters = (
@@ -549,12 +550,14 @@ export class Serialize {
     if (target.property) {
       return [target.property];
     } else if (target.singleTarget) {
-      throw new Error(
+      throw new WeaviateSerializationError(
         'Cannot use Filter.byRef() in the aggregate API currently. Instead use Filter.byRefMultiTarget() and specify the target collection explicitly.'
       );
     } else if (target.multiTarget) {
       if (target.multiTarget.target === undefined) {
-        throw new Error(`target of multiTarget filter was unexpectedly undefined: ${target}`);
+        throw new WeaviateSerializationError(
+          `target of multiTarget filter was unexpectedly undefined: ${target}`
+        );
       }
       return [
         target.multiTarget.on,
@@ -577,7 +580,7 @@ export class Serialize {
       };
     } else {
       if (filters.target === undefined) {
-        throw new Error(`target of filter was unexpectedly undefined: ${filters}`);
+        throw new WeaviateSerializationError(`target of filter was unexpectedly undefined: ${filters}`);
       }
       const out = {
         path: Serialize.filterTargetToREST(filters.target),
@@ -647,7 +650,7 @@ export class Serialize {
           },
         };
       } else {
-        throw new Error('Invalid filter value type');
+        throw new WeaviateInvalidInputError('Invalid filter value type');
       }
     }
   };

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -488,7 +488,7 @@ export class Serialize {
     return {
       ...Serialize.common(args),
       nearVector: NearVector.fromPartial({
-        vectorBytes: args.vector ? Serialize.vectorToBytes(args.vector) : undefined,
+        vectorBytes: Serialize.vectorToBytes(args.vector),
         certainty: args.certainty,
         distance: args.distance,
         targetVectors: args.targetVector ? [args.targetVector] : undefined,

--- a/src/collections/serialize/unit.test.ts
+++ b/src/collections/serialize/unit.test.ts
@@ -47,7 +47,7 @@ describe('Unit testing of Serialize', () => {
       filters: filter<any>().byProperty('name').equal('test'),
       sort: sort<any>().byProperty('name'),
       includeVector: true,
-      returnMetadata: ['certainty'],
+      returnMetadata: 'all',
       returnProperties: ['name'],
       returnReferences: [{ linkOn: 'ref' }],
     });
@@ -65,8 +65,15 @@ describe('Unit testing of Serialize', () => {
       sortBy: [{ ascending: true, path: ['name'] }],
       metadata: MetadataRequest.fromPartial({
         certainty: true,
+        distance: true,
         uuid: true,
         vector: true,
+        vectors: undefined,
+        creationTimeUnix: true,
+        lastUpdateTimeUnix: true,
+        isConsistent: true,
+        explainScore: true,
+        score: true,
       }),
       properties: PropertiesRequest.fromPartial({
         nonRefProperties: ['name'],

--- a/src/collections/sort/integration.test.ts
+++ b/src/collections/sort/integration.test.ts
@@ -45,8 +45,8 @@ describe('Testing of the Sort class with a simple collection', () => {
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
-    collections = [collection, client.collections.use(collectionName)];
+    collection = client.collections.get(collectionName);
+    collections = [collection, client.collections.get(collectionName)];
     ids = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/sort/integration.test.ts
+++ b/src/collections/sort/integration.test.ts
@@ -45,8 +45,8 @@ describe('Testing of the Sort class with a simple collection', () => {
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
-    collections = [collection, client.collections.get(collectionName)];
+    collection = client.collections.use(collectionName);
+    collections = [collection, client.collections.use(collectionName)];
     ids = await client.collections
       .create({
         name: collectionName,

--- a/src/collections/tenants/integration.test.ts
+++ b/src/collections/tenants/integration.test.ts
@@ -27,7 +27,7 @@ describe('Testing of the collection.data methods', () => {
         port: 50051,
       },
     });
-    collection = client.collections.use(collectionName);
+    collection = client.collections.get(collectionName);
     return client.collections
       .create({
         name: collectionName,

--- a/src/collections/tenants/integration.test.ts
+++ b/src/collections/tenants/integration.test.ts
@@ -27,7 +27,7 @@ describe('Testing of the collection.data methods', () => {
         port: 50051,
       },
     });
-    collection = client.collections.get(collectionName);
+    collection = client.collections.use(collectionName);
     return client.collections
       .create({
         name: collectionName,

--- a/src/collections/types/query.ts
+++ b/src/collections/types/query.ts
@@ -32,7 +32,7 @@ type Metadata = {
 
 export type MetadataKeys = (keyof Metadata)[];
 
-export type QueryMetadata = MetadataKeys | undefined;
+export type QueryMetadata = 'all' | MetadataKeys | undefined;
 
 // export type ReturnMetadata<M extends MetadataKeys> = {
 //   [Key in M[number]]: Metadata[Key];

--- a/src/connection/grpc.ts
+++ b/src/connection/grpc.ts
@@ -12,6 +12,8 @@ import { HealthDefinition, HealthCheckResponse_ServingStatus } from '../proto/go
 import Batcher, { Batch } from '../grpc/batcher.js';
 import Searcher, { Search } from '../grpc/searcher.js';
 
+import { WeaviateGRPCUnavailableError } from '../errors.js';
+
 export interface GrpcConnectionParams extends ConnectionParams {
   grpcAddress: string;
   grpcSecure: boolean;
@@ -25,10 +27,12 @@ const MAX_GRPC_MESSAGE_LENGTH = 104858000; // 10mb, needs to be synchronized wit
 // which are tightly coupled to ConnectionGQL
 export default class ConnectionGRPC extends ConnectionGQL {
   private grpc: GrpcClient;
+  private grpcAddress: string;
 
   private constructor(params: GrpcConnectionParams) {
     super(params);
     this.grpc = grpcClient(params);
+    this.grpcAddress = params.grpcAddress;
   }
 
   static use = async (params: GrpcConnectionParams) => {
@@ -40,7 +44,7 @@ export default class ConnectionGRPC extends ConnectionGQL {
   private async connect() {
     const isHealthy = await this.grpc.health();
     if (!isHealthy) {
-      throw new Error('gRPC server is not healthy');
+      throw new WeaviateGRPCUnavailableError(this.grpcAddress);
     }
   }
 

--- a/src/connection/http.ts
+++ b/src/connection/http.ts
@@ -8,6 +8,7 @@ import {
   AuthUserPasswordCredentials,
   OidcAuthenticator,
 } from './auth.js';
+import { WeaviateInvalidInputError, WeaviateUnexpectedStatusCodeError } from '../errors.js';
 
 /**
  * You can only specify the gRPC proxy URL at this point in time. This is because ProxiesParams should be used to define tunnelling proxies
@@ -48,7 +49,9 @@ export default class ConnectionREST {
 
   private parseAuthParams(params: ConnectionParams): boolean {
     if (params.authClientSecret && params.apiKey) {
-      throw new Error('must provide one of authClientSecret (OIDC) or apiKey, cannot provide both');
+      throw new WeaviateInvalidInputError(
+        'must provide one of authClientSecret (OIDC) or apiKey, cannot provide both'
+      );
     }
     if (params.authClientSecret) {
       this.oidcAuth = new OidcAuthenticator(this.http, params.authClientSecret);
@@ -74,7 +77,7 @@ export default class ConnectionREST {
     if (params.scheme) {
       // If the host contains a scheme different than provided scheme, replace it and throw a warning
       if (extractedSchemeMatch && extractedSchemeMatch[1] !== `${params.scheme}`) {
-        throw new Error(
+        throw new WeaviateInvalidInputError(
           `The host contains a different protocol than specified in the scheme (scheme: ${params.scheme} != host: ${extractedSchemeMatch[1]})`
         );
       } else if (!extractedSchemeMatch) {
@@ -83,7 +86,7 @@ export default class ConnectionREST {
       }
       // If there's no scheme in params, ensure the host starts with a recognized protocol
     } else if (!extractedSchemeMatch) {
-      throw new Error(
+      throw new WeaviateInvalidInputError(
         'The host must start with a recognized protocol (e.g., http or https) if no scheme is provided.'
       );
     }
@@ -332,7 +335,7 @@ const checkStatus =
         } catch (e) {
           err = errText;
         }
-        return Promise.reject(new Error(`usage error (${res.status}): ${err}`));
+        return Promise.reject(new WeaviateUnexpectedStatusCodeError(res.status, err));
       });
     }
     if (expectResponseBody) {

--- a/src/data/journey.test.ts
+++ b/src/data/journey.test.ts
@@ -75,7 +75,7 @@ describe('data', () => {
       .do()
       .catch((e: Error) => {
         expect(e.message).toEqual(
-          `usage error (422): {"error":[{"message":"invalid object: invalid text property 'stringProp' on class 'DataJourneyTestThing': not a string, but json.Number"}]}`
+          `The request to Weaviate failed with status code: 422 and message: {"error":[{"message":"invalid object: invalid text property 'stringProp' on class 'DataJourneyTestThing': not a string, but json.Number"}]}`
         );
       });
   });
@@ -491,7 +491,7 @@ describe('data', () => {
       .withId('00000000-0000-0000-0000-000000000000')
       .do()
       .catch((err: Error) => {
-        expect(err.message).toEqual('usage error (404): ');
+        expect(err.message).toEqual('The request to Weaviate failed with status code: 404 and message: ');
       });
   });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,104 @@
+class WeaviateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
+/**
+ * Is thrown if the input to a function is invalid.
+ */
+export class WeaviateInvalidInputError extends WeaviateError {
+  constructor(message: string) {
+    super(`Invalid input provided: ${message}`);
+  }
+}
+
+/**
+ * Is thrown if a query (either gRPC or GraphQL) to Weaviate fails in any way.
+ */
+export class WeaviateQueryError extends WeaviateError {
+  constructor(message: string, protocolType: 'GraphQL' | 'gRPC') {
+    super(`Query call with protocol ${protocolType} failed with message: ${message}`);
+  }
+}
+
+/**
+ * Is thrown if a gRPC delete many request to Weaviate fails in any way.
+ */
+export class WeaviateDeleteManyError extends WeaviateError {
+  constructor(message: string) {
+    super(`Delete many failed with message: ${message}`);
+  }
+}
+
+/**
+ * Is thrown if a gRPC batch query to Weaviate fails in any way.
+ */
+export class WeaviateBatchError extends WeaviateError {
+  constructor(message: string) {
+    super(`Batch objects insert failed with message: ${message}`);
+  }
+}
+
+/**
+ * Is thrown if the gRPC health check against Weaviate fails.
+ */
+export class WeaviateGRPCUnavailableError extends WeaviateError {
+  constructor(address: string) {
+    const grpcMsg = `Please check that the server address and port: ${address} are correct.`;
+    const msg = `Weaviate makes use of a high-speed gRPC API as well as a REST API.
+      Unfortunately, the gRPC health check against Weaviate could not be completed.
+
+      This error could be due to one of several reasons:
+        - The gRPC traffic at the specified port is blocked by a firewall.
+        - gRPC is not enabled or incorrectly configured on the server or the client.
+            - ${grpcMsg}
+        - your connection is unstable or has a high latency. In this case you can:
+            - increase init-timeout in weaviate.connectToLocal({timeout: {init: X}})'
+            - disable startup checks by connecting using 'skipInitChecks=true'
+    `;
+    super(msg);
+  }
+}
+
+/**
+ * Is thrown if data returned by Weaviate cannot be processed by the client.
+ */
+export class WeaviateDeserializationError extends WeaviateError {
+  constructor(message: string) {
+    super(`Converting data from Weaviate failed with message: ${message}`);
+  }
+}
+
+/**
+ * Is thrown if data to be sent to Weaviate cannot be processed by the client.
+ */
+export class WeaviateSerializationError extends WeaviateError {
+  constructor(message: string) {
+    super(`Converting data to Weaviate failed with message: ${message}`);
+  }
+}
+
+/**
+ * Is thrown if Weaviate returns an unexpected status code.
+ */
+export class WeaviateUnexpectedStatusCodeError extends WeaviateError {
+  public code: number;
+  constructor(code: number, message: string) {
+    super(`The request to Weaviate failed with status code: ${code} and message: ${message}`);
+    this.code = code;
+  }
+}
+
+/**
+ * Is thrown when a backup creation or restoration fails.
+ */
+export class WeaviateBackupFailed extends WeaviateError {
+  constructor(message: string, kind: 'creation' | 'restoration') {
+    super(`Backup ${kind} failed with message: ${message}`);
+  }
+}

--- a/src/graphql/journey.test.ts
+++ b/src/graphql/journey.test.ts
@@ -2113,7 +2113,7 @@ describe('named vectors test', () => {
     });
   });
 
-  const className = 'NamedVectorTest';
+  const className = 'VectorTest';
   const oneUUID = 'abefd256-8574-442b-9293-9205193737e1';
 
   describe('setup', () => {
@@ -2154,7 +2154,7 @@ describe('named vectors test', () => {
       return client.schema.classCreator().withClass(namedVectorTest).do();
     });
 
-    it('should insert NamedVectorTest data', () => {
+    it('should insert VectorTest data', () => {
       const objects: WeaviateObject[] = [
         {
           class: className,
@@ -2197,8 +2197,8 @@ describe('named vectors test', () => {
         .withFields('title')
         .do()
         .then((res) => {
-          expect(res.data.Get.NamedVectorTest).toHaveLength(3);
-          expect(res.data.Get.NamedVectorTest[0].title).toBe('Two');
+          expect(res.data.Get.VectorTest).toHaveLength(3);
+          expect(res.data.Get.VectorTest[0].title).toBe('Two');
         });
     });
 
@@ -2213,8 +2213,8 @@ describe('named vectors test', () => {
         .withFields('rating')
         .do()
         .then((res) => {
-          expect(res.data.Get.NamedVectorTest).toHaveLength(3);
-          expect(res.data.Get.NamedVectorTest[0].rating).toBe('Good');
+          expect(res.data.Get.VectorTest).toHaveLength(3);
+          expect(res.data.Get.VectorTest[0].rating).toBe('Good');
         });
     });
   });
@@ -2238,8 +2238,8 @@ describe('named vectors test', () => {
           .do()
       )
       .then((res) => {
-        expect(res.data.Get.NamedVectorTest).toHaveLength(3);
-        expect(res.data.Get.NamedVectorTest[0].title).toBe('One');
+        expect(res.data.Get.VectorTest).toHaveLength(3);
+        expect(res.data.Get.VectorTest[0].title).toBe('One');
       });
   });
 
@@ -2254,13 +2254,13 @@ describe('named vectors test', () => {
       .withFields('rating')
       .do()
       .then((res) => {
-        expect(res.data.Get.NamedVectorTest).toHaveLength(3);
-        expect(res.data.Get.NamedVectorTest[0].rating).toBe('Best');
+        expect(res.data.Get.VectorTest).toHaveLength(3);
+        expect(res.data.Get.VectorTest[0].rating).toBe('Best');
       });
   });
 
   describe('destroy', () => {
-    it('tears down NamedVectorTest class', () => {
+    it('tears down VectorTest class', () => {
       return client.schema.classDeleter().withClassName(className).do();
     });
   });

--- a/src/graphql/journey.test.ts
+++ b/src/graphql/journey.test.ts
@@ -2135,7 +2135,7 @@ describe('named vectors test', () => {
             vectorIndexType: 'hnsw',
             vectorizer: {
               'text2vec-contextionary': {
-                vectorizeClassName: false,
+                vectorizeCollectionName: false,
                 properties: ['title'],
               },
             },
@@ -2144,7 +2144,7 @@ describe('named vectors test', () => {
             vectorIndexType: 'hnsw',
             vectorizer: {
               'text2vec-contextionary': {
-                vectorizeClassName: false,
+                vectorizeCollectionName: false,
                 properties: ['rating'],
               },
             },

--- a/src/graphql/journey.test.ts
+++ b/src/graphql/journey.test.ts
@@ -2135,7 +2135,7 @@ describe('named vectors test', () => {
             vectorIndexType: 'hnsw',
             vectorizer: {
               'text2vec-contextionary': {
-                vectorizeCollectionName: false,
+                vectorizeClassName: false,
                 properties: ['title'],
               },
             },
@@ -2144,7 +2144,7 @@ describe('named vectors test', () => {
             vectorIndexType: 'hnsw',
             vectorizer: {
               'text2vec-contextionary': {
-                vectorizeCollectionName: false,
+                vectorizeClassName: false,
                 properties: ['rating'],
               },
             },

--- a/src/grpc/batcher.ts
+++ b/src/grpc/batcher.ts
@@ -8,6 +8,7 @@ import { WeaviateClient } from '../proto/v1/weaviate.js';
 import Base from './base.js';
 import { BatchDeleteReply, BatchDeleteRequest } from '../proto/v1/batch_delete.js';
 import { Filters } from '../proto/v1/base.js';
+import { WeaviateBatchError, WeaviateDeleteManyError } from '../errors.js';
 
 export interface Batch {
   withDelete: (args: BatchDeleteArgs) => Promise<BatchDeleteReply>;
@@ -39,28 +40,36 @@ export default class Batcher extends Base implements Batch {
   public withObjects = (args: BatchObjectsArgs) => this.callObjects(BatchObjectsRequest.fromPartial(args));
 
   private callDelete(message: BatchDeleteRequest) {
-    return this.connection.batchDelete(
-      {
-        ...message,
-        collection: this.name,
-        consistencyLevel: this.consistencyLevel,
-        tenant: this.tenant,
-      },
-      {
-        metadata: this.metadata,
-      }
-    );
+    return this.connection
+      .batchDelete(
+        {
+          ...message,
+          collection: this.name,
+          consistencyLevel: this.consistencyLevel,
+          tenant: this.tenant,
+        },
+        {
+          metadata: this.metadata,
+        }
+      )
+      .catch((err) => {
+        throw new WeaviateDeleteManyError(err.message);
+      });
   }
 
   private callObjects(message: BatchObjectsRequest) {
-    return this.connection.batchObjects(
-      {
-        ...message,
-        consistencyLevel: this.consistencyLevel,
-      },
-      {
-        metadata: this.metadata,
-      }
-    );
+    return this.connection
+      .batchObjects(
+        {
+          ...message,
+          consistencyLevel: this.consistencyLevel,
+        },
+        {
+          metadata: this.metadata,
+        }
+      )
+      .catch((err) => {
+        throw new WeaviateBatchError(err.message);
+      });
   }
 }

--- a/src/grpc/searcher.ts
+++ b/src/grpc/searcher.ts
@@ -39,7 +39,7 @@ export type SearchFetchArgs = {
   groupBy?: GroupBy;
 };
 
-type BaseSearchArgs = {
+export type BaseSearchArgs = {
   limit?: number;
   offset?: number;
   autocut?: number;

--- a/src/grpc/searcher.ts
+++ b/src/grpc/searcher.ts
@@ -26,6 +26,7 @@ import {
 import { Metadata } from 'nice-grpc';
 
 import Base from './base.js';
+import { WeaviateQueryError } from '../errors.js';
 
 export type SearchFetchArgs = {
   limit?: number;
@@ -135,17 +136,21 @@ export default class Searcher extends Base implements Search {
   public withNearVideo = (args: SearchNearVideoArgs) => this.call(SearchRequest.fromPartial(args));
 
   private call(message: SearchRequest) {
-    return this.connection.search(
-      {
-        ...message,
-        collection: this.name,
-        consistencyLevel: this.consistencyLevel,
-        tenant: this.tenant,
-        uses123Api: true,
-      },
-      {
-        metadata: this.metadata,
-      }
-    );
+    return this.connection
+      .search(
+        {
+          ...message,
+          collection: this.name,
+          consistencyLevel: this.consistencyLevel,
+          tenant: this.tenant,
+          uses123Api: true,
+        },
+        {
+          metadata: this.metadata,
+        }
+      )
+      .catch((err) => {
+        throw new WeaviateQueryError(err.message, 'gRPC');
+      });
   }
 }

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -177,7 +177,7 @@ describe('schema', () => {
               },
               moduleConfig: {
                 'text2vec-contextionary': {
-                  vectorizeClassName: true,
+                  vectorizeCollectionName: true,
                 },
               },
               multiTenancyConfig: {
@@ -822,7 +822,7 @@ function newClassObject(className: string) {
     },
     moduleConfig: {
       'text2vec-contextionary': {
-        vectorizeClassName: true,
+        vectorizeCollectionName: true,
       },
     },
     multiTenancyConfig: {

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -92,7 +92,7 @@ describe('schema', () => {
       .do()
       .catch((err: Error) => {
         expect(err.message).toEqual(
-          'usage error (422): {"error":[{"message":"Tokenization is not allowed for data type \'int[]\'"}]}'
+          'The request to Weaviate failed with status code: 422 and message: {"error":[{"message":"Tokenization is not allowed for data type \'int[]\'"}]}'
         );
       });
   });

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -177,7 +177,7 @@ describe('schema', () => {
               },
               moduleConfig: {
                 'text2vec-contextionary': {
-                  vectorizeCollectionName: true,
+                  vectorizeClassName: true,
                 },
               },
               multiTenancyConfig: {
@@ -822,7 +822,7 @@ function newClassObject(className: string) {
     },
     moduleConfig: {
       'text2vec-contextionary': {
-        vectorizeCollectionName: true,
+        vectorizeClassName: true,
       },
     },
     multiTenancyConfig: {


### PR DESCRIPTION
- ~~Introduce `collections.use()` in place of `collections.get()` deprecating the latter~~ may come in subsequent RC
- Fix bug when updating legacy vectorizer's index configuration
- Split `vectorizer` into `vectorizer` and `vectorizers` in `collections.create()`
- Deprecate `vectorizer` with a warning in favour of `vectorizers`
- Allow `vectorizers` to accept instance of `NamedVectorizerConfig`
- Refactors `configure.namedVectorizer()` method into separate individual methods within `configure.namedVectorizer.` namespace for each vectorizer
- Renames all instances of `namedVectorizer` to `vectorizer` thereby forbidding legacy vectorization for new collections
- Renames all instances of `vectorizeClassName` to `vectorizeCollectionName`
- Adds specific errors as class extensions of `Error` for certain failure modes, e.g. `WeaviateQueryError`