### PR TITLE
fix: return seconds for elapsedSeconds instead of ms

### DIFF
--- a/src/collections/data/index.ts
+++ b/src/collections/data/index.ts
@@ -266,7 +266,8 @@ const data = <T>(
         const start = Date.now();
         const reply = await batch.withObjects({ objects: serialized.mapped });
         const end = Date.now();
-        return Deserialize.batchObjects<T>(reply, serialized.batch, serialized.mapped, end - start);
+        const elapsedSeconds = (end - start) / 1000;
+        return Deserialize.batchObjects<T>(reply, serialized.batch, serialized.mapped, elapsedSeconds);
       }),
     referenceAdd: <P extends Properties>(args: ReferenceArgs<P>): Promise<void> =>
       referencesPath
@@ -306,7 +307,7 @@ const data = <T>(
             }
           });
           return {
-            elapsedSeconds: end - start,
+            elapsedSeconds: (end - start) / 1000,
             errors: errors,
             hasErrors: Object.keys(errors).length > 0,
           };


### PR DESCRIPTION
This should close #310 

Tested locally 

```
Insertion response:  {
  uuids: {
    "0": "e2845267-ffe1-4d37-9af7-11e5d5e51c47",
    "1": "03cd0b38-6326-40a7-be4a-6723166ddc48",
    "2": "e4298e09-fe31-4b28-836b-8ebfbd5307ad",
    "3": "cca8c0b2-09c2-45de-a7f8-9f2336ab8b1f",
    "4": "1cb26840-36fa-4db0-a006-3915f1f884e5",
    "5": "e3808a54-5109-4983-82a4-aa99e184e6a8",
    "6": "f5a8ae35-d0b1-4a31-9154-7cc8e017e4bb",
    "7": "84d32342-5562-4aa4-85fb-a0d60d6cab3e",
    "8": "c73aefce-8ebe-4f60-b51a-70d22bdd14d5",
    "9": "a3cc64a0-e80d-4a55-9ed6-eab98ba9e389",
  },
  errors: {},
  hasErrors: false,
  allResponses: [ "e2845267-ffe1-4d37-9af7-11e5d5e51c47", "03cd0b38-6326-40a7-be4a-6723166ddc48",
    "e4298e09-fe31-4b28-836b-8ebfbd5307ad", "cca8c0b2-09c2-45de-a7f8-9f2336ab8b1f", "1cb26840-36fa-4db0-a006-3915f1f884e5",
    "e3808a54-5109-4983-82a4-aa99e184e6a8", "f5a8ae35-d0b1-4a31-9154-7cc8e017e4bb", "84d32342-5562-4aa4-85fb-a0d60d6cab3e",
    "c73aefce-8ebe-4f60-b51a-70d22bdd14d5", "a3cc64a0-e80d-4a55-9ed6-eab98ba9e389"
  ],
  elapsedSeconds: 0.057,
}
```