### PR TITLE
Adjust generic for `NestedDataTypeConfig` when `ObjectDataType`

### DIFF
--- a/src/collections/configure/types/base.ts
+++ b/src/collections/configure/types/base.ts
@@ -44,7 +44,7 @@ export type NestedDataTypeConfig<T> =
   | {
       dataType: ObjectDataType;
       /** only for object types */
-      nestedProperties?: NestedPropertyConfigCreate<T, ObjectDataType>[];
+      nestedProperties?: NestedPropertyCreate<T>[];
     }
   | {
       dataType: PrimitiveDataType;


### PR DESCRIPTION
This PR adjusts the generic of the `nestedProperties` field in `NestedDataTypeConfig` when `dataType` has the type `ObjectDataType` so that there are no compiler errors when `strict: false` when defining the `nestedProperties` field of a property type with `object` or `object[]` data type

In short, by making use of `NestedPropertyConfigCreate`, the same issue of `strict: false` not resolving the conditional type `T extends undefined ? ... : ...` is encountered. With this change, we avoid that and so remove the bug