### PR TITLE
Support adding named vectors to a collection

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,7 @@ env:
   WEAVIATE_128: 1.28.11
   WEAVIATE_129: 1.29.1
   WEAVIATE_130: 1.30.1
+  WEAVIATE_131: 1.31.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/collections/config/index.ts
+++ b/src/collections/config/index.ts
@@ -40,7 +40,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveProperty<any>(property, []))
         .do()
-        .then(() => { }),
+        .then(() => {}),
     addReference: (
       reference: ReferenceSingleTargetConfigCreate<any> | ReferenceMultiTargetConfigCreate<any>
     ) =>
@@ -48,7 +48,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveReference<any>(reference))
         .do()
-        .then(() => { }),
+        .then(() => {}),
     addVector: async (vectors: VectorizersConfigAdd<T>) => {
       const supportsDynamicVectorIndex = await dbVersionSupport.supportsDynamicVectorIndex();
       const { vectorsConfig } = makeVectorsConfig(vectors, supportsDynamicVectorIndex);
@@ -72,7 +72,7 @@ const config = <T>(
         })
       );
     },
-    updateShards: async function(status: 'READY' | 'READONLY', names?: string | string[]) {
+    updateShards: async function (status: 'READY' | 'READONLY', names?: string | string[]) {
       let shardNames: string[];
       if (names === undefined) {
         shardNames = await this.getShards().then((shards) => shards.map((s) => s.name));
@@ -97,7 +97,7 @@ const config = <T>(
           )
         )
         .then((merged) => new ClassUpdater(connection).withClass(merged).do())
-        .then(() => { });
+        .then(() => {});
     },
   };
 };
@@ -122,15 +122,15 @@ export interface Config<T> {
     reference: ReferenceSingleTargetConfigCreate<T> | ReferenceMultiTargetConfigCreate<T>
   ) => Promise<void>;
   /**
-    * Add one or more named vectors to the collection in Weaviate.
-    * Named vectors can be added to collections with existing named vectors only.
-    *
-    * Existing named vectors are immutable in Weaviate. The client will not include
-  * any of those in the request.
-    *
-    * @param {VectorizersConfigAdd<any>} vectors Vector configurations.
-    * @returns {Promise<void>} A promise that resolves when the named vector has been created.
-    */
+   * Add one or more named vectors to the collection in Weaviate.
+   * Named vectors can be added to collections with existing named vectors only.
+   *
+   * Existing named vectors are immutable in Weaviate. The client will not include
+   * any of those in the request.
+   *
+   * @param {VectorizersConfigAdd<any>} vectors Vector configurations.
+   * @returns {Promise<void>} A promise that resolves when the named vector has been created.
+   */
   addVector: (vectors: VectorizersConfigAdd<T>) => Promise<void>;
   /**
    * Get the configuration for this collection from Weaviate.

--- a/src/collections/config/index.ts
+++ b/src/collections/config/index.ts
@@ -40,7 +40,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveProperty<any>(property, []))
         .do()
-        .then(() => {}),
+        .then(() => { }),
     addReference: (
       reference: ReferenceSingleTargetConfigCreate<any> | ReferenceMultiTargetConfigCreate<any>
     ) =>
@@ -48,7 +48,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveReference<any>(reference))
         .do()
-        .then(() => {}),
+        .then(() => { }),
     addVector: async (vectors: VectorizersConfigAdd<T>) => {
       const supportsDynamicVectorIndex = await dbVersionSupport.supportsDynamicVectorIndex();
       const { vectorsConfig } = makeVectorsConfig(vectors, supportsDynamicVectorIndex);
@@ -72,7 +72,7 @@ const config = <T>(
         })
       );
     },
-    updateShards: async function (status: 'READY' | 'READONLY', names?: string | string[]) {
+    updateShards: async function(status: 'READY' | 'READONLY', names?: string | string[]) {
       let shardNames: string[];
       if (names === undefined) {
         shardNames = await this.getShards().then((shards) => shards.map((s) => s.name));
@@ -97,7 +97,7 @@ const config = <T>(
           )
         )
         .then((merged) => new ClassUpdater(connection).withClass(merged).do())
-        .then(() => {});
+        .then(() => { });
     },
   };
 };
@@ -121,6 +121,16 @@ export interface Config<T> {
   addReference: (
     reference: ReferenceSingleTargetConfigCreate<T> | ReferenceMultiTargetConfigCreate<T>
   ) => Promise<void>;
+  /**
+    * Add one or more named vectors to the collection in Weaviate.
+    * Named vectors can be added to collections with existing named vectors only.
+    *
+    * Existing named vectors are immutable in Weaviate. The client will not include
+  * any of those in the request.
+    *
+    * @param {VectorizersConfigAdd<any>} vectors Vector configurations.
+    * @returns {Promise<void>} A promise that resolves when the named vector has been created.
+    */
   addVector: (vectors: VectorizersConfigAdd<T>) => Promise<void>;
   /**
    * Get the configuration for this collection from Weaviate.

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -386,6 +386,27 @@ describe('Testing of the collection.config namespace', () => {
     ]);
   });
 
+  it('should be able to add a reference to a collection', async () => {
+    const collectionName = 'TestCollectionConfigAddVector' as const;
+    const collection = await client.collections.create({
+      name: collectionName,
+      vectorizers: [weaviate.configure.vectorizer.none({ name: 'original' })],
+    });
+    // Add a single named vector
+    await collection.config.addVector(weaviate.configure.vectorizer.none({ name: 'vector-a' }));
+
+    // Add several named vectors
+    await collection.config.addVector([
+      weaviate.configure.vectorizer.none({ name: 'vector-b' }),
+      weaviate.configure.vectorizer.none({ name: 'vector-c' }),
+    ]);
+
+    const config = await collection.config.get();
+    expect(config.vectorizers).toHaveProperty('vector-a');
+    expect(config.vectorizers).toHaveProperty('vector-b');
+    expect(config.vectorizers).toHaveProperty('vector-c');
+  });
+
   it('should get the shards of a sharded collection', async () => {
     const shards = await client.collections
       .create({

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -403,10 +403,18 @@ describe('Testing of the collection.config namespace', () => {
         weaviate.configure.vectorizer.none({ name: 'vector-c' }),
       ]);
 
+      // Trying to update 'original' vector -- should be omitted from request.
+      await collection.config.addVector(weaviate.configure.vectorizer.none({
+        name: 'original',
+        vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
+      }));
+
       const config = await collection.config.get();
       expect(config.vectorizers).toHaveProperty('vector-a');
       expect(config.vectorizers).toHaveProperty('vector-b');
       expect(config.vectorizers).toHaveProperty('vector-c');
+
+      expect(config.vectorizers['original']).toHaveProperty('indexType', 'hnsw');
     });
   });
 

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -396,7 +396,7 @@ describe('Testing of the collection.config namespace', () => {
       const collectionName = 'TestCollectionConfigAddVector' as const;
       const collection = await client.collections.create({
         name: collectionName,
-        vectorizers: [weaviate.configure.vectorizer.none({ name: 'original' })],
+        vectorizers: weaviate.configure.vectorizer.none(),
       });
       // Add a single named vector
       await collection.config.addVector(weaviate.configure.vectorizer.none({ name: 'vector-a' }));
@@ -407,10 +407,10 @@ describe('Testing of the collection.config namespace', () => {
         weaviate.configure.vectorizer.none({ name: 'vector-c' }),
       ]);
 
-      // Trying to update 'original' vector -- should be omitted from request.
+      // Trying to update 'default' vector -- should be omitted from request.
       await collection.config.addVector(
         weaviate.configure.vectorizer.none({
-          name: 'original',
+          name: 'default',
           vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
         })
       );
@@ -420,7 +420,7 @@ describe('Testing of the collection.config namespace', () => {
       expect(config.vectorizers).toHaveProperty('vector-b');
       expect(config.vectorizers).toHaveProperty('vector-c');
 
-      expect(config.vectorizers.original).toHaveProperty('indexType', 'hnsw');
+      expect(config.vectorizers['default']).toHaveProperty('indexType', 'hnsw');
     });
   });
 

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -387,7 +387,11 @@ describe('Testing of the collection.config namespace', () => {
     ]);
   });
 
-  requireAtLeast(1, 31, 0)('Mutable named vectors', () => {
+  requireAtLeast(
+    1,
+    31,
+    0
+  )('Mutable named vectors', () => {
     it('should be able to add named vectors to a collection', async () => {
       const collectionName = 'TestCollectionConfigAddVector' as const;
       const collection = await client.collections.create({
@@ -404,17 +408,19 @@ describe('Testing of the collection.config namespace', () => {
       ]);
 
       // Trying to update 'original' vector -- should be omitted from request.
-      await collection.config.addVector(weaviate.configure.vectorizer.none({
-        name: 'original',
-        vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
-      }));
+      await collection.config.addVector(
+        weaviate.configure.vectorizer.none({
+          name: 'original',
+          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
+        })
+      );
 
       const config = await collection.config.get();
       expect(config.vectorizers).toHaveProperty('vector-a');
       expect(config.vectorizers).toHaveProperty('vector-b');
       expect(config.vectorizers).toHaveProperty('vector-c');
 
-      expect(config.vectorizers['original']).toHaveProperty('indexType', 'hnsw');
+      expect(config.vectorizers.original).toHaveProperty('indexType', 'hnsw');
     });
   });
 

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -420,7 +420,7 @@ describe('Testing of the collection.config namespace', () => {
       expect(config.vectorizers).toHaveProperty('vector-b');
       expect(config.vectorizers).toHaveProperty('vector-c');
 
-      expect(config.vectorizers['default']).toHaveProperty('indexType', 'hnsw');
+      expect(config.vectorizers.default).toHaveProperty('indexType', 'hnsw');
     });
   });
 

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -1,5 +1,10 @@
-import { WeaviateDeserializationError } from '../../errors.js';
 import {
+  WeaviateDeserializationError,
+  WeaviateInvalidInputError,
+  WeaviateUnsupportedFeatureError,
+} from '../../errors.js';
+import {
+  Properties,
   WeaviateBM25Config,
   WeaviateClass,
   WeaviateInvertedIndexConfig,
@@ -13,11 +18,19 @@ import {
   WeaviateVectorIndexConfig,
   WeaviateVectorsConfig,
 } from '../../openapi/types.js';
+import { DbVersionSupport } from '../../utils/dbVersion.js';
+import { QuantizerGuards } from '../configure/parsing.js';
 import {
   PropertyConfigCreate,
   ReferenceConfigCreate,
   ReferenceMultiTargetConfigCreate,
   ReferenceSingleTargetConfigCreate,
+  VectorIndexConfigCreate,
+  VectorIndexConfigDynamicCreate,
+  VectorIndexConfigFlatCreate,
+  VectorIndexConfigHNSWCreate,
+  VectorizersConfigAdd,
+  VectorizersConfigCreate,
 } from '../configure/types/index.js';
 import {
   BQConfig,
@@ -46,6 +59,7 @@ import {
   VectorIndexConfigHNSW,
   VectorIndexConfigType,
   VectorIndexFilterStrategy,
+  VectorIndexType,
   VectorizerConfig,
 } from './types/index.js';
 
@@ -121,6 +135,91 @@ export const classToCollection = <T>(cls: WeaviateClass): CollectionConfig => {
     sharding: ConfigMapping.sharding(cls.shardingConfig),
     vectorizers: ConfigMapping.vectorizer(cls),
   };
+};
+
+export const parseVectorIndex = (module: ModuleConfig<VectorIndexType, VectorIndexConfigCreate>): any => {
+  if (module.config === undefined) return undefined;
+  if (module.name === 'dynamic') {
+    const { hnsw, flat, ...conf } = module.config as VectorIndexConfigDynamicCreate;
+    return {
+      ...conf,
+      hnsw: parseVectorIndex({ name: 'hnsw', config: hnsw }),
+      flat: parseVectorIndex({ name: 'flat', config: flat }),
+    };
+  }
+  const { quantizer, ...conf } = module.config as
+    | VectorIndexConfigFlatCreate
+    | VectorIndexConfigHNSWCreate
+    | Record<string, any>;
+  if (quantizer === undefined) return conf;
+  if (QuantizerGuards.isBQCreate(quantizer)) {
+    const { type, ...quant } = quantizer;
+    return {
+      ...conf,
+      bq: {
+        ...quant,
+        enabled: true,
+      },
+    };
+  }
+  if (QuantizerGuards.isPQCreate(quantizer)) {
+    const { type, ...quant } = quantizer;
+    return {
+      ...conf,
+      pq: {
+        ...quant,
+        enabled: true,
+      },
+    };
+  }
+};
+
+export const parseVectorizerConfig = (config?: VectorizerConfig): any => {
+  if (config === undefined) return {};
+  const { vectorizeCollectionName, ...rest } = config as any;
+  return {
+    ...rest,
+    vectorizeClassName: vectorizeCollectionName,
+  };
+};
+
+export const makeVectorsConfig = <TProperties extends Properties | undefined = undefined>(
+  configVectorizers: VectorizersConfigCreate<TProperties> | VectorizersConfigAdd<TProperties>,
+  supportsDynamicVectorIndex: Awaited<ReturnType<DbVersionSupport['supportsDynamicVectorIndex']>>
+) => {
+  let vectorizers: string[] = [];
+  const vectorsConfig: Record<string, any> = {};
+  const vectorizersConfig = Array.isArray(configVectorizers)
+    ? configVectorizers
+    : [
+        {
+          ...configVectorizers,
+          name: configVectorizers.name || 'default',
+        },
+      ];
+  vectorizersConfig.forEach((v) => {
+    if (v.vectorIndex.name === 'dynamic' && !supportsDynamicVectorIndex.supports) {
+      throw new WeaviateUnsupportedFeatureError(supportsDynamicVectorIndex.message);
+    }
+    const vectorConfig: any = {
+      vectorIndexConfig: parseVectorIndex(v.vectorIndex),
+      vectorIndexType: v.vectorIndex.name,
+      vectorizer: {},
+    };
+    const vectorizer = v.vectorizer.name === 'text2vec-azure-openai' ? 'text2vec-openai' : v.vectorizer.name;
+    vectorizers = [...vectorizers, vectorizer];
+    vectorConfig.vectorizer[vectorizer] = {
+      properties: v.properties,
+      ...parseVectorizerConfig(v.vectorizer.config),
+    };
+    if (v.name === undefined) {
+      throw new WeaviateInvalidInputError(
+        'vectorName is required for each vectorizer when specifying more than one vectorizer'
+      );
+    }
+    vectorsConfig[v.name] = vectorConfig;
+  });
+  return { vectorsConfig, vectorizers };
 };
 
 function populated<T>(v: T | null | undefined): v is T {

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -55,7 +55,7 @@ export type VectorConfigUpdate<N extends string | undefined, I extends VectorInd
 };
 
 export type VectorizersConfigCreate<T> =
-  | VectorConfigCreate<PrimitiveKeys<T>, undefined, VectorIndexType, Vectorizer>
+  | VectorConfigCreate<PrimitiveKeys<T>, string | undefined, VectorIndexType, Vectorizer>
   | VectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>[];
 
 export type VectorizersConfigAdd<T> =

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -58,6 +58,10 @@ export type VectorizersConfigCreate<T> =
   | VectorConfigCreate<PrimitiveKeys<T>, undefined, VectorIndexType, Vectorizer>
   | VectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>[];
 
+export type VectorizersConfigAdd<T> =
+  | VectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>
+  | VectorConfigCreate<PrimitiveKeys<T>, string, VectorIndexType, Vectorizer>[];
+
 export type ConfigureNonTextVectorizerOptions<
   N extends string | undefined,
   I extends VectorIndexType,

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -147,7 +147,7 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
           throw new WeaviateUnsupportedFeatureError(supportsNamedVectors.message);
         }
         const configs = config.vectorizers
-          ? makeLegacyVectorizer(config.vectorizers)
+          ? makeLegacyVectorizer({ ...config.vectorizers, name: undefined })
           : {
               vectorizer: undefined,
               moduleConfig: undefined,

--- a/src/collections/integration.test.ts
+++ b/src/collections/integration.test.ts
@@ -174,6 +174,20 @@ describe('Testing of the collections.create method', () => {
     expect(response.vectorizers.default.vectorizer.name).toEqual('text2vec-contextionary');
   });
 
+  it('should be able to create a collection with 1 custom named vector', async () => {
+    const collectionName = 'TestCollectionSingleCustomNamedVector';
+    const response = await contextionary.collections
+      .create({
+        name: collectionName,
+        vectorizers: weaviate.configure.vectorizer.none({ name: 'custom' }),
+      })
+      .then(() => contextionary.collections.use(collectionName).config.get());
+    expect(response.name).toEqual(collectionName);
+    expect(response.properties?.length).toEqual(0);
+    expect(response.vectorizers.custom.indexConfig).toBeDefined();
+    expect(response.vectorizers.custom.indexType).toEqual('hnsw');
+  });
+
   it('should be able to create a simple collection without a generic using a schema var', async () => {
     const collectionName = 'TestCollectionSimpleNonGenericVar';
     const schema = {

--- a/src/schema/vectorAdder.ts
+++ b/src/schema/vectorAdder.ts
@@ -1,0 +1,56 @@
+import Connection from '../connection/index.js';
+import { VectorConfig } from '../index.js';
+import { CommandBase } from '../validation/commandBase.js';
+import { isValidStringProperty } from '../validation/string.js';
+import ClassGetter from './classGetter.js';
+
+export default class VectorAdder<T> extends CommandBase {
+  private className!: string;
+  private vectors!: Record<string, any>;
+
+  constructor(client: Connection) {
+    super(client);
+  }
+
+  withClassName = (className: string) => {
+    this.className = className;
+    return this;
+  };
+  withVectors = (vectors: Record<string, VectorConfig>) => {
+    this.vectors = vectors;
+    return this;
+  };
+
+  validateClassName = () => {
+    if (!isValidStringProperty(this.className)) {
+      this.addError('className must be set - set with .withClassName(className)');
+    }
+  };
+
+  validate = () => {
+    this.validateClassName();
+  };
+
+  do = (): Promise<void> => {
+    this.validate();
+    if (this.errors.length > 0) {
+      return Promise.reject(new Error('invalid usage: ' + this.errors.join(', ')));
+    }
+
+    return new ClassGetter(this.client)
+      .withClassName(this.className)
+      .do()
+      .then(async (schema) => {
+        if (schema.vectorConfig === undefined) {
+          schema.vectorConfig = {};
+        }
+
+        for (const [key, value] of Object.entries(this.vectors)) {
+          schema.vectorConfig![key] = { ...value };
+        }
+
+        const path = `/schema/${this.className}`;
+        await this.client.put(path, schema);
+      });
+  };
+}

--- a/src/schema/vectorAdder.ts
+++ b/src/schema/vectorAdder.ts
@@ -46,6 +46,9 @@ export default class VectorAdder<T> extends CommandBase {
         }
 
         for (const [key, value] of Object.entries(this.vectors)) {
+          if (schema.vectorConfig[key] !== undefined) {
+            continue;
+          }
           schema.vectorConfig![key] = { ...value };
         }
 


### PR DESCRIPTION
This PR:
- adds `collection.config.addVector` method to support creating new named vectors on the collection. Only named vectors can be created and existing named vectors cannot be modified.
The method accepts the same arguments as `collections.create(... { vectorizers: XXX })` with the exception that anonymous vectors are not permitted, e.g. `vectorizer.none()`. 
- fixes a bug whereby passing a vector with a custom name as a `single object` and passing it as an array `[single object]` to `collections.create()` would result in 2 different behaviors: custom name changed to `default` vs custom name preserved.

```ts
// Both cases should generate vectorConfig: { 'custom': {...} }
collections.create(..., { vectorizers: vectorizer.none('custom') });
collections.create(..., { vectorizers: [vectorizer.none('custom')] });