### PR TITLE
Add `Bm25QueryProperty` type for use in weighted `.bm25` and `.hybrid`

### DIFF
--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -94,6 +94,38 @@ describe('Testing of the collection.query methods with a simple collection', () 
     expect(ret.objects[0].uuid).toEqual(id);
   });
 
+  it('should query with bm25 and weighted query properties', async () => {
+    const ret = await collection.query.bm25('test', {
+      queryProperties: [
+        {
+          name: 'testProp',
+          weight: 2,
+        },
+        'testProp2',
+      ],
+    });
+    expect(ret.objects.length).toEqual(1);
+    expect(ret.objects[0].properties.testProp).toEqual('test');
+    expect(ret.objects[0].properties.testProp2).toEqual('test2');
+    expect(ret.objects[0].uuid).toEqual(id);
+  });
+
+  it('should query with bm25 and weighted query properties with a non-generic collection', async () => {
+    const ret = await client.collections.get(collectionName).query.bm25('test', {
+      queryProperties: [
+        {
+          name: 'testProp',
+          weight: 2,
+        },
+        'testProp2',
+      ],
+    });
+    expect(ret.objects.length).toEqual(1);
+    expect(ret.objects[0].properties.testProp).toEqual('test');
+    expect(ret.objects[0].properties.testProp2).toEqual('test2');
+    expect(ret.objects[0].uuid).toEqual(id);
+  });
+
   it('should query with hybrid', async () => {
     const ret = await collection.query.hybrid('test', { limit: 1 });
     expect(ret.objects.length).toEqual(1);

--- a/src/collections/query/types.ts
+++ b/src/collections/query/types.ts
@@ -76,10 +76,18 @@ export type SearchOptions<T> = {
   returnReferences?: QueryReference<T>[];
 };
 
+/** Which property of the collection to perform the keyword search on. */
+export type Bm25QueryProperty<T> = {
+  /** The property name to search on. */
+  name: PrimitiveKeys<T>;
+  /** The weight to provide to the keyword search for this property. */
+  weight: number;
+};
+
 /** Base options available in the `query.bm25` method */
 export type BaseBm25Options<T> = SearchOptions<T> & {
   /** Which properties of the collection to perform the keyword search on. */
-  queryProperties?: PrimitiveKeys<T>[];
+  queryProperties?: (PrimitiveKeys<T> | Bm25QueryProperty<T>)[];
 };
 
 /** Options available in the `query.bm25` method when specifying the `groupBy` parameter. */
@@ -98,7 +106,7 @@ export type BaseHybridOptions<T> = SearchOptions<T> & {
   /** The specific vector to search for or a specific vector subsearch. If not specified, the query is vectorized and used in the similarity search. */
   vector?: NearVectorInputType | HybridNearTextSubSearch | HybridNearVectorSubSearch;
   /** The properties to search in. If not specified, all properties are searched. */
-  queryProperties?: PrimitiveKeys<T>[];
+  queryProperties?: (PrimitiveKeys<T> | Bm25QueryProperty<T>)[];
   /** The type of fusion to apply. If not specified, the default fusion type specified by the server is used. */
   fusionType?: 'Ranked' | 'RelativeScore';
   /** Specify which vector(s) to search on if using named vectors. */


### PR DESCRIPTION
Adds the new `Bm25QueryProperty<T>` type for use when defining weighted keyword searches in BM25 and Hybrid queries. It maps internally to the `prop^w` string syntax expected by Weaviate

Closes https://github.com/weaviate/typescript-client/issues/178