### PR TITLE
fix: revert npm login

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,7 +125,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-      - run: npm login
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weaviate-client",
-  "version": "3.5.4",
+  "version": "3.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weaviate-client",
-      "version": "3.5.4",
+      "version": "3.5.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "abort-controller-x": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weaviate-client",
-  "version": "3.5.4",
+  "version": "3.5.3",
   "description": "JS/TS client for Weaviate",
   "main": "dist/node/cjs/index.js",
   "type": "module",


### PR DESCRIPTION
`npm login` is an interactive command, it should not be part of the CI script.

Rolling back package version to 3.5.3, we'll bump the version on the next release attempt.