### PR TITLE
Align `ClientParams` with Python client

### DIFF
--- a/src/collections/aggregate/integration.test.ts
+++ b/src/collections/aggregate/integration.test.ts
@@ -37,18 +37,7 @@ describe('Testing of the collection.aggregate methods', () => {
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     return client.collections
       .create({
@@ -309,18 +298,7 @@ describe('Testing of the collection.aggregate methods with named vectors', () =>
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     return client.collections.create<TestCollectionAggregateVectors>({
       name: collectionName,

--- a/src/collections/cluster/integration.test.ts
+++ b/src/collections/cluster/integration.test.ts
@@ -11,18 +11,7 @@ describe('Testing of the client.cluster methods', () => {
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     return Promise.all([client.collections.create({ name: one }), client.collections.create({ name: two })]);
   });
 

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -10,18 +10,7 @@ describe('Testing of the collection.config namespace', () => {
   let client: WeaviateClient;
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
   });
 
   it('should be able get the config of a collection without generics', async () => {

--- a/src/collections/data/integration.test.ts
+++ b/src/collections/data/integration.test.ts
@@ -38,18 +38,7 @@ describe('Testing of the collection.data methods with a single target reference'
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     await client.collections
       .create<undefined>({
@@ -501,18 +490,7 @@ describe('Testing of the collection.data methods with a multi target reference',
   let twoId: string;
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collectionOne = client.collections.get(classNameOne);
     collectionTwo = client.collections.get(classNameTwo);
     oneId = await client.collections
@@ -611,18 +589,7 @@ describe('Testing of the collection.data.insertMany method with all possible typ
   };
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     const primitives = [
       {
         name: 'text' as const,

--- a/src/collections/filters/integration.test.ts
+++ b/src/collections/filters/integration.test.ts
@@ -31,18 +31,7 @@ describe('Testing of the filter class with a simple collection', () => {
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     ids = await client.collections
       .create({
@@ -302,18 +291,7 @@ describe('Testing of the filter class with complex data type', () => {
   };
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     await client.collections
       .create<TestCollectionFilterComplex>({

--- a/src/collections/generate/integration.test.ts
+++ b/src/collections/generate/integration.test.ts
@@ -33,17 +33,9 @@ maybe('Testing of the collection.generate methods with a simple collection', () 
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8086,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50057,
-      },
+    client = await weaviate.connectToLocal({
+      port: 8086,
+      grpcPort: 50057,
       headers: {
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
       },
@@ -188,17 +180,9 @@ maybe('Testing of the groupBy collection.generate methods with a simple collecti
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8086,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50057,
-      },
+    client = await weaviate.connectToLocal({
+      port: 8086,
+      grpcPort: 50057,
       headers: {
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
       },

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -20,41 +20,17 @@ describe('Testing of the collections.create method', () => {
   let openai: WeaviateClient;
 
   beforeAll(async () => {
-    cluster = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8087,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
+    cluster = await weaviate.connectToLocal({
+      port: 8087,
+      grpcPort: 50051,
     });
-    contextionary = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
+    contextionary = await weaviate.connectToLocal({
+      port: 8080,
+      grpcPort: 50051,
     });
-    openai = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8086,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
+    openai = await weaviate.connectToLocal({
+      port: 8086,
+      grpcPort: 50051,
     });
   });
 

--- a/src/collections/iterator/integration.test.ts
+++ b/src/collections/iterator/integration.test.ts
@@ -22,18 +22,7 @@ describe('Testing of the collection.iterator method with a simple collection', (
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal({ port: 8080, grpcPort: 50051 });
     collection = client.collections.get(collectionName);
     id = await client.collections
       .create({

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -26,18 +26,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     id = await client.collections
       .create({
@@ -216,18 +205,7 @@ describe('Testing of the collection.query methods with a collection with a refer
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     return client.collections
       .create({
@@ -448,18 +426,7 @@ describe('Testing of the collection.query methods with a collection with a refer
     });
 
     beforeAll(async () => {
-      client = await weaviate.client({
-        rest: {
-          secure: false,
-          host: 'localhost',
-          port: 8080,
-        },
-        grpc: {
-          secure: false,
-          host: 'localhost',
-          port: 50051,
-        },
-      });
+      client = await weaviate.connectToLocal();
       collection = client.collections.get(collectionName);
       return client.collections
         .create<TestCollectionQueryWithNestedProps>({
@@ -584,18 +551,7 @@ describe('Testing of the collection.query methods with a collection with a refer
     });
 
     beforeAll(async () => {
-      client = await weaviate.client({
-        rest: {
-          secure: false,
-          host: 'localhost',
-          port: 8080,
-        },
-        grpc: {
-          secure: false,
-          host: 'localhost',
-          port: 50051,
-        },
-      });
+      client = await weaviate.connectToLocal();
       collection = client.collections.get(collectionName);
       return client.collections
         .create<TestCollectionQueryWithMultiVector>({
@@ -685,18 +641,7 @@ describe('Testing of the groupBy collection.query methods with a simple collecti
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     id = await client.collections
       .create({

--- a/src/collections/sort/integration.test.ts
+++ b/src/collections/sort/integration.test.ts
@@ -33,18 +33,7 @@ describe('Testing of the Sort class with a simple collection', () => {
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     collections = [collection, client.collections.get(collectionName)];
     ids = await client.collections

--- a/src/collections/tenants/integration.test.ts
+++ b/src/collections/tenants/integration.test.ts
@@ -16,18 +16,7 @@ describe('Testing of the collection.tenants methods', () => {
   });
 
   beforeAll(async () => {
-    client = await weaviate.client({
-      rest: {
-        secure: false,
-        host: 'localhost',
-        port: 8080,
-      },
-      grpc: {
-        secure: false,
-        host: 'localhost',
-        port: 50051,
-      },
-    });
+    client = await weaviate.connectToLocal();
     collection = client.collections.get(collectionName);
     return client.collections
       .create({

--- a/src/connection/auth.ts
+++ b/src/connection/auth.ts
@@ -42,7 +42,7 @@ export interface OidcAuthFlow {
 }
 
 export class OidcAuthenticator {
-  private readonly rest: HttpClient;
+  private readonly http: HttpClient;
   private readonly creds: OidcCredentials;
   private accessToken: string;
   private refreshToken?: string;
@@ -50,8 +50,8 @@ export class OidcAuthenticator {
   private refreshRunning: boolean;
   private refreshInterval!: NodeJS.Timeout;
 
-  constructor(rest: HttpClient, creds: any) {
-    this.rest = rest;
+  constructor(http: HttpClient, creds: any) {
+    this.http = http;
     this.creds = creds;
     this.accessToken = '';
     this.refreshToken = '';
@@ -73,13 +73,13 @@ export class OidcAuthenticator {
     let authenticator: OidcAuthFlow;
     switch (this.creds.constructor) {
       case AuthUserPasswordCredentials:
-        authenticator = new UserPasswordAuthenticator(this.rest, this.creds, config);
+        authenticator = new UserPasswordAuthenticator(this.http, this.creds, config);
         break;
       case AuthAccessTokenCredentials:
-        authenticator = new AccessTokenAuthenticator(this.rest, this.creds, config);
+        authenticator = new AccessTokenAuthenticator(this.http, this.creds, config);
         break;
       case AuthClientCredentials:
-        authenticator = new ClientCredentialsAuthenticator(this.rest, this.creds, config);
+        authenticator = new ClientCredentialsAuthenticator(this.http, this.creds, config);
         break;
       default:
         throw new Error('unsupported credential type');
@@ -94,7 +94,7 @@ export class OidcAuthenticator {
   };
 
   getOpenidConfig = (localConfig: any) => {
-    return this.rest.externalGet(localConfig.href).then((openidProviderConfig: any) => {
+    return this.http.externalGet(localConfig.href).then((openidProviderConfig: any) => {
       const scopes = localConfig.scopes || [];
       return {
         clientId: localConfig.clientId,

--- a/src/connection/helpers.ts
+++ b/src/connection/helpers.ts
@@ -69,15 +69,17 @@ export function connectToWCS(
   }
 
   return clientMaker({
-    rest: {
-      secure: true,
-      host: url.hostname,
-      port: 443,
-    },
-    grpc: {
-      secure: true,
-      host: grpcHost,
-      port: 443,
+    connectionParams: {
+      http: {
+        secure: true,
+        host: url.hostname,
+        port: 443,
+      },
+      grpc: {
+        secure: true,
+        host: grpcHost,
+        port: 443,
+      },
     },
     auth: options?.authCredentials,
     headers: options?.headers,
@@ -91,15 +93,17 @@ export function connectToLocal(
   options?: ConnectToLocalOptions
 ): Promise<WeaviateClient> {
   return clientMaker({
-    rest: {
-      secure: false,
-      host: options?.host || 'localhost',
-      port: options?.port || 8080,
-    },
-    grpc: {
-      secure: false,
-      host: options?.host || 'localhost',
-      port: options?.grpcPort || 50051,
+    connectionParams: {
+      http: {
+        secure: false,
+        host: options?.host || 'localhost',
+        port: options?.port || 8080,
+      },
+      grpc: {
+        secure: false,
+        host: options?.host || 'localhost',
+        port: options?.grpcPort || 50051,
+      },
     },
     auth: options?.authCredentials,
     headers: options?.headers,
@@ -113,16 +117,18 @@ export function connectToCustom(
   options?: ConnectToCustomOptions
 ): Promise<WeaviateClient> {
   return clientMaker({
-    rest: {
-      secure: options?.httpSecure || false,
-      host: options?.httpHost || 'localhost',
-      path: options?.httpPath || '',
-      port: options?.httpPort || 8080,
-    },
-    grpc: {
-      secure: options?.grpcSecure || false,
-      host: options?.grpcHost || 'localhost',
-      port: options?.grpcPort || 50051,
+    connectionParams: {
+      http: {
+        secure: options?.httpSecure || false,
+        host: options?.httpHost || 'localhost',
+        path: options?.httpPath || '',
+        port: options?.httpPort || 8080,
+      },
+      grpc: {
+        secure: options?.grpcSecure || false,
+        host: options?.grpcHost || 'localhost',
+        port: options?.grpcPort || 50051,
+      },
     },
     auth: options?.authCredentials,
     headers: options?.headers,


### PR DESCRIPTION
- Changes `ClientParams` to have a `connectionParams: ConnectionParams` field
- Moves `rest` and `grpc` fields inside `connectionParams`
- Renames `rest` to `http`