### PR TITLE
fix(ci): npm login before attempting to publish

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,6 +125,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
+      - run: npm login
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
Recent `publish` jobs are failing with this a [404 error]( https://github.com/weaviate/typescript-client/actions/runs/14858676368/job/41720415632#step:6:1475). Commonly recommended [solution](https://stackoverflow.com/questions/39115101/getting-404-when-attempting-to-publish-new-package-to-npm) is to `npm login` first. 