### PR TITLE
BM25 and Hybrid search with minimum_should_match

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,7 @@ env:
   WEAVIATE_128: 1.28.11
   WEAVIATE_129: 1.29.1
   WEAVIATE_130: 1.30.1
+  WEAVIATE_131: 1.31.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/collections/query/index.ts
+++ b/src/collections/query/index.ts
@@ -247,6 +247,7 @@ export {
   BaseHybridOptions,
   BaseNearOptions,
   BaseNearTextOptions,
+  Bm25OperatorOptions,
   Bm25Options,
   FetchObjectByIdOptions,
   FetchObjectsOptions,
@@ -266,3 +267,5 @@ export {
   QueryReturn,
   SearchOptions,
 } from './types.js';
+
+export { Bm25Operator } from './utils.js';

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
+import { requireAtLeast } from '../../../test/version.js';
 import { WeaviateUnsupportedFeatureError } from '../../errors.js';
 import weaviate, { WeaviateClient } from '../../index.js';
 import { Collection } from '../collection/index.js';
 import { CrossReference, Reference } from '../references/index.js';
 import { GroupByOptions } from '../types/index.js';
+import { Bm25Operator } from './utils.js';
 
 describe('Testing of the collection.query methods with a simple collection', () => {
   let client: WeaviateClient;
@@ -130,6 +132,28 @@ describe('Testing of the collection.query methods with a simple collection', () 
     expect(ret.objects.length).toEqual(1);
     expect(ret.objects[0].properties.testProp).toEqual('carrot');
     expect(ret.objects[0].uuid).toEqual(id);
+  });
+
+  requireAtLeast(1, 31, 0)('bm25 search operator (minimum_should_match)', () => {
+    it('should query with bm25 + operator', async () => {
+      const ret = await collection.query.bm25('carrot', {
+        limit: 1,
+        operator: Bm25Operator.or({ minimumMatch: 1 }),
+      });
+      expect(ret.objects.length).toEqual(1);
+      expect(ret.objects[0].properties.testProp).toEqual('carrot');
+      expect(ret.objects[0].uuid).toEqual(id);
+    });
+
+    it('should query with hybrid + bm25Operator', async () => {
+      const ret = await collection.query.hybrid('carrot', {
+        limit: 1,
+        bm25Operator: Bm25Operator.and({ minimumMatch: 1 }),
+      });
+      expect(ret.objects.length).toEqual(1);
+      expect(ret.objects[0].properties.testProp).toEqual('carrot');
+      expect(ret.objects[0].uuid).toEqual(id);
+    });
   });
 
   it('should query with hybrid and vector', async () => {

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -152,7 +152,7 @@ describe('Testing of the collection.query methods with a simple collection', () 
     it('should query with hybrid + bm25Operator', async () => {
       const ret = await collection.query.hybrid('carrot', {
         limit: 1,
-        bm25Operator: Bm25Operator.and({ minimumMatch: 1 }),
+        bm25Operator: Bm25Operator.and(),
       });
       expect(ret.objects.length).toEqual(1);
       expect(ret.objects[0].properties.testProp).toEqual('carrot');

--- a/src/collections/query/integration.test.ts
+++ b/src/collections/query/integration.test.ts
@@ -134,7 +134,11 @@ describe('Testing of the collection.query methods with a simple collection', () 
     expect(ret.objects[0].uuid).toEqual(id);
   });
 
-  requireAtLeast(1, 31, 0)('bm25 search operator (minimum_should_match)', () => {
+  requireAtLeast(
+    1,
+    31,
+    0
+  )('bm25 search operator (minimum_should_match)', () => {
     it('should query with bm25 + operator', async () => {
       const ret = await collection.query.bm25('carrot', {
         limit: 1,

--- a/src/collections/query/types.ts
+++ b/src/collections/query/types.ts
@@ -87,7 +87,7 @@ export type Bm25QueryProperty<T> = {
 export type Bm25OperatorOptions = {
   operator: 'And' | 'Or';
   minimumMatch: number;
-}
+};
 
 export type Bm25SearchOptions<T> = {
   /** Which properties of the collection to perform the keyword search on. */
@@ -507,12 +507,12 @@ interface NearVector<T> {
 /** All the available methods on the `.query` namespace. */
 export interface Query<T>
   extends Bm25<T>,
-  Hybrid<T>,
-  NearImage<T>,
-  NearMedia<T>,
-  NearObject<T>,
-  NearText<T>,
-  NearVector<T> {
+    Hybrid<T>,
+    NearImage<T>,
+    NearMedia<T>,
+    NearObject<T>,
+    NearText<T>,
+    NearVector<T> {
   /**
    * Retrieve an object from the server by its UUID.
    *

--- a/src/collections/query/types.ts
+++ b/src/collections/query/types.ts
@@ -84,9 +84,15 @@ export type Bm25QueryProperty<T> = {
   weight: number;
 };
 
+export type Bm25OperatorOptions = {
+  operator: 'and' | 'or';
+  minimumMatch: number;
+}
+
 export type Bm25SearchOptions<T> = {
   /** Which properties of the collection to perform the keyword search on. */
   queryProperties?: (PrimitiveKeys<T> | Bm25QueryProperty<T>)[];
+  operator?: Bm25OperatorOptions;
 };
 
 /** Base options available in the `query.bm25` method */
@@ -115,6 +121,7 @@ export type HybridSearchOptions<T> = {
   targetVector?: TargetVectorInputType;
   /** The specific vector to search for or a specific vector subsearch. If not specified, the query is vectorized and used in the similarity search. */
   vector?: NearVectorInputType | HybridNearTextSubSearch | HybridNearVectorSubSearch;
+  bm25Operator?: Bm25OperatorOptions;
 };
 
 /** Base options available in the `query.hybrid` method */
@@ -500,12 +507,12 @@ interface NearVector<T> {
 /** All the available methods on the `.query` namespace. */
 export interface Query<T>
   extends Bm25<T>,
-    Hybrid<T>,
-    NearImage<T>,
-    NearMedia<T>,
-    NearObject<T>,
-    NearText<T>,
-    NearVector<T> {
+  Hybrid<T>,
+  NearImage<T>,
+  NearMedia<T>,
+  NearObject<T>,
+  NearText<T>,
+  NearVector<T> {
   /**
    * Retrieve an object from the server by its UUID.
    *

--- a/src/collections/query/types.ts
+++ b/src/collections/query/types.ts
@@ -84,10 +84,10 @@ export type Bm25QueryProperty<T> = {
   weight: number;
 };
 
-export type Bm25OperatorOptions = {
-  operator: 'And' | 'Or';
-  minimumMatch: number;
-};
+export type Bm25OperatorOr = { operator: 'Or'; minimumMatch: number };
+export type Bm25OperatorAnd = { operator: 'And' };
+
+export type Bm25OperatorOptions = Bm25OperatorOr | Bm25OperatorAnd;
 
 export type Bm25SearchOptions<T> = {
   /** Which properties of the collection to perform the keyword search on. */

--- a/src/collections/query/types.ts
+++ b/src/collections/query/types.ts
@@ -85,7 +85,7 @@ export type Bm25QueryProperty<T> = {
 };
 
 export type Bm25OperatorOptions = {
-  operator: 'and' | 'or';
+  operator: 'And' | 'Or';
   minimumMatch: number;
 }
 

--- a/src/collections/query/utils.ts
+++ b/src/collections/query/utils.ts
@@ -1,5 +1,5 @@
 import { MultiTargetVectorJoin } from '../index.js';
-import { NearVectorInputType, TargetVectorInputType } from './types.js';
+import { Bm25OperatorOptions, NearVectorInputType, TargetVectorInputType } from './types.js';
 
 export class NearVectorInputGuards {
   public static is1DArray(input: NearVectorInputType): input is number[] {
@@ -33,4 +33,15 @@ export class TargetVectorInputGuards {
     const i = input as MultiTargetVectorJoin;
     return i.combination !== undefined && i.targetVectors !== undefined;
   }
+}
+
+export class Bm25Operator {
+  static and(opts: Omit<Bm25OperatorOptions, 'operator'>): Bm25OperatorOptions {
+    return { ...opts, operator: 'And' };
+  }
+
+  static or(opts: Omit<Bm25OperatorOptions, 'operator'>): Bm25OperatorOptions {
+    return { ...opts, operator: 'Or' };
+  }
+
 }

--- a/src/collections/query/utils.ts
+++ b/src/collections/query/utils.ts
@@ -43,5 +43,4 @@ export class Bm25Operator {
   static or(opts: Omit<Bm25OperatorOptions, 'operator'>): Bm25OperatorOptions {
     return { ...opts, operator: 'Or' };
   }
-
 }

--- a/src/collections/query/utils.ts
+++ b/src/collections/query/utils.ts
@@ -1,5 +1,5 @@
 import { MultiTargetVectorJoin } from '../index.js';
-import { Bm25OperatorOptions, NearVectorInputType, TargetVectorInputType } from './types.js';
+import { Bm25OperatorOptions, Bm25OperatorOr, NearVectorInputType, TargetVectorInputType } from './types.js';
 
 export class NearVectorInputGuards {
   public static is1DArray(input: NearVectorInputType): input is number[] {
@@ -36,11 +36,11 @@ export class TargetVectorInputGuards {
 }
 
 export class Bm25Operator {
-  static and(opts: Omit<Bm25OperatorOptions, 'operator'>): Bm25OperatorOptions {
-    return { ...opts, operator: 'And' };
+  static and(): Bm25OperatorOptions {
+    return { operator: 'And' };
   }
 
-  static or(opts: Omit<Bm25OperatorOptions, 'operator'>): Bm25OperatorOptions {
+  static or(opts: Omit<Bm25OperatorOr, 'operator'>): Bm25OperatorOptions {
     return { ...opts, operator: 'Or' };
   }
 }

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -388,10 +388,10 @@ class Aggregate {
         text:
           metric.kind === 'text'
             ? AggregateRequest_Aggregation_Text.fromPartial({
-              count: metric.count,
-              topOccurencesLimit: metric.minOccurrences,
-              topOccurences: metric.topOccurrences != undefined,
-            })
+                count: metric.count,
+                topOccurencesLimit: metric.minOccurrences,
+                topOccurences: metric.topOccurrences != undefined,
+              })
             : undefined,
       })
     );
@@ -525,27 +525,27 @@ class Search {
       returnAllNonrefProperties: nonRefProperties === undefined,
       refProperties: refProperties
         ? refProperties.map((property) => {
-          return {
-            referenceProperty: property.linkOn,
-            properties: Search.queryProperties(property.returnProperties as any),
-            metadata: Search.metadata(property.includeVector, property.returnMetadata),
-            targetCollection: property.targetCollection ? property.targetCollection : '',
-          };
-        })
+            return {
+              referenceProperty: property.linkOn,
+              properties: Search.queryProperties(property.returnProperties as any),
+              metadata: Search.metadata(property.includeVector, property.returnMetadata),
+              targetCollection: property.targetCollection ? property.targetCollection : '',
+            };
+          })
         : [],
       objectProperties: objectProperties
         ? objectProperties.map((property) => {
-          const objProps = property.properties.filter(
-            (property) => typeof property !== 'string'
-          ) as unknown; // cannot get types to work currently :(
-          return {
-            propName: property.name,
-            primitiveProperties: property.properties.filter(
-              (property) => typeof property === 'string'
-            ) as string[],
-            objectProperties: (objProps as QueryNested<T>[]).map(resolveObjectProperty),
-          };
-        })
+            const objProps = property.properties.filter(
+              (property) => typeof property !== 'string'
+            ) as unknown; // cannot get types to work currently :(
+            return {
+              propName: property.name,
+              primitiveProperties: property.properties.filter(
+                (property) => typeof property === 'string'
+              ) as string[],
+              objectProperties: (objProps as QueryNested<T>[]).map(resolveObjectProperty),
+            };
+          })
         : [],
     };
   };
@@ -917,30 +917,30 @@ export class Serialize {
 
     return args.supportsSingleGrouped
       ? GenerativeSearch.fromPartial({
-        single: opts?.singlePrompt
-          ? GenerativeSearch_Single.fromPartial({
-            prompt: singlePrompt,
-            debug: singlePromptDebug,
-            queries: opts.config ? [await Serialize.generativeQuery(opts.config, singleOpts)] : undefined,
-          })
-          : undefined,
-        grouped: opts?.groupedTask
-          ? GenerativeSearch_Grouped.fromPartial({
-            task: groupedTask,
-            queries: opts.config
-              ? [await Serialize.generativeQuery(opts.config, groupedOpts)]
-              : undefined,
-            properties: groupedProperties
-              ? TextArray.fromPartial({ values: groupedProperties as string[] })
-              : undefined,
-          })
-          : undefined,
-      })
+          single: opts?.singlePrompt
+            ? GenerativeSearch_Single.fromPartial({
+                prompt: singlePrompt,
+                debug: singlePromptDebug,
+                queries: opts.config ? [await Serialize.generativeQuery(opts.config, singleOpts)] : undefined,
+              })
+            : undefined,
+          grouped: opts?.groupedTask
+            ? GenerativeSearch_Grouped.fromPartial({
+                task: groupedTask,
+                queries: opts.config
+                  ? [await Serialize.generativeQuery(opts.config, groupedOpts)]
+                  : undefined,
+                properties: groupedProperties
+                  ? TextArray.fromPartial({ values: groupedProperties as string[] })
+                  : undefined,
+              })
+            : undefined,
+        })
       : GenerativeSearch.fromPartial({
-        singleResponsePrompt: singlePrompt,
-        groupedResponseTask: groupedTask,
-        groupedProperties: groupedProperties as string[],
-      });
+          singleResponsePrompt: singlePrompt,
+          groupedResponseTask: groupedTask,
+          groupedProperties: groupedProperties as string[],
+        });
   };
 
   public static isSinglePrompt(arg?: string | SinglePrompt): arg is SinglePrompt {
@@ -963,14 +963,19 @@ export class Serialize {
     });
   };
 
-  private static bm25SearchOperator = (searchOperator?: Bm25OperatorOptions): SearchOperatorOptions | undefined => {
+  private static bm25SearchOperator = (
+    searchOperator?: Bm25OperatorOptions
+  ): SearchOperatorOptions | undefined => {
     if (searchOperator) {
       return SearchOperatorOptions.fromPartial({
         minimumOrTokensMatch: searchOperator.minimumMatch,
-        operator: searchOperator.operator === 'And' as const ? SearchOperatorOptions_Operator.OPERATOR_AND : SearchOperatorOptions_Operator.OPERATOR_OR,
+        operator:
+          searchOperator.operator === ('And' as const)
+            ? SearchOperatorOptions_Operator.OPERATOR_AND
+            : SearchOperatorOptions_Operator.OPERATOR_OR,
       });
     }
-  }
+  };
 
   public static bm25Search = <T>(args: { query: string } & Bm25SearchOptions<T>): BM25 => {
     return BM25.fromPartial({
@@ -1018,13 +1023,13 @@ export class Serialize {
       return vectorBytes !== undefined
         ? { vectorBytes, targetVectors, targets }
         : {
-          targetVectors,
-          targets,
-          nearVector: NearVector.fromPartial({
-            vectorForTargets,
-            vectorPerTarget,
-          }),
-        };
+            targetVectors,
+            targets,
+            nearVector: NearVector.fromPartial({
+              vectorForTargets,
+              vectorPerTarget,
+            }),
+          };
     } else if (Serialize.isHybridNearTextSearch(vector)) {
       const { targetVectors, targets } = Serialize.targetVector(args);
       return {
@@ -1081,7 +1086,11 @@ export class Serialize {
     };
     const { targets, targetVectors, vectorBytes, nearText, nearVector } = Serialize.hybridVector(args);
 
-    console.info(`search operator: ${JSON.stringify(SearchOperatorOptions.toJSON(this.bm25SearchOperator(args.bm25Operator)!))}`);
+    console.info(
+      `search operator: ${JSON.stringify(
+        SearchOperatorOptions.toJSON(this.bm25SearchOperator(args.bm25Operator)!)
+      )}`
+    );
     return Hybrid.fromPartial({
       query: args.query,
       alpha: args.alpha ? args.alpha : 0.5,
@@ -1181,17 +1190,17 @@ export class Serialize {
       targetVectors,
       moveAway: args.moveAway
         ? NearTextSearch_Move.fromPartial({
-          concepts: args.moveAway.concepts,
-          force: args.moveAway.force,
-          uuids: args.moveAway.objects,
-        })
+            concepts: args.moveAway.concepts,
+            force: args.moveAway.force,
+            uuids: args.moveAway.objects,
+          })
         : undefined,
       moveTo: args.moveTo
         ? NearTextSearch_Move.fromPartial({
-          concepts: args.moveTo.concepts,
-          force: args.moveTo.force,
-          uuids: args.moveTo.objects,
-        })
+            concepts: args.moveTo.concepts,
+            force: args.moveTo.force,
+            uuids: args.moveTo.objects,
+          })
         : undefined,
     });
   };
@@ -1247,18 +1256,18 @@ export class Serialize {
     } else if (TargetVectorInputGuards.isSingle(args.targetVector)) {
       return args.supportsTargets
         ? {
-          targets: Targets.fromPartial({
-            targetVectors: [args.targetVector],
-          }),
-        }
+            targets: Targets.fromPartial({
+              targetVectors: [args.targetVector],
+            }),
+          }
         : { targetVectors: [args.targetVector] };
     } else if (TargetVectorInputGuards.isMulti(args.targetVector)) {
       return args.supportsTargets
         ? {
-          targets: Targets.fromPartial({
-            targetVectors: args.targetVector,
-          }),
-        }
+            targets: Targets.fromPartial({
+              targetVectors: args.targetVector,
+            }),
+          }
         : { targetVectors: args.targetVector };
     } else {
       return { targets: Serialize.targets(args.targetVector, args.supportsWeightsForTargets) };
@@ -1303,22 +1312,22 @@ export class Serialize {
           .reduce((acc, { target, vector }) => {
             return ArrayInputGuards.is2DArray(vector)
               ? acc.concat(
-                vector.map((v) => ({ name: target, vectorBytes: Serialize.vectorToBytes(v), vectors: [] }))
-              )
+                  vector.map((v) => ({ name: target, vectorBytes: Serialize.vectorToBytes(v), vectors: [] }))
+                )
               : acc.concat([{ name: target, vectorBytes: Serialize.vectorToBytes(vector), vectors: [] }]);
           }, [] as VectorForTarget[]);
         return args.targetVector !== undefined
           ? {
-            ...Serialize.targetVector(args),
-            vectorForTargets,
-          }
+              ...Serialize.targetVector(args),
+              vectorForTargets,
+            }
           : {
-            targetVectors: undefined,
-            targets: Targets.fromPartial({
-              targetVectors: vectorForTargets.map((v) => v.name),
-            }),
-            vectorForTargets,
-          };
+              targetVectors: undefined,
+              targets: Targets.fromPartial({
+                targetVectors: vectorForTargets.map((v) => v.name),
+              }),
+              vectorForTargets,
+            };
       } else {
         const vectorPerTarget: Record<string, Uint8Array> = {};
         Object.entries(args.vector).forEach(([k, v]) => {
@@ -1337,15 +1346,15 @@ export class Serialize {
         } else {
           return args.supportsTargets
             ? {
-              targets: Targets.fromPartial({
-                targetVectors: Object.keys(vectorPerTarget),
-              }),
-              vectorPerTarget,
-            }
+                targets: Targets.fromPartial({
+                  targetVectors: Object.keys(vectorPerTarget),
+                }),
+                vectorPerTarget,
+              }
             : {
-              targetVectors: Object.keys(vectorPerTarget),
-              vectorPerTarget,
-            };
+                targetVectors: Object.keys(vectorPerTarget),
+                vectorPerTarget,
+              };
         }
       }
     } else {

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -967,13 +967,14 @@ export class Serialize {
     searchOperator?: Bm25OperatorOptions
   ): SearchOperatorOptions | undefined => {
     if (searchOperator) {
-      return SearchOperatorOptions.fromPartial({
-        minimumOrTokensMatch: searchOperator.minimumMatch,
-        operator:
-          searchOperator.operator === ('And' as const)
-            ? SearchOperatorOptions_Operator.OPERATOR_AND
-            : SearchOperatorOptions_Operator.OPERATOR_OR,
-      });
+      return SearchOperatorOptions.fromPartial(
+        searchOperator.operator === ('And' as const)
+          ? { operator: SearchOperatorOptions_Operator.OPERATOR_AND }
+          : {
+              operator: SearchOperatorOptions_Operator.OPERATOR_OR,
+              minimumOrTokensMatch: searchOperator.minimumMatch,
+            }
+      );
     }
   };
 

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -1085,12 +1085,6 @@ export class Serialize {
       }
     };
     const { targets, targetVectors, vectorBytes, nearText, nearVector } = Serialize.hybridVector(args);
-
-    console.info(
-      `search operator: ${JSON.stringify(
-        SearchOperatorOptions.toJSON(this.bm25SearchOperator(args.bm25Operator)!)
-      )}`
-    );
     return Hybrid.fromPartial({
       query: args.query,
       alpha: args.alpha ? args.alpha : 0.5,

--- a/src/collections/serialize/index.ts
+++ b/src/collections/serialize/index.ts
@@ -967,7 +967,7 @@ export class Serialize {
     if (searchOperator) {
       return SearchOperatorOptions.fromPartial({
         minimumOrTokensMatch: searchOperator.minimumMatch,
-        operator: searchOperator.operator === 'and' as const ? SearchOperatorOptions_Operator.OPERATOR_AND : SearchOperatorOptions_Operator.OPERATOR_OR,
+        operator: searchOperator.operator === 'And' as const ? SearchOperatorOptions_Operator.OPERATOR_AND : SearchOperatorOptions_Operator.OPERATOR_OR,
       });
     }
   }
@@ -1080,6 +1080,8 @@ export class Serialize {
       }
     };
     const { targets, targetVectors, vectorBytes, nearText, nearVector } = Serialize.hybridVector(args);
+
+    console.info(`search operator: ${JSON.stringify(SearchOperatorOptions.toJSON(this.bm25SearchOperator(args.bm25Operator)!))}`);
     return Hybrid.fromPartial({
       query: args.query,
       alpha: args.alpha ? args.alpha : 0.5,

--- a/src/proto/v1/base_search.ts
+++ b/src/proto/v1/base_search.ts
@@ -100,6 +100,50 @@ export interface VectorForTarget {
   vectors: Vectors[];
 }
 
+export interface SearchOperatorOptions {
+  operator: SearchOperatorOptions_Operator;
+  minimumOrTokensMatch?: number | undefined;
+}
+
+export enum SearchOperatorOptions_Operator {
+  OPERATOR_UNSPECIFIED = 0,
+  OPERATOR_OR = 1,
+  OPERATOR_AND = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function searchOperatorOptions_OperatorFromJSON(object: any): SearchOperatorOptions_Operator {
+  switch (object) {
+    case 0:
+    case "OPERATOR_UNSPECIFIED":
+      return SearchOperatorOptions_Operator.OPERATOR_UNSPECIFIED;
+    case 1:
+    case "OPERATOR_OR":
+      return SearchOperatorOptions_Operator.OPERATOR_OR;
+    case 2:
+    case "OPERATOR_AND":
+      return SearchOperatorOptions_Operator.OPERATOR_AND;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return SearchOperatorOptions_Operator.UNRECOGNIZED;
+  }
+}
+
+export function searchOperatorOptions_OperatorToJSON(object: SearchOperatorOptions_Operator): string {
+  switch (object) {
+    case SearchOperatorOptions_Operator.OPERATOR_UNSPECIFIED:
+      return "OPERATOR_UNSPECIFIED";
+    case SearchOperatorOptions_Operator.OPERATOR_OR:
+      return "OPERATOR_OR";
+    case SearchOperatorOptions_Operator.OPERATOR_AND:
+      return "OPERATOR_AND";
+    case SearchOperatorOptions_Operator.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
 export interface Hybrid {
   query: string;
   properties: string[];
@@ -130,6 +174,7 @@ export interface Hybrid {
   /** same as above. Use the target vector in the hybrid message */
   nearVector: NearVector | undefined;
   targets: Targets | undefined;
+  bm25SearchOperator?: SearchOperatorOptions | undefined;
   vectorDistance?: number | undefined;
   vectors: Vectors[];
 }
@@ -346,6 +391,7 @@ export interface NearIMUSearch {
 export interface BM25 {
   query: string;
   properties: string[];
+  searchOperator?: SearchOperatorOptions | undefined;
 }
 
 function createBaseWeightsForTarget(): WeightsForTarget {
@@ -712,6 +758,82 @@ export const VectorForTarget = {
   },
 };
 
+function createBaseSearchOperatorOptions(): SearchOperatorOptions {
+  return { operator: 0, minimumOrTokensMatch: undefined };
+}
+
+export const SearchOperatorOptions = {
+  encode(message: SearchOperatorOptions, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.operator !== 0) {
+      writer.uint32(8).int32(message.operator);
+    }
+    if (message.minimumOrTokensMatch !== undefined) {
+      writer.uint32(16).int32(message.minimumOrTokensMatch);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): SearchOperatorOptions {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSearchOperatorOptions();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 8) {
+            break;
+          }
+
+          message.operator = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag !== 16) {
+            break;
+          }
+
+          message.minimumOrTokensMatch = reader.int32();
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SearchOperatorOptions {
+    return {
+      operator: isSet(object.operator) ? searchOperatorOptions_OperatorFromJSON(object.operator) : 0,
+      minimumOrTokensMatch: isSet(object.minimumOrTokensMatch)
+        ? globalThis.Number(object.minimumOrTokensMatch)
+        : undefined,
+    };
+  },
+
+  toJSON(message: SearchOperatorOptions): unknown {
+    const obj: any = {};
+    if (message.operator !== 0) {
+      obj.operator = searchOperatorOptions_OperatorToJSON(message.operator);
+    }
+    if (message.minimumOrTokensMatch !== undefined) {
+      obj.minimumOrTokensMatch = Math.round(message.minimumOrTokensMatch);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<SearchOperatorOptions>): SearchOperatorOptions {
+    return SearchOperatorOptions.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<SearchOperatorOptions>): SearchOperatorOptions {
+    const message = createBaseSearchOperatorOptions();
+    message.operator = object.operator ?? 0;
+    message.minimumOrTokensMatch = object.minimumOrTokensMatch ?? undefined;
+    return message;
+  },
+};
+
 function createBaseHybrid(): Hybrid {
   return {
     query: "",
@@ -724,6 +846,7 @@ function createBaseHybrid(): Hybrid {
     nearText: undefined,
     nearVector: undefined,
     targets: undefined,
+    bm25SearchOperator: undefined,
     vectorDistance: undefined,
     vectors: [],
   };
@@ -762,6 +885,9 @@ export const Hybrid = {
     }
     if (message.targets !== undefined) {
       Targets.encode(message.targets, writer.uint32(82).fork()).ldelim();
+    }
+    if (message.bm25SearchOperator !== undefined) {
+      SearchOperatorOptions.encode(message.bm25SearchOperator, writer.uint32(90).fork()).ldelim();
     }
     if (message.vectorDistance !== undefined) {
       writer.uint32(165).float(message.vectorDistance);
@@ -859,6 +985,13 @@ export const Hybrid = {
 
           message.targets = Targets.decode(reader, reader.uint32());
           continue;
+        case 11:
+          if (tag !== 90) {
+            break;
+          }
+
+          message.bm25SearchOperator = SearchOperatorOptions.decode(reader, reader.uint32());
+          continue;
         case 20:
           if (tag !== 165) {
             break;
@@ -898,6 +1031,9 @@ export const Hybrid = {
       nearText: isSet(object.nearText) ? NearTextSearch.fromJSON(object.nearText) : undefined,
       nearVector: isSet(object.nearVector) ? NearVector.fromJSON(object.nearVector) : undefined,
       targets: isSet(object.targets) ? Targets.fromJSON(object.targets) : undefined,
+      bm25SearchOperator: isSet(object.bm25SearchOperator)
+        ? SearchOperatorOptions.fromJSON(object.bm25SearchOperator)
+        : undefined,
       vectorDistance: isSet(object.vectorDistance) ? globalThis.Number(object.vectorDistance) : undefined,
       vectors: globalThis.Array.isArray(object?.vectors) ? object.vectors.map((e: any) => Vectors.fromJSON(e)) : [],
     };
@@ -935,6 +1071,9 @@ export const Hybrid = {
     if (message.targets !== undefined) {
       obj.targets = Targets.toJSON(message.targets);
     }
+    if (message.bm25SearchOperator !== undefined) {
+      obj.bm25SearchOperator = SearchOperatorOptions.toJSON(message.bm25SearchOperator);
+    }
     if (message.vectorDistance !== undefined) {
       obj.vectorDistance = message.vectorDistance;
     }
@@ -964,6 +1103,9 @@ export const Hybrid = {
       : undefined;
     message.targets = (object.targets !== undefined && object.targets !== null)
       ? Targets.fromPartial(object.targets)
+      : undefined;
+    message.bm25SearchOperator = (object.bm25SearchOperator !== undefined && object.bm25SearchOperator !== null)
+      ? SearchOperatorOptions.fromPartial(object.bm25SearchOperator)
       : undefined;
     message.vectorDistance = object.vectorDistance ?? undefined;
     message.vectors = object.vectors?.map((e) => Vectors.fromPartial(e)) || [];
@@ -2390,7 +2532,7 @@ export const NearIMUSearch = {
 };
 
 function createBaseBM25(): BM25 {
-  return { query: "", properties: [] };
+  return { query: "", properties: [], searchOperator: undefined };
 }
 
 export const BM25 = {
@@ -2400,6 +2542,9 @@ export const BM25 = {
     }
     for (const v of message.properties) {
       writer.uint32(18).string(v!);
+    }
+    if (message.searchOperator !== undefined) {
+      SearchOperatorOptions.encode(message.searchOperator, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -2425,6 +2570,13 @@ export const BM25 = {
 
           message.properties.push(reader.string());
           continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.searchOperator = SearchOperatorOptions.decode(reader, reader.uint32());
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2440,6 +2592,7 @@ export const BM25 = {
       properties: globalThis.Array.isArray(object?.properties)
         ? object.properties.map((e: any) => globalThis.String(e))
         : [],
+      searchOperator: isSet(object.searchOperator) ? SearchOperatorOptions.fromJSON(object.searchOperator) : undefined,
     };
   },
 
@@ -2451,6 +2604,9 @@ export const BM25 = {
     if (message.properties?.length) {
       obj.properties = message.properties;
     }
+    if (message.searchOperator !== undefined) {
+      obj.searchOperator = SearchOperatorOptions.toJSON(message.searchOperator);
+    }
     return obj;
   },
 
@@ -2461,6 +2617,9 @@ export const BM25 = {
     const message = createBaseBM25();
     message.query = object.query ?? "";
     message.properties = object.properties?.map((e) => e) || [];
+    message.searchOperator = (object.searchOperator !== undefined && object.searchOperator !== null)
+      ? SearchOperatorOptions.fromPartial(object.searchOperator)
+      : undefined;
     return message;
   },
 };


### PR DESCRIPTION
This PR adds an optional search operator argument to BM25 and Hybrid queries that provides the new `minimum_should_match` semantics.

```ts
collection.query.hybrid(..., { bm25Operator: BM25Operator.and({ minimumMatch: 5 })});

collection.query.bm25(..., { operator: BM25Operator.or({ minimumMatch: 3 })});
```