### PR TITLE
Improve nestedProperties' type configuration

### DIFF
--- a/src/collections/configure/types/base.ts
+++ b/src/collections/configure/types/base.ts
@@ -55,7 +55,6 @@ export type NestedDataTypeConfig<T> =
 export type NestedPropertyCreate<T = undefined> = T extends undefined
   ? {
       name: string;
-      dataType: DataType;
       description?: string;
       indexInverted?: boolean;
       indexFilterable?: boolean;

--- a/src/collections/configure/types/base.ts
+++ b/src/collections/configure/types/base.ts
@@ -36,17 +36,32 @@ export type MultiTenancyConfigUpdate = {
   autoTenantCreation?: boolean;
 };
 
+export type ObjectDataType = 'object' | 'object[]';
+
+export type PrimitiveDataType = Exclude<DataType, ObjectDataType>;
+
+export type NestedDataTypeConfig<T> =
+  | {
+      dataType: ObjectDataType;
+      /** only for object types */
+      nestedProperties?: NestedPropertyConfigCreate<T, ObjectDataType>[];
+    }
+  | {
+      dataType: PrimitiveDataType;
+      /** If not an object, or an array of objecs, this field should never be assigned. */
+      nestedProperties?: never;
+    };
+
 export type NestedPropertyCreate<T = undefined> = T extends undefined
   ? {
       name: string;
       dataType: DataType;
       description?: string;
-      nestedProperties?: NestedPropertyConfigCreate<T, DataType>[];
       indexInverted?: boolean;
       indexFilterable?: boolean;
       indexSearchable?: boolean;
       tokenization?: WeaviateNestedProperty['tokenization'];
-    }
+    } & NestedDataTypeConfig<T>
   : {
       [K in NonRefKeys<T>]: RequiresNested<DataType<T[K]>> extends true
         ? {
@@ -92,9 +107,7 @@ export type NestedPropertyConfigCreateBase = {
 export type PropertyConfigCreate<T> = T extends undefined
   ? {
       name: string;
-      dataType: DataType;
       description?: string;
-      nestedProperties?: NestedPropertyConfigCreate<T, DataType>[];
       indexInverted?: boolean;
       indexFilterable?: boolean;
       indexRangeFilters?: boolean;
@@ -102,7 +115,7 @@ export type PropertyConfigCreate<T> = T extends undefined
       tokenization?: WeaviateProperty['tokenization'];
       skipVectorization?: boolean;
       vectorizePropertyName?: boolean;
-    }
+    } & NestedDataTypeConfig<T>
   : {
       [K in NonRefKeys<T>]: RequiresNested<DataType<T[K]>> extends true
         ? {


### PR DESCRIPTION
# This PR

> Ensures proper type association for `nestedProperties` in data type configurations
- Fix #203 
- [x] Resolved incorrect handling of `nestedProperties` for non-object data types:
- - Previously, even primitive types like string or boolean could accept `nestedProperties` when `strict` mode was enabled, which is technically invalid.
- - When strict mode was disabled, valid cases involving objects also triggered errors.
- [x] Introduced `ObjectDataType` and `PrimitiveDataType` to improve type distinction and prevent misuse.
- [x] Updated `NestedPropertyCreate` and `NestedPropertyConfigCreate` to align with conditional dataType logic.
- [x] Preserved support for deeply nested properties with proper validation.

## Current behavior (without the fix)

### Strict Mode: true

Primitive types (`string`, `boolean`, etc.) erroneously accept `nestedProperties`, which is technically impossible.
Example (Invalid but currently allowed):

```typescript
const invalidConfig = {
  name: 'Example',
  dataType: 'text', // Primitive type
  nestedProperties: [
    { name: 'Invalid', dataType: 'number' }, // ❌ should trigger a typescript error here, but doesn't
  ],
};
```

### Strict Mode: false

Both invalid and valid configurations trigger errors.
For instance, even proper configurations like the following are flagged:

```typescript
const validConfig = {
  name: 'ValidExample',
  dataType: 'object',
  nestedProperties: [
    { name: 'ValidNested', dataType: 'text' }, // should not trigger a typescript error but currently triggering `Type '{ name: string; dataType: "text"; }' is not assignable to type 'never'.` which is incorrect
  ],
};
```

## Behavior With This Fix

### Primitive Types:

Cannot accept `nestedProperties` regardless of whether strict mode is enabled or not(desired behavior).
Example (Now correctly flagged as invalid):

```typescript
const invalidConfig = {
  name: 'Example',
  dataType: 'text',
  nestedProperties: [
    { name: 'Invalid', dataType: 'number' }, // ❌ triggering the `Type '{ name: string; dataType: "text"; }' is not assignable to type 'never'.` error preventing developers from trying this (desired behavior)
  ],
};
```

## Object Types:

Continue to support deeply nested configurations without errors.
Example (Valid and supported):

```typescript
export const configs: CollectionConfigCreate<undefined, string> = {
  name: 'Movies',
  properties: [
    {
      name: 'Testing',
      dataType: dataType.OBJECT_ARRAY,
      nestedProperties: [
        {
          name: 'width',
          dataType: dataType.NUMBER,
        },
        {
          name: 'isBool',
          dataType: dataType.BOOLEAN,
        },
        {
          name: 'object-with-nested',
          dataType: dataType.OBJECT,
          nestedProperties: [ // ✅ no matter the strict flag, works as expected -> expected behavior
            {
              name: 'nested-url',
              dataType: dataType.TEXT,
            },
            {
              name: 'another-array-object-in-nested',
              dataType: dataType.OBJECT_ARRAY,
              nestedProperties: [ // ✅ works as expected
                {
                  name: 'nested-url',
                  dataType: dataType.TEXT,
                },
              ],
            },
          ],
        },
      ],
    },
  ],
};
```

The updated types now prevent invalid configurations and allow valid nested configurations without breaking existing functionality no matter the `strict` flag in tsconfig