### PR TITLE
Refactor `roles` namespace, adding `users`, to align with new Python API

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ env:
   WEAVIATE_126: 1.26.14
   WEAVIATE_127: 1.27.11
   WEAVIATE_128: 1.28.4
-  WEAVIATE_129: 1.29.0-rc.0
+  WEAVIATE_129: 1.29.0-rc.0-a8c0bce
 
 jobs:
   checks:

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { LiveChecker, OpenidConfigurationGetter, ReadyChecker } from './misc/ind
 import weaviateV2 from './v2/index.js';
 
 import { ConsistencyLevel } from './data/replication.js';
+import users, { Users } from './users/index.js';
 
 export type ProtocolParams = {
   /**
@@ -105,6 +106,7 @@ export interface WeaviateClient {
   collections: Collections;
   oidcAuth?: OidcAuthenticator;
   roles: Roles;
+  users: Users;
 
   close: () => Promise<void>;
   getMeta: () => Promise<Meta>;
@@ -224,6 +226,7 @@ async function client(params: ClientParams): Promise<WeaviateClient> {
     cluster: cluster(connection),
     collections: collections(connection, dbVersionSupport),
     roles: roles(connection),
+    users: users(connection),
     close: () => Promise.resolve(connection.close()), // hedge against future changes to add I/O to .close()
     getMeta: () => new MetaGetter(connection).do(),
     getOpenIDConfig: () => new OpenidConfigurationGetter(connection.http).do(),

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -54,6 +54,7 @@ export type WeaviateMultiTenancyConfig = WeaviateClass['multiTenancyConfig'];
 export type WeaviateReplicationConfig = WeaviateClass['replicationConfig'];
 export type WeaviateShardingConfig = WeaviateClass['shardingConfig'];
 export type WeaviateShardStatus = definitions['ShardStatusGetResponse'];
+export type WeaviateUser = definitions['UserInfo'];
 export type WeaviateVectorIndexConfig = WeaviateClass['vectorIndexConfig'];
 export type WeaviateVectorsConfig = WeaviateClass['vectorConfig'];
 export type WeaviateVectorConfig = definitions['VectorConfig'];

--- a/src/roles/index.ts
+++ b/src/roles/index.ts
@@ -14,15 +14,72 @@ import {
 import { Map } from './util.js';
 
 export interface Roles {
+  /**
+   * Retrieve all the roles in the system.
+   *
+   * @returns {Promise<Record<string, Role>>} A map of role names to their respective roles.
+   */
   listAll: () => Promise<Record<string, Role>>;
+  /**
+   * Retrieve a role by its name.
+   *
+   * @param {string} roleName The name of the role to retrieve.
+   * @returns {Promise<Role | null>} The role if it exists, or null if it does not.
+   */
   byName: (roleName: string) => Promise<Role | null>;
+  /**
+   * Retrieve the user IDs assigned to a role.
+   *
+   * @param {string} roleName The name of the role to retrieve the assigned user IDs for.
+   * @returns {Promise<string[]>} The user IDs assigned to the role.
+   */
   assignedUserIds: (roleName: string) => Promise<string[]>;
+  /**
+   * Delete a role by its name.
+   *
+   * @param {string} roleName The name of the role to delete.
+   * @returns {Promise<void>} A promise that resolves when the role is deleted.
+   */
   delete: (roleName: string) => Promise<void>;
+  /**
+   * Create a new role.
+   *
+   * @param {string} roleName The name of the new role.
+   * @param {PermissionsInput} permissions The permissions to assign to the new role.
+   * @returns {Promise<Role>} The newly created role.
+   */
   create: (roleName: string, permissions: PermissionsInput) => Promise<Role>;
+  /**
+   * Check if a role exists.
+   *
+   * @param {string} roleName The name of the role to check for.
+   * @returns {Promise<boolean>} A promise that resolves to true if the role exists, or false if it does not.
+   */
   exists: (roleName: string) => Promise<boolean>;
+  /**
+   * Add permissions to a role.
+   *
+   * @param {string} roleName The name of the role to add permissions to.
+   * @param {PermissionsInput} permissions The permissions to add.
+   * @returns {Promise<void>} A promise that resolves when the permissions are added.
+   */
   addPermissions: (roleName: string, permissions: PermissionsInput) => Promise<void>;
+  /**
+   * Remove permissions from a role.
+   *
+   * @param {string} roleName The name of the role to remove permissions from.
+   * @param {PermissionsInput} permissions The permissions to remove.
+   * @returns {Promise<void>} A promise that resolves when the permissions are removed.
+   */
   removePermissions: (roleName: string, permissions: PermissionsInput) => Promise<void>;
-  hasPermissions: (roleName: string, permission: Permission) => Promise<boolean>;
+  /**
+   * Check if a role has the specified permissions.
+   *
+   * @param {string} roleName The name of the role to check.
+   * @param {Permission | Permission[]} permission The permission or permissions to check for.
+   * @returns {Promise<boolean>} A promise that resolves to true if the role has the permissions, or false if it does not.
+   */
+  hasPermissions: (roleName: string, permission: Permission | Permission[]) => Promise<boolean>;
 }
 
 const roles = (connection: ConnectionREST): Roles => {

--- a/src/roles/types.ts
+++ b/src/roles/types.ts
@@ -19,32 +19,32 @@ export type RolesAction = Extract<Action, 'manage_roles' | 'read_roles'>;
 
 export type BackupsPermission = {
   collection: string;
-  action: BackupsAction;
+  actions: BackupsAction[];
 };
 
 export type ClusterPermission = {
-  action: ClusterAction;
+  actions: ClusterAction[];
 };
 
 export type CollectionsPermission = {
   collection: string;
-  action: CollectionsAction;
+  actions: CollectionsAction[];
 };
 
 export type DataPermission = {
   collection: string;
-  action: DataAction;
+  actions: DataAction[];
 };
 
 export type NodesPermission = {
   collection: string;
   verbosity: 'verbose' | 'minimal';
-  action: NodesAction;
+  actions: NodesAction[];
 };
 
 export type RolesPermission = {
   role: string;
-  action: RolesAction;
+  actions: RolesAction[];
 };
 
 export type Role = {
@@ -55,10 +55,6 @@ export type Role = {
   dataPermissions: DataPermission[];
   nodesPermissions: NodesPermission[];
   rolesPermissions: RolesPermission[];
-};
-
-export type User = {
-  name: string;
 };
 
 export type Permission =

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -1,4 +1,5 @@
-import { Permission as WeaviatePermission, Role as WeaviateRole } from '../openapi/types.js';
+import { Permission as WeaviatePermission, Role as WeaviateRole, WeaviateUser } from '../openapi/types.js';
+import { User } from '../users/types.js';
 import {
   BackupsAction,
   BackupsPermission,
@@ -14,30 +15,37 @@ import {
   Role,
   RolesAction,
   RolesPermission,
-  User,
 } from './types.js';
 
 export class PermissionGuards {
+  private static includes = (permission: Permission, ...actions: string[]): boolean =>
+    actions.filter((a) => Array.from<string>(permission.actions).includes(a)).length > 0;
   static isBackups = (permission: Permission): permission is BackupsPermission =>
-    (permission as BackupsPermission).action === 'manage_backups';
+    PermissionGuards.includes(permission, 'manage_backups');
   static isCluster = (permission: Permission): permission is ClusterPermission =>
-    (permission as ClusterPermission).action === 'read_cluster';
+    PermissionGuards.includes(permission, 'read_cluster');
   static isCollections = (permission: Permission): permission is CollectionsPermission =>
-    [
+    PermissionGuards.includes(
+      permission,
       'create_collections',
       'delete_collections',
       'read_collections',
       'update_collections',
-      'manage_collections',
-    ].includes((permission as CollectionsPermission).action);
+      'manage_collections'
+    );
   static isData = (permission: Permission): permission is DataPermission =>
-    ['create_data', 'delete_data', 'read_data', 'update_data', 'manage_data'].includes(
-      (permission as DataPermission).action
+    PermissionGuards.includes(
+      permission,
+      'create_data',
+      'delete_data',
+      'read_data',
+      'update_data',
+      'manage_data'
     );
   static isNodes = (permission: Permission): permission is NodesPermission =>
-    (permission as NodesPermission).action === 'read_nodes';
+    PermissionGuards.includes(permission, 'read_nodes');
   static isRoles = (permission: Permission): permission is RolesPermission =>
-    (permission as RolesPermission).action === 'manage_roles';
+    PermissionGuards.includes(permission, 'manage_roles');
   static isPermission = (permissions: PermissionsInput): permissions is Permission =>
     !Array.isArray(permissions);
   static isPermissionArray = (permissions: PermissionsInput): permissions is Permission[] =>
@@ -56,89 +64,87 @@ export class Map {
   static flattenPermissions = (permissions: PermissionsInput): Permission[] =>
     !Array.isArray(permissions) ? [permissions] : permissions.flat(2);
 
-  static permissionToWeaviate = (permission: Permission): WeaviatePermission => {
+  static permissionToWeaviate = (permission: Permission): WeaviatePermission[] => {
     if (PermissionGuards.isBackups(permission)) {
-      return { backups: { collection: permission.collection }, action: permission.action };
+      return Array.from(permission.actions).map((action) => ({
+        backups: { collection: permission.collection },
+        action,
+      }));
     } else if (PermissionGuards.isCluster(permission)) {
-      return { action: permission.action };
+      return Array.from(permission.actions).map((action) => ({ action }));
     } else if (PermissionGuards.isCollections(permission)) {
-      return { collections: { collection: permission.collection }, action: permission.action };
+      return Array.from(permission.actions).map((action) => ({
+        collections: { collection: permission.collection },
+        action,
+      }));
     } else if (PermissionGuards.isData(permission)) {
-      return { data: { collection: permission.collection }, action: permission.action };
+      return Array.from(permission.actions).map((action) => ({
+        data: { collection: permission.collection },
+        action,
+      }));
     } else if (PermissionGuards.isNodes(permission)) {
-      return {
+      return Array.from(permission.actions).map((action) => ({
         nodes: { collection: permission.collection, verbosity: permission.verbosity },
-        action: permission.action,
-      };
+        action,
+      }));
     } else if (PermissionGuards.isRoles(permission)) {
-      return { roles: { role: permission.role }, action: permission.action };
+      return Array.from(permission.actions).map((action) => ({ roles: { role: permission.role }, action }));
     } else {
       throw new Error(`Unknown permission type: ${permission}`);
     }
   };
 
   static roleFromWeaviate = (role: WeaviateRole): Role => {
-    const out: Role = {
-      name: role.name,
-      backupsPermissions: [],
-      clusterPermissions: [],
-      collectionsPermissions: [],
-      dataPermissions: [],
-      nodesPermissions: [],
-      rolesPermissions: [],
+    const perms = {
+      backups: {} as Record<string, BackupsPermission>,
+      cluster: {} as Record<string, ClusterPermission>,
+      collections: {} as Record<string, CollectionsPermission>,
+      data: {} as Record<string, DataPermission>,
+      nodes: {} as Record<string, NodesPermission>,
+      roles: {} as Record<string, RolesPermission>,
     };
     role.permissions.forEach((permission) => {
       if (permission.backups !== undefined) {
-        if (permission.backups.collection === undefined) {
-          throw new Error('Backups permission missing collection');
-        }
-        out.backupsPermissions.push({
-          collection: permission.backups?.collection,
-          action: permission.action as BackupsAction,
-        });
+        const key = permission.backups.collection;
+        if (key === undefined) throw new Error('Backups permission missing collection');
+        if (perms.backups[key] === undefined) perms.backups[key] = { collection: key, actions: [] };
+        perms.backups[key].actions.push(permission.action as BackupsAction);
       } else if (permission.action === 'read_cluster') {
-        out.clusterPermissions.push({
-          action: permission.action,
-        });
+        if (perms.cluster[''] === undefined) perms.cluster[''] = { actions: [] };
+        perms.cluster[''].actions.push('read_cluster');
       } else if (permission.collections !== undefined) {
-        if (permission.collections.collection === undefined) {
-          throw new Error('Collections permission missing collection');
-        }
-        out.collectionsPermissions.push({
-          collection: permission.collections.collection,
-          action: permission.action as CollectionsAction,
-        });
+        const key = permission.collections.collection;
+        if (key === undefined) throw new Error('Collections permission missing collection');
+        if (perms.collections[key] === undefined) perms.collections[key] = { collection: key, actions: [] };
+        perms.collections[key].actions.push(permission.action as CollectionsAction);
       } else if (permission.data !== undefined) {
-        if (permission.data.collection === undefined) {
-          throw new Error('Data permission missing collection');
-        }
-        out.dataPermissions.push({
-          collection: permission.data.collection,
-          action: permission.action as DataAction,
-        });
+        const key = permission.data.collection;
+        if (key === undefined) throw new Error('Data permission missing collection');
+        if (perms.data[key] === undefined) perms.data[key] = { collection: key, actions: [] };
+        perms.data[key].actions.push(permission.action as DataAction);
       } else if (permission.nodes !== undefined) {
-        if (permission.nodes.collection === undefined) {
-          throw new Error('Nodes permission missing collection');
-        }
-        if (permission.nodes.verbosity === undefined) {
-          throw new Error('Nodes permission missing verbosity');
-        }
-        out.nodesPermissions.push({
-          collection: permission.nodes.collection,
-          verbosity: permission.nodes.verbosity,
-          action: permission.action as NodesAction,
-        });
+        const { collection, verbosity } = permission.nodes;
+        if (collection === undefined) throw new Error('Nodes permission missing collection');
+        if (verbosity === undefined) throw new Error('Nodes permission missing verbosity');
+        const key = `${collection}#${verbosity}`;
+        if (perms.nodes[key] === undefined) perms.nodes[key] = { collection, verbosity, actions: [] };
+        perms.nodes[key].actions.push(permission.action as NodesAction);
       } else if (permission.roles !== undefined) {
-        if (permission.roles.role === undefined) {
-          throw new Error('Roles permission missing role');
-        }
-        out.rolesPermissions.push({
-          role: permission.roles.role,
-          action: permission.action as RolesAction,
-        });
+        const key = permission.roles.role;
+        if (key === undefined) throw new Error('Roles permission missing role');
+        if (perms.roles[key] === undefined) perms.roles[key] = { role: key, actions: [] };
+        perms.roles[key].actions.push(permission.action as RolesAction);
       }
     });
-    return out;
+    return {
+      name: role.name,
+      backupsPermissions: Object.values(perms.backups),
+      clusterPermissions: Object.values(perms.cluster),
+      collectionsPermissions: Object.values(perms.collections),
+      dataPermissions: Object.values(perms.data),
+      nodesPermissions: Object.values(perms.nodes),
+      rolesPermissions: Object.values(perms.roles),
+    };
   };
 
   static roles = (roles: WeaviateRole[]): Record<string, Role> =>
@@ -149,7 +155,11 @@ export class Map {
 
   static users = (users: string[]): Record<string, User> =>
     users.reduce((acc, user) => {
-      acc[user] = { name: user };
+      acc[user] = { id: user };
       return acc;
     }, {} as Record<string, User>);
+  static user = (user: WeaviateUser): User => ({
+    id: user.username,
+    roles: user.roles?.map(Map.roleFromWeaviate),
+  });
 }

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -5,9 +5,34 @@ import { Map } from '../roles/util.js';
 import { User } from './types.js';
 
 export interface Users {
+  /**
+   * Retrieve the information relevant to the currently authenticated user.
+   *
+   * @returns {Promise<User>} The user information.
+   */
   getMyUser: () => Promise<User>;
+  /**
+   * Retrieve the roles assigned to a user.
+   *
+   * @param {string} userId The ID of the user to retrieve the assigned roles for.
+   * @returns {Promise<Record<string, Role>>} A map of role names to their respective roles.
+   */
   getAssignedRoles: (userId: string) => Promise<Record<string, Role>>;
+  /**
+   * Assign roles to a user.
+   *
+   * @param {string | string[]} roleNames The name or names of the roles to assign.
+   * @param {string} userId The ID of the user to assign the roles to.
+   * @returns {Promise<void>} A promise that resolves when the roles are assigned.
+   */
   assignRoles: (roleNames: string | string[], userId: string) => Promise<void>;
+  /**
+   * Revoke roles from a user.
+   *
+   * @param {string | string[]} roleNames The name or names of the roles to revoke.
+   * @param {string} userId The ID of the user to revoke the roles from.
+   * @returns {Promise<void>} A promise that resolves when the roles are revoked.
+   */
   revokeRoles: (roleNames: string | string[], userId: string) => Promise<void>;
 }
 

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,0 +1,30 @@
+import { ConnectionREST } from '../index.js';
+import { Role as WeaviateRole, WeaviateUser } from '../openapi/types.js';
+import { Role } from '../roles/types.js';
+import { Map } from '../roles/util.js';
+import { User } from './types.js';
+
+export interface Users {
+  getMyUser: () => Promise<User>;
+  getAssignedRoles: (userId: string) => Promise<Record<string, Role>>;
+  assignRoles: (roleNames: string | string[], userId: string) => Promise<void>;
+  revokeRoles: (roleNames: string | string[], userId: string) => Promise<void>;
+}
+
+const users = (connection: ConnectionREST): Users => {
+  return {
+    getMyUser: () => connection.get<WeaviateUser>('/users/own-info').then(Map.user),
+    getAssignedRoles: (userId: string) =>
+      connection.get<WeaviateRole[]>(`/authz/users/${userId}/roles`).then(Map.roles),
+    assignRoles: (roleNames: string | string[], userId: string) =>
+      connection.postEmpty(`/authz/users/${userId}/assign`, {
+        roles: Array.isArray(roleNames) ? roleNames : [roleNames],
+      }),
+    revokeRoles: (roleNames: string | string[], userId: string) =>
+      connection.postEmpty(`/authz/users/${userId}/revoke`, {
+        roles: Array.isArray(roleNames) ? roleNames : [roleNames],
+      }),
+  };
+};
+
+export default users;

--- a/src/users/integration.test.ts
+++ b/src/users/integration.test.ts
@@ -1,0 +1,63 @@
+import weaviate, { ApiKey } from '..';
+import { DbVersion } from '../utils/dbVersion';
+
+const only = DbVersion.fromString(`v${process.env.WEAVIATE_VERSION!}`).isAtLeast(1, 29, 0)
+  ? describe
+  : describe.skip;
+
+only('Integration testing of the users namespace', () => {
+  const makeClient = (key: string) =>
+    weaviate.connectToLocal({
+      port: 8091,
+      grpcPort: 50062,
+      authCredentials: new ApiKey(key),
+    });
+
+  beforeAll(() =>
+    makeClient('admin-key').then((c) =>
+      c.roles.create('test', weaviate.permissions.data({ collection: 'Thing', read: true }))
+    )
+  );
+
+  it('should be able to retrieve own admin user with root roles', async () => {
+    const user = await makeClient('admin-key').then((client) => client.users.getMyUser());
+    expect(user.id).toBe('admin-user'); // defined in the compose file in the ci/ dir
+    expect(user.roles).toBeDefined();
+  });
+
+  it('should be able to retrieve own custom user with no roles', async () => {
+    const user = await makeClient('custom-key').then((client) => client.users.getMyUser());
+    expect(user.id).toBe('custom-user'); // defined in the compose file in the ci/ dir
+    expect(user.roles).toBeUndefined();
+  });
+
+  it('should be able to retrieve the assigned roles of a user', async () => {
+    const roles = await makeClient('admin-key').then((client) => client.users.getAssignedRoles('admin-user'));
+    expect(roles.root).toBeDefined();
+    expect(roles.root.backupsPermissions.length).toBeGreaterThan(0);
+    expect(roles.root.clusterPermissions.length).toBeGreaterThan(0);
+    expect(roles.root.collectionsPermissions.length).toBeGreaterThan(0);
+    expect(roles.root.dataPermissions.length).toBeGreaterThan(0);
+    expect(roles.root.nodesPermissions.length).toBeGreaterThan(0);
+    expect(roles.root.rolesPermissions.length).toBeGreaterThan(0);
+  });
+
+  it('should be able to assign a role to a user', async () => {
+    const adminClient = await makeClient('admin-key');
+    await adminClient.users.assignRoles('test', 'custom-user');
+
+    const roles = await adminClient.users.getAssignedRoles('custom-user');
+    expect(roles.test).toBeDefined();
+    expect(roles.test.dataPermissions.length).toEqual(1);
+  });
+
+  it('should be able to revoke a role from a user', async () => {
+    const adminClient = await makeClient('admin-key');
+    await adminClient.users.revokeRoles('test', 'custom-user');
+
+    const roles = await adminClient.users.getAssignedRoles('custom-user');
+    expect(roles.test).toBeUndefined();
+  });
+
+  afterAll(() => makeClient('admin-key').then((c) => c.roles.delete('test')));
+});

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -1,0 +1,6 @@
+import { Role } from '../roles/types.js';
+
+export type User = {
+  id: string;
+  roles?: Role[];
+};


### PR DESCRIPTION
- Split `roles` with `users`
- make `actions` an array inside `permissions`
- rename several methods to be aligned with py client in a non-BC way
- only run roles/users tests for `>1.29` due to no BC