### PR TITLE
Add graphql as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "graphql": "^16.8.1",
         "graphql-request": "^5.2.0",
         "uuid": "^9.0.1"
       },
@@ -3781,7 +3782,6 @@
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
       "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -9324,8 +9324,7 @@
     "graphql": {
       "version": "16.8.1",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
-      "peer": true
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw=="
     },
     "graphql-request": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/weaviate/typescript-client#readme",
   "dependencies": {
+    "graphql": "^16.8.1",
     "graphql-request": "^5.2.0",
     "uuid": "^9.0.1"
   },


### PR DESCRIPTION
This PR adds `graphql` as a direct dependency to avoid installation problems due to it being a peer dependency of `graphql-request`