### PR TITLE
feat(v1.30.1): retrieve users' last login time and preview API keys

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,7 +125,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-      - run: npm publish --tag alpha
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
       - run: npm run docs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ env:
   WEAVIATE_127: 1.27.15
   WEAVIATE_128: 1.28.11
   WEAVIATE_129: 1.29.1
-  WEAVIATE_130: 1.30.0
+  WEAVIATE_130: 1.30.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,7 +125,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
       - run: npm run docs

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -29,6 +29,9 @@ import {
   UsersPermission,
 } from './types.js';
 
+/** ZERO_TIME is the timestamp Weaviate server sends in abscence of a value (null value). */
+const ZERO_TIME = '0001-01-01T00:00:00.000Z';
+
 export class PermissionGuards {
   private static includes = <A extends string>(permission: Permission, ...actions: A[]): boolean =>
     actions.filter((a) => Array.from<string>(permission.actions).includes(a)).length > 0;
@@ -157,6 +160,7 @@ export class Map {
     active: user.active,
     createdAt: Map.unknownDate(user.createdAt),
     lastUsedAt: Map.unknownDate(user.lastUsedAt),
+    apiKeyFirstLetters: user.apiKeyFirstLetters as string,
   });
   static dbUsers = (users: WeaviateDBUser[]): UserDB[] => users.map(Map.dbUser);
   static assignedUsers = (users: WeaviateAssignedUser[]): UserAssignment[] =>
@@ -164,9 +168,8 @@ export class Map {
       id: user.userId || '',
       userType: user.userType,
     }));
-  static unknownDate = (date?: unknown): Date | undefined => (
-    date !== undefined && typeof date === "string"
-      ? new Date(date) : undefined);
+  static unknownDate = (date?: unknown): Date | undefined =>
+    date !== undefined && typeof date === 'string' && date !== ZERO_TIME ? new Date(date) : undefined;
 }
 
 class PermissionsMapping {

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -155,6 +155,8 @@ export class Map {
     id: user.userId,
     roleNames: user.roles,
     active: user.active,
+    createdAt: Map.unknownDate(user.createdAt),
+    lastUsedAt: Map.unknownDate(user.lastUsedAt),
   });
   static dbUsers = (users: WeaviateDBUser[]): UserDB[] => users.map(Map.dbUser);
   static assignedUsers = (users: WeaviateAssignedUser[]): UserAssignment[] =>
@@ -162,6 +164,9 @@ export class Map {
       id: user.userId || '',
       userType: user.userType,
     }));
+  static unknownDate = (date?: unknown): Date | undefined => (
+    date !== undefined && typeof date === "string"
+      ? new Date(date) : undefined);
 }
 
 class PermissionsMapping {

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -8,7 +8,14 @@ import {
 } from '../openapi/types.js';
 import { Role } from '../roles/types.js';
 import { Map } from '../roles/util.js';
-import { AssignRevokeOptions, DeactivateOptions, GetAssignedRolesOptions, GetUserOptions, User, UserDB } from './types.js';
+import {
+  AssignRevokeOptions,
+  DeactivateOptions,
+  GetAssignedRolesOptions,
+  GetUserOptions,
+  User,
+  UserDB,
+} from './types.js';
 
 /**
  * Operations supported for 'db', 'oidc', and legacy (non-namespaced) users.
@@ -195,8 +202,17 @@ const db = (connection: ConnectionREST): DBUsers => {
         .postEmpty<DeactivateOptions | null>(`/users/db/${userId}/deactivate`, opts || null)
         .then(() => true)
         .catch(expectCode(409)),
-    byName: (userId: string, opts?: GetUserOptions) => connection.get<WeaviateDBUser>(`/users/db/${userId}?includeLastUsedTime=${opts?.includeLastUsedTime || false}`, true).then(Map.dbUser),
-    listAll: (opts?: GetUserOptions) => connection.get<WeaviateDBUser[]>(`/users/db?includeLastUsedTime=${opts?.includeLastUsedTime || false}`, true).then(Map.dbUsers),
+    byName: (userId: string, opts?: GetUserOptions) =>
+      connection
+        .get<WeaviateDBUser>(
+          `/users/db/${userId}?includeLastUsedTime=${opts?.includeLastUsedTime || false}`,
+          true
+        )
+        .then(Map.dbUser),
+    listAll: (opts?: GetUserOptions) =>
+      connection
+        .get<WeaviateDBUser[]>(`/users/db?includeLastUsedTime=${opts?.includeLastUsedTime || false}`, true)
+        .then(Map.dbUsers),
   };
 };
 

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -11,6 +11,10 @@ export type UserDB = {
   id: string;
   roleNames: string[];
   active: boolean;
+
+  createdAt?: Date;
+  lastUsedAt?: Date;
+  apiKeyFirstLetters?: string;
 };
 
 /** Optional arguments to /user/{type}/{username} enpoint. */
@@ -23,3 +27,6 @@ export type AssignRevokeOptions = { userType?: WeaviateUserTypeInternal };
 
 /** Optional arguments to /deactivate endpoint. */
 export type DeactivateOptions = { revokeKey?: boolean };
+
+/** Optional arguments to /users and /users/<id> endpoints. */
+export type GetUserOptions = { includeLastUsedTime?: boolean };


### PR DESCRIPTION
### What is changed?
This PR adds optional `includeLastUsedTime` parameter to `users.db.byName` and `users.db.listAll` methods, which controls if the last login time will be retrieved for the users.

Additionally, `UserDB` model has 2 new fields:
- `createdAt`: returned for all users (provided server is `v1.30.1` and above)
- `apiKeyFirstLetters`: returned whenever request is made by the cluster admin (intended to be displayed in the WCS Console)

Updated `openapi.ts` schema spec.

### TODO
- [x] Run tests with `v1.30.1`