### PR TITLE
unnest exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "3.2.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "abort-controller-x": "^0.4.3",
         "graphql": "^16.9.0",
         "graphql-request": "^6.1.0",
         "long": "^5.2.3",
         "nice-grpc": "^2.1.10",
         "nice-grpc-client-middleware-retry": "^3.1.9",
+        "nice-grpc-common": "^2.0.2",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
@@ -37,13 +39,10 @@
         "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-prettier": "^4.2.1",
         "express": "^4.19.2",
-        "graphql-request": "^6.1.0",
         "grpc-tools": "^1.12.4",
         "husky": "^8.0.3",
         "jest": "^29.4.3",
         "lint-staged": "^13.2.0",
-        "long": "^5.2.3",
-        "nice-grpc": "^2.1.10",
         "openapi-typescript": "^5.4.1",
         "prettier": "^2.8.4",
         "prettier-plugin-organize-imports": "^3.2.4",
@@ -54,8 +53,7 @@
         "tsup": "^8.0.2",
         "typedoc": "^0.25.12",
         "typedoc-plugin-extras": "^3.0.0",
-        "typescript": "5.1.3",
-        "uuid": "^9.0.1"
+        "typescript": "5.1.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1347,7 +1345,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "dev": true,
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -1356,7 +1353,6 @@
       "version": "1.10.10",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.10.tgz",
       "integrity": "sha512-HPa/K5NX6ahMoeBv15njAc/sfF4/jmiXLar9UlC2UfHFKZzsCVLc3wbe7+7qua7w9VPh2/L6EBxyAV7/E8Wftg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
@@ -1370,7 +1366,6 @@
       "version": "0.7.13",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
       "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
@@ -1859,7 +1854,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1947,32 +1941,27 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "dev": true
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dev": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1981,32 +1970,27 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "dev": true
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "dev": true
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -2374,7 +2358,6 @@
     },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {
@@ -2501,7 +2484,6 @@
     },
     "node_modules/@types/node": {
       "version": "18.14.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prettier": {
@@ -2994,7 +2976,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3008,7 +2989,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/color-name": "^1.1.1",
@@ -3919,7 +3899,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3946,7 +3925,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3957,7 +3935,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -4169,7 +4146,6 @@
     },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7"
@@ -4459,7 +4435,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4474,7 +4449,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -4484,7 +4458,6 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -4576,7 +4549,6 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5397,7 +5369,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -5569,7 +5540,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
       "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
-      "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "cross-fetch": "^3.1.5"
@@ -5888,7 +5858,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6997,7 +6966,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -7069,8 +7037,7 @@
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "dev": true
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7334,7 +7301,6 @@
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.10.tgz",
       "integrity": "sha512-Nujs/4wWJvE5OSxWPp3M5H+zHJAgsWMo38bMNfKQP1VDeCChp7MiKTkhJBV5JZvrBIkPhYQCLIbfvVqEoSuTuA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.8",
@@ -7362,7 +7328,6 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -7381,17 +7346,14 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -7980,7 +7942,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
       "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -8184,7 +8145,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8349,7 +8309,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -8742,7 +8702,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8771,7 +8730,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9575,7 +9533,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9683,7 +9640,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9756,7 +9712,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -9783,7 +9738,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -9799,7 +9753,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
   },
   "homepage": "https://github.com/weaviate/typescript-client#readme",
   "dependencies": {
+    "abort-controller-x": "^0.4.3",
     "graphql": "^16.9.0",
     "graphql-request": "^6.1.0",
     "long": "^5.2.3",
     "nice-grpc": "^2.1.10",
     "nice-grpc-client-middleware-retry": "^3.1.9",
+    "nice-grpc-common": "^2.0.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -79,13 +81,10 @@
     "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "express": "^4.19.2",
-    "graphql-request": "^6.1.0",
     "grpc-tools": "^1.12.4",
     "husky": "^8.0.3",
     "jest": "^29.4.3",
     "lint-staged": "^13.2.0",
-    "long": "^5.2.3",
-    "nice-grpc": "^2.1.10",
     "openapi-typescript": "^5.4.1",
     "prettier": "^2.8.4",
     "prettier-plugin-organize-imports": "^3.2.4",
@@ -96,8 +95,7 @@
     "tsup": "^8.0.2",
     "typedoc": "^0.25.12",
     "typedoc-plugin-extras": "^3.0.0",
-    "typescript": "5.1.3",
-    "uuid": "^9.0.1"
+    "typescript": "5.1.3"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,15 +17,13 @@ import {
   isApiKey,
   mapApiKey,
 } from './connection/auth.js';
+import * as helpers from './connection/helpers.js';
 import {
   ConnectToCustomOptions,
   ConnectToLocalOptions,
   ConnectToWCDOptions,
   ConnectToWCSOptions,
   ConnectToWeaviateCloudOptions,
-  connectToCustom,
-  connectToLocal,
-  connectToWeaviateCloud,
 } from './connection/helpers.js';
 import { ProxiesParams, TimeoutParams } from './connection/http.js';
 import { ConnectionGRPC } from './connection/index.js';
@@ -125,112 +123,123 @@ const cleanHost = (host: string, protocol: 'rest' | 'grpc') => {
   return host;
 };
 
+/**
+ * Connect to a custom Weaviate deployment, e.g. your own self-hosted Kubernetes cluster.
+ *
+ * @param {ConnectToCustomOptions} options Options for the connection.
+ * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your custom Weaviate deployment.
+ */
+export function connectToCustom(options: ConnectToCustomOptions): Promise<WeaviateClient> {
+  return helpers.connectToCustom(client, options);
+}
+
+/**
+ * Connect to a locally-deployed Weaviate instance, e.g. as a Docker compose stack.
+ *
+ * @param {ConnectToLocalOptions} [options] Options for the connection.
+ * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your local Weaviate instance.
+ */
+export function connectToLocal(options?: ConnectToLocalOptions): Promise<WeaviateClient> {
+  return helpers.connectToLocal(client, options);
+}
+
+/**
+ * Connect to your own Weaviate Cloud (WCD) instance.
+ *
+ * @deprecated Use `connectToWeaviateCloud` instead.
+ *
+ * @param {string} clusterURL The URL of your WCD instance. E.g., `https://example.weaviate.network`.
+ * @param {ConnectToWCDOptions} [options] Additional options for the connection.
+ * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your WCD instance.
+ */
+export function connectToWCD(clusterURL: string, options?: ConnectToWCDOptions): Promise<WeaviateClient> {
+  console.warn(
+    'The `connectToWCD` method is deprecated. Please use `connectToWeaviateCloud` instead. This method will be removed in a future release.'
+  );
+  return helpers.connectToWeaviateCloud(clusterURL, client, options);
+}
+
+/**
+ * Connect to your own Weaviate Cloud Service (WCS) instance.
+ *
+ * @deprecated Use `connectToWeaviateCloud` instead.
+ *
+ * @param {string} clusterURL The URL of your WCD instance. E.g., `https://example.weaviate.network`.
+ * @param {ConnectToWCSOptions} [options] Additional options for the connection.
+ * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your WCS instance.
+ */
+export function connectToWCS(clusterURL: string, options?: ConnectToWCSOptions): Promise<WeaviateClient> {
+  console.warn(
+    'The `connectToWCS` method is deprecated. Please use `connectToWeaviateCloud` instead. This method will be removed in a future release.'
+  );
+  return helpers.connectToWeaviateCloud(clusterURL, client, options);
+}
+
+/**
+ * Connect to your own Weaviate Cloud (WCD) instance.
+ *
+ * @param {string} clusterURL The URL of your WCD instance. E.g., `https://example.weaviate.network`.
+ * @param {ConnectToWeaviateCloudOptions} [options] Additional options for the connection.
+ * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your WCD instance.
+ */
+export function connectToWeaviateCloud(
+  clusterURL: string,
+  options?: ConnectToWeaviateCloudOptions
+): Promise<WeaviateClient> {
+  return helpers.connectToWeaviateCloud(clusterURL, client, options);
+}
+
+async function client(params: ClientParams): Promise<WeaviateClient> {
+  let { host: httpHost } = params.connectionParams.http;
+  let { host: grpcHost } = params.connectionParams.grpc;
+  const { port: httpPort, secure: httpSecure, path: httpPath } = params.connectionParams.http;
+  const { port: grpcPort, secure: grpcSecure } = params.connectionParams.grpc;
+  httpHost = cleanHost(httpHost, 'rest');
+  grpcHost = cleanHost(grpcHost, 'grpc');
+
+  // check if headers are set
+  if (!params.headers) params.headers = {};
+
+  const scheme = httpSecure ? 'https' : 'http';
+  const agent = httpSecure ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true });
+
+  const { connection, dbVersionProvider, dbVersionSupport } = await ConnectionGRPC.use({
+    host: `${scheme}://${httpHost}:${httpPort}${httpPath || ''}`,
+    scheme: scheme,
+    headers: params.headers,
+    grpcAddress: `${grpcHost}:${grpcPort}`,
+    grpcSecure: grpcSecure,
+    grpcProxyUrl: params.proxies?.grpc,
+    apiKey: isApiKey(params.auth) ? mapApiKey(params.auth) : undefined,
+    authClientSecret: isApiKey(params.auth) ? undefined : params.auth,
+    agent,
+    timeout: params.timeout,
+    skipInitChecks: params.skipInitChecks,
+  });
+
+  const ifc: WeaviateClient = {
+    backup: backup(connection),
+    cluster: cluster(connection),
+    collections: collections(connection, dbVersionSupport),
+    close: () => Promise.resolve(connection.close()), // hedge against future changes to add I/O to .close()
+    getMeta: () => new MetaGetter(connection).do(),
+    getOpenIDConfig: () => new OpenidConfigurationGetter(connection.http).do(),
+    getWeaviateVersion: () => dbVersionSupport.getVersion(),
+    isLive: () => new LiveChecker(connection, dbVersionProvider).do(),
+    isReady: () => new ReadyChecker(connection, dbVersionProvider).do(),
+  };
+  if (connection.oidcAuth) ifc.oidcAuth = connection.oidcAuth;
+
+  return ifc;
+}
+
 const app = {
-  /**
-   * Connect to a custom Weaviate deployment, e.g. your own self-hosted Kubernetes cluster.
-   *
-   * @param {ConnectToCustomOptions} options Options for the connection.
-   * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your custom Weaviate deployment.
-   */
-  connectToCustom: function (options: ConnectToCustomOptions): Promise<WeaviateClient> {
-    return connectToCustom(this.client, options);
-  },
-  /**
-   * Connect to a locally-deployed Weaviate instance, e.g. as a Docker compose stack.
-   *
-   * @param {ConnectToLocalOptions} [options] Options for the connection.
-   * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your local Weaviate instance.
-   */
-  connectToLocal: function (options?: ConnectToLocalOptions): Promise<WeaviateClient> {
-    return connectToLocal(this.client, options);
-  },
-  /**
-   * Connect to your own Weaviate Cloud (WCD) instance.
-   *
-   * @deprecated Use `connectToWeaviateCloud` instead.
-   *
-   * @param {string} clusterURL The URL of your WCD instance. E.g., `https://example.weaviate.network`.
-   * @param {ConnectToWCDOptions} [options] Additional options for the connection.
-   * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your WCD instance.
-   */
-  connectToWCD: function (clusterURL: string, options?: ConnectToWCDOptions): Promise<WeaviateClient> {
-    console.warn(
-      'The `connectToWCD` method is deprecated. Please use `connectToWeaviateCloud` instead. This method will be removed in a future release.'
-    );
-    return connectToWeaviateCloud(clusterURL, this.client, options);
-  },
-  /**
-   * Connect to your own Weaviate Cloud Service (WCS) instance.
-   *
-   * @deprecated Use `connectToWeaviateCloud` instead.
-   *
-   * @param {string} clusterURL The URL of your WCD instance. E.g., `https://example.weaviate.network`.
-   * @param {ConnectToWCSOptions} [options] Additional options for the connection.
-   * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your WCS instance.
-   */
-  connectToWCS: function (clusterURL: string, options?: ConnectToWCSOptions): Promise<WeaviateClient> {
-    console.warn(
-      'The `connectToWCS` method is deprecated. Please use `connectToWeaviateCloud` instead. This method will be removed in a future release.'
-    );
-    return connectToWeaviateCloud(clusterURL, this.client, options);
-  },
-  /**
-   * Connect to your own Weaviate Cloud (WCD) instance.
-   *
-   * @param {string} clusterURL The URL of your WCD instance. E.g., `https://example.weaviate.network`.
-   * @param {ConnectToWeaviateCloudOptions} [options] Additional options for the connection.
-   * @returns {Promise<WeaviateClient>} A Promise that resolves to a client connected to your WCD instance.
-   */
-  connectToWeaviateCloud: function (
-    clusterURL: string,
-    options?: ConnectToWeaviateCloudOptions
-  ): Promise<WeaviateClient> {
-    return connectToWeaviateCloud(clusterURL, this.client, options);
-  },
-  client: async function (params: ClientParams): Promise<WeaviateClient> {
-    let { host: httpHost } = params.connectionParams.http;
-    let { host: grpcHost } = params.connectionParams.grpc;
-    const { port: httpPort, secure: httpSecure, path: httpPath } = params.connectionParams.http;
-    const { port: grpcPort, secure: grpcSecure } = params.connectionParams.grpc;
-    httpHost = cleanHost(httpHost, 'rest');
-    grpcHost = cleanHost(grpcHost, 'grpc');
-
-    // check if headers are set
-    if (!params.headers) params.headers = {};
-
-    const scheme = httpSecure ? 'https' : 'http';
-    const agent = httpSecure ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true });
-
-    const { connection, dbVersionProvider, dbVersionSupport } = await ConnectionGRPC.use({
-      host: `${scheme}://${httpHost}:${httpPort}${httpPath || ''}`,
-      scheme: scheme,
-      headers: params.headers,
-      grpcAddress: `${grpcHost}:${grpcPort}`,
-      grpcSecure: grpcSecure,
-      grpcProxyUrl: params.proxies?.grpc,
-      apiKey: isApiKey(params.auth) ? mapApiKey(params.auth) : undefined,
-      authClientSecret: isApiKey(params.auth) ? undefined : params.auth,
-      agent,
-      timeout: params.timeout,
-      skipInitChecks: params.skipInitChecks,
-    });
-
-    const ifc: WeaviateClient = {
-      backup: backup(connection),
-      cluster: cluster(connection),
-      collections: collections(connection, dbVersionSupport),
-      close: () => Promise.resolve(connection.close()), // hedge against future changes to add I/O to .close()
-      getMeta: () => new MetaGetter(connection).do(),
-      getOpenIDConfig: () => new OpenidConfigurationGetter(connection.http).do(),
-      getWeaviateVersion: () => dbVersionSupport.getVersion(),
-      isLive: () => new LiveChecker(connection, dbVersionProvider).do(),
-      isReady: () => new ReadyChecker(connection, dbVersionProvider).do(),
-    };
-    if (connection.oidcAuth) ifc.oidcAuth = connection.oidcAuth;
-
-    return ifc;
-  },
-
+  connectToCustom,
+  connectToLocal,
+  connectToWCD,
+  connectToWCS,
+  connectToWeaviateCloud,
+  client,
   ApiKey,
   AuthUserPasswordCredentials,
   AuthAccessTokenCredentials,


### PR DESCRIPTION
Unnest export to fully leverage IDE autoimports.

So you can just do:
```
pnpm add weaviate-client
```

And type the code you want, leveraging IDE autocomplete and autoimport, so you don't need to deal with imports manually:

<img width="570" alt="image" src="https://github.com/user-attachments/assets/052a2f58-614f-40cd-b451-e3a06ab07754">
