### PR TITLE
Send vectors optimistically to handle legacy vectorizers in >1.24.0

### DIFF
--- a/src/collections/data/index.ts
+++ b/src/collections/data/index.ts
@@ -193,6 +193,7 @@ const data = <T>(
     if (Array.isArray(object.vectors)) {
       const supportsNamedVectors = await dbVersionSupport.supportsNamedVectors();
       if (supportsNamedVectors.supports) {
+        obj.vector = object.vectors;
         obj.vectors = { default: object.vectors };
       } else {
         obj.vector = object.vectors;

--- a/src/collections/data/integration.test.ts
+++ b/src/collections/data/integration.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import { v4 } from 'uuid';
 import { WeaviateUnsupportedFeatureError } from '../../errors.js';
-import weaviate, { WeaviateClient } from '../../index.js';
+import weaviate, { WeaviateClient, weaviateV2 } from '../../index.js';
 import { GeoCoordinate, PhoneNumber } from '../../proto/v1/properties.js';
 import { Collection } from '../collection/index.js';
 import { CrossReference, CrossReferences, Reference } from '../references/index.js';
@@ -998,5 +998,40 @@ describe('Testing of the collection.data methods with a vector index', () => {
       includeVector: true,
     });
     expect(obj2?.vectors.default).toEqual([5, 6, 7, 8]);
+  });
+});
+
+describe('Testing of BYOV insertion with legacy vectorizer', () => {
+  const collectionName = 'TestBYOVEdgeCase';
+  const oldClient = weaviateV2.client({ scheme: 'http', host: 'localhost:8080' });
+
+  beforeAll(() =>
+    oldClient.schema
+      .classCreator()
+      .withClass({
+        class: collectionName,
+        vectorizer: 'none',
+      })
+      .do()
+  );
+
+  afterAll(() => oldClient.schema.classDeleter().withClassName(collectionName).do());
+
+  it('should insert and retrieve many vectors using the new client', async () => {
+    const client = await weaviate.connectToLocal();
+    const collection = client.collections.get(collectionName);
+    await collection.data.insertMany([{ vectors: [1, 2, 3] }, { vectors: [4, 5, 6] }]);
+    const objects = await collection.query.fetchObjects({ includeVector: true }).then((res) => res.objects);
+    expect(objects.length).toEqual(2);
+    expect(objects[0].vectors.default).toEqual([1, 2, 3]);
+    expect(objects[1].vectors.default).toEqual([4, 5, 6]);
+  });
+
+  it('should insert and retrieve single vectors using the new client', async () => {
+    const client = await weaviate.connectToLocal();
+    const collection = client.collections.get(collectionName);
+    const id = await collection.data.insert({ vectors: [7, 8, 9] });
+    const object = await collection.query.fetchObjectById(id, { includeVector: true });
+    expect(object?.vectors.default).toEqual([7, 8, 9]);
   });
 });

--- a/src/collections/data/integration.test.ts
+++ b/src/collections/data/integration.test.ts
@@ -1020,11 +1020,13 @@ describe('Testing of BYOV insertion with legacy vectorizer', () => {
   it('should insert and retrieve many vectors using the new client', async () => {
     const client = await weaviate.connectToLocal();
     const collection = client.collections.get(collectionName);
-    await collection.data.insertMany([{ vectors: [1, 2, 3] }, { vectors: [4, 5, 6] }]);
-    const objects = await collection.query.fetchObjects({ includeVector: true }).then((res) => res.objects);
-    expect(objects.length).toEqual(2);
-    expect(objects[0].vectors.default).toEqual([1, 2, 3]);
-    expect(objects[1].vectors.default).toEqual([4, 5, 6]);
+    const { uuids } = await collection.data.insertMany([{ vectors: [1, 2, 3] }, { vectors: [4, 5, 6] }]);
+    await collection.query
+      .fetchObjectById(uuids[0], { includeVector: true })
+      .then((res) => expect(res?.vectors.default).toEqual([1, 2, 3]));
+    await collection.query
+      .fetchObjectById(uuids[1], { includeVector: true })
+      .then((res) => expect(res?.vectors.default).toEqual([4, 5, 6]));
   });
 
   it('should insert and retrieve single vectors using the new client', async () => {

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -1096,6 +1096,8 @@ export class Serialize {
             name: 'default',
           }),
         ];
+        vectorBytes = Serialize.vectorToBytes(obj.vectors);
+        // required in case collection was made with <1.24.0 and has since been migrated to >=1.24.0
       } else if (obj.vectors !== undefined) {
         vectorBytes = Serialize.vectorToBytes(obj.vectors);
       }


### PR DESCRIPTION
The `v3` client currently doesn't handle the edge case where a collection is configured using the single vectorizer per collection syntax and has been upgraded to Weaviate `>=v1.24.0`. As such, it fails to insert BYoV for such collections

This PR changes the object insertion to send the provided vector in both channels to handle each use-case

Closes https://github.com/weaviate/typescript-client/issues/167