### PR TITLE
feat: Add support for RQ

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,7 @@ env:
   WEAVIATE_129: 1.29.8
   WEAVIATE_130: 1.30.7
   WEAVIATE_131: 1.31.0
+  WEAVIATE_132: 1.32.0-rc.1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,9 +49,11 @@ jobs:
           { node: "22.x", weaviate: $WEAVIATE_127},
           { node: "22.x", weaviate: $WEAVIATE_128},
           { node: "22.x", weaviate: $WEAVIATE_129},
-          { node: "18.x", weaviate: $WEAVIATE_130},
-          { node: "20.x", weaviate: $WEAVIATE_130},
-          { node: "22.x", weaviate: $WEAVIATE_130}
+          { node: "22.x", weaviate: $WEAVIATE_130},
+          { node: "22.x", weaviate: $WEAVIATE_131},
+          { node: "18.x", weaviate: $WEAVIATE_132},
+          { node: "20.x", weaviate: $WEAVIATE_132},
+          { node: "22.x", weaviate: $WEAVIATE_132}
         ]
     steps:
     - uses: actions/checkout@v3

--- a/src/collections/config/index.ts
+++ b/src/collections/config/index.ts
@@ -19,6 +19,7 @@ import {
   CollectionConfigUpdate,
   PQConfig,
   QuantizerConfig,
+  RQConfig,
   SQConfig,
   VectorIndexConfig,
   VectorIndexConfigDynamic,
@@ -40,7 +41,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveProperty<any>(property, []))
         .do()
-        .then(() => {}),
+        .then(() => { }),
     addReference: (
       reference: ReferenceSingleTargetConfigCreate<any> | ReferenceMultiTargetConfigCreate<any>
     ) =>
@@ -48,7 +49,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveReference<any>(reference))
         .do()
-        .then(() => {}),
+        .then(() => { }),
     addVector: async (vectors: VectorizersConfigAdd<T>) => {
       const supportsDynamicVectorIndex = await dbVersionSupport.supportsDynamicVectorIndex();
       const { vectorsConfig } = makeVectorsConfig(vectors, supportsDynamicVectorIndex);
@@ -72,7 +73,7 @@ const config = <T>(
         })
       );
     },
-    updateShards: async function (status: 'READY' | 'READONLY', names?: string | string[]) {
+    updateShards: async function(status: 'READY' | 'READONLY', names?: string | string[]) {
       let shardNames: string[];
       if (names === undefined) {
         shardNames = await this.getShards().then((shards) => shards.map((s) => s.name));
@@ -97,7 +98,7 @@ const config = <T>(
           )
         )
         .then((merged) => new ClassUpdater(connection).withClass(merged).do())
-        .then(() => {});
+        .then(() => { });
     },
   };
 };
@@ -191,6 +192,9 @@ export class Quantizer {
   }
   static isSQ(config?: QuantizerConfig): config is SQConfig {
     return config?.type === 'sq';
+  }
+  static isRQ(config?: QuantizerConfig): config is RQConfig {
+    return config?.type === 'rq';
   }
 }
 

--- a/src/collections/config/index.ts
+++ b/src/collections/config/index.ts
@@ -41,7 +41,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveProperty<any>(property, []))
         .do()
-        .then(() => { }),
+        .then(() => {}),
     addReference: (
       reference: ReferenceSingleTargetConfigCreate<any> | ReferenceMultiTargetConfigCreate<any>
     ) =>
@@ -49,7 +49,7 @@ const config = <T>(
         .withClassName(name)
         .withProperty(resolveReference<any>(reference))
         .do()
-        .then(() => { }),
+        .then(() => {}),
     addVector: async (vectors: VectorizersConfigAdd<T>) => {
       const supportsDynamicVectorIndex = await dbVersionSupport.supportsDynamicVectorIndex();
       const { vectorsConfig } = makeVectorsConfig(vectors, supportsDynamicVectorIndex);
@@ -73,7 +73,7 @@ const config = <T>(
         })
       );
     },
-    updateShards: async function(status: 'READY' | 'READONLY', names?: string | string[]) {
+    updateShards: async function (status: 'READY' | 'READONLY', names?: string | string[]) {
       let shardNames: string[];
       if (names === undefined) {
         shardNames = await this.getShards().then((shards) => shards.map((s) => s.name));
@@ -98,7 +98,7 @@ const config = <T>(
           )
         )
         .then((merged) => new ClassUpdater(connection).withClass(merged).do())
-        .then(() => { });
+        .then(() => {});
     },
   };
 };

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -554,8 +554,8 @@ describe('Testing of the collection.config namespace', () => {
       .update({
         propertyDescriptions: supportsUpdatingPropertyDescriptions
           ? {
-            testProp: 'This is a test property',
-          }
+              testProp: 'This is a test property',
+            }
           : undefined,
         vectorizers: weaviate.reconfigure.vectorizer.update({
           vectorIndexConfig: weaviate.reconfigure.vectorIndex.hnsw({

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -12,9 +12,6 @@ import {
   VectorIndexConfigHNSW,
 } from './types/index.js';
 
-const fail = (msg: string) => {
-  throw new Error(msg);
-};
 
 describe('Testing of the collection.config namespace', () => {
   let client: WeaviateClient;
@@ -205,6 +202,30 @@ describe('Testing of the collection.config namespace', () => {
     expect(vectorIndexConfig).toBeDefined();
     expect(vectorIndexConfig.quantizer).toBeDefined();
     expect(vectorIndexConfig.quantizer?.type).toEqual('pq');
+    expect(config.vectorizers.default.indexType).toEqual('hnsw');
+    expect(config.vectorizers.default.properties).toBeUndefined();
+    expect(config.vectorizers.default.vectorizer.name).toEqual('none');
+  });
+
+  it('should be able to get the config of a collection with hnsw-rq', async () => {
+    const collectionName = 'TestCollectionConfigGetHNSWPlusRQ';
+    const collection = await client.collections.create({
+      name: collectionName,
+      vectorizers: weaviate.configure.vectorizer.none({
+        vectorIndexConfig: weaviate.configure.vectorIndex.hnsw({
+          quantizer: weaviate.configure.vectorIndex.quantizer.rq(),
+        }),
+      }),
+    });
+    const config = await collection.config.get();
+
+    const vectorIndexConfig = config.vectorizers.default.indexConfig as VectorIndexConfigHNSW;
+    expect(config.name).toEqual(collectionName);
+    expect(config.generative).toBeUndefined();
+    expect(config.reranker).toBeUndefined();
+    expect(vectorIndexConfig).toBeDefined();
+    expect(vectorIndexConfig.quantizer).toBeDefined();
+    expect(vectorIndexConfig.quantizer?.type).toEqual('rq');
     expect(config.vectorizers.default.indexType).toEqual('hnsw');
     expect(config.vectorizers.default.properties).toBeUndefined();
     expect(config.vectorizers.default.vectorizer.name).toEqual('none');
@@ -534,8 +555,8 @@ describe('Testing of the collection.config namespace', () => {
       .update({
         propertyDescriptions: supportsUpdatingPropertyDescriptions
           ? {
-              testProp: 'This is a test property',
-            }
+            testProp: 'This is a test property',
+          }
           : undefined,
         vectorizers: weaviate.reconfigure.vectorizer.update({
           vectorIndexConfig: weaviate.reconfigure.vectorIndex.hnsw({

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -206,7 +206,7 @@ describe('Testing of the collection.config namespace', () => {
     expect(config.vectorizers.default.vectorizer.name).toEqual('none');
   });
 
-  it('should be able to get the config of a collection with hnsw-rq', async () => {
+  requireAtLeast(1, 32, 0).it('should be able to get the config of a collection with hnsw-rq', async () => {
     const collectionName = 'TestCollectionConfigGetHNSWPlusRQ';
     const collection = await client.collections.create({
       name: collectionName,
@@ -554,8 +554,8 @@ describe('Testing of the collection.config namespace', () => {
       .update({
         propertyDescriptions: supportsUpdatingPropertyDescriptions
           ? {
-              testProp: 'This is a test property',
-            }
+            testProp: 'This is a test property',
+          }
           : undefined,
         vectorizers: weaviate.reconfigure.vectorizer.update({
           vectorIndexConfig: weaviate.reconfigure.vectorIndex.hnsw({

--- a/src/collections/config/integration.test.ts
+++ b/src/collections/config/integration.test.ts
@@ -12,7 +12,6 @@ import {
   VectorIndexConfigHNSW,
 } from './types/index.js';
 
-
 describe('Testing of the collection.config namespace', () => {
   let client: WeaviateClient;
 
@@ -555,8 +554,8 @@ describe('Testing of the collection.config namespace', () => {
       .update({
         propertyDescriptions: supportsUpdatingPropertyDescriptions
           ? {
-            testProp: 'This is a test property',
-          }
+              testProp: 'This is a test property',
+            }
           : undefined,
         vectorizers: weaviate.reconfigure.vectorizer.update({
           vectorIndexConfig: weaviate.reconfigure.vectorIndex.hnsw({

--- a/src/collections/config/types/vectorIndex.ts
+++ b/src/collections/config/types/vectorIndex.ts
@@ -9,7 +9,7 @@ export type VectorIndexConfigHNSW = {
   filterStrategy: VectorIndexFilterStrategy;
   flatSearchCutoff: number;
   maxConnections: number;
-  quantizer: PQConfig | BQConfig | SQConfig | RQConfig | undefined;
+  quantizer: QuantizerConfig | undefined;
   skip: boolean;
   vectorCacheMaxObjects: number;
   type: 'hnsw';

--- a/src/collections/config/types/vectorIndex.ts
+++ b/src/collections/config/types/vectorIndex.ts
@@ -65,7 +65,7 @@ export type RQConfig = {
   bits?: number;
   rescoreLimit?: number;
   type: 'rq';
-}
+};
 
 export type PQEncoderConfig = {
   type: PQEncoderType;

--- a/src/collections/config/types/vectorIndex.ts
+++ b/src/collections/config/types/vectorIndex.ts
@@ -9,7 +9,7 @@ export type VectorIndexConfigHNSW = {
   filterStrategy: VectorIndexFilterStrategy;
   flatSearchCutoff: number;
   maxConnections: number;
-  quantizer: PQConfig | BQConfig | SQConfig | undefined;
+  quantizer: PQConfig | BQConfig | SQConfig | RQConfig | undefined;
   skip: boolean;
   vectorCacheMaxObjects: number;
   type: 'hnsw';
@@ -61,6 +61,12 @@ export type PQConfig = {
   type: 'pq';
 };
 
+export type RQConfig = {
+  bits?: number;
+  rescoreLimit?: number;
+  type: 'rq';
+}
+
 export type PQEncoderConfig = {
   type: PQEncoderType;
   distribution: PQEncoderDistribution;
@@ -77,4 +83,4 @@ export type VectorIndexFilterStrategy = 'sweeping' | 'acorn';
 
 export type VectorIndexConfig = VectorIndexConfigHNSW | VectorIndexConfigFlat | VectorIndexConfigDynamic;
 
-export type QuantizerConfig = PQConfig | BQConfig | SQConfig;
+export type QuantizerConfig = PQConfig | BQConfig | SQConfig | RQConfig;

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -214,11 +214,11 @@ export const makeVectorsConfig = <TProperties extends Properties | undefined = u
   const vectorizersConfig = Array.isArray(configVectorizers)
     ? configVectorizers
     : [
-      {
-        ...configVectorizers,
-        name: configVectorizers.name || 'default',
-      },
-    ];
+        {
+          ...configVectorizers,
+          name: configVectorizers.name || 'default',
+        },
+      ];
   vectorizersConfig.forEach((v) => {
     if (v.vectorIndex.name === 'dynamic' && !supportsDynamicVectorIndex.supports) {
       throw new WeaviateUnsupportedFeatureError(supportsDynamicVectorIndex.message);
@@ -341,18 +341,18 @@ class ConfigMapping {
         vectorizer:
           v.vectorizer === 'none'
             ? {
-              name: 'none',
-              config: undefined,
-            }
+                name: 'none',
+                config: undefined,
+              }
             : {
-              name: v.vectorizer,
-              config: v.moduleConfig
-                ? ({
-                  ...(v.moduleConfig[v.vectorizer] as any),
-                  vectorizeCollectionName: (v.moduleConfig[v.vectorizer] as any).vectorizeClassName,
-                } as VectorizerConfig)
-                : undefined,
-            },
+                name: v.vectorizer,
+                config: v.moduleConfig
+                  ? ({
+                      ...(v.moduleConfig[v.vectorizer] as any),
+                      vectorizeCollectionName: (v.moduleConfig[v.vectorizer] as any).vectorizeClassName,
+                    } as VectorizerConfig)
+                  : undefined,
+              },
         indexConfig: ConfigMapping.vectorIndex(v.vectorIndexConfig, v.vectorIndexType),
         indexType: ConfigMapping.vectorIndexType(v.vectorIndexType),
       },

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -213,11 +213,11 @@ export const makeVectorsConfig = <TProperties extends Properties | undefined = u
   const vectorizersConfig = Array.isArray(configVectorizers)
     ? configVectorizers
     : [
-      {
-        ...configVectorizers,
-        name: configVectorizers.name || 'default',
-      },
-    ];
+        {
+          ...configVectorizers,
+          name: configVectorizers.name || 'default',
+        },
+      ];
   vectorizersConfig.forEach((v) => {
     if (v.vectorIndex.name === 'dynamic' && !supportsDynamicVectorIndex.supports) {
       throw new WeaviateUnsupportedFeatureError(supportsDynamicVectorIndex.message);
@@ -340,18 +340,18 @@ class ConfigMapping {
         vectorizer:
           v.vectorizer === 'none'
             ? {
-              name: 'none',
-              config: undefined,
-            }
+                name: 'none',
+                config: undefined,
+              }
             : {
-              name: v.vectorizer,
-              config: v.moduleConfig
-                ? ({
-                  ...(v.moduleConfig[v.vectorizer] as any),
-                  vectorizeCollectionName: (v.moduleConfig[v.vectorizer] as any).vectorizeClassName,
-                } as VectorizerConfig)
-                : undefined,
-            },
+                name: v.vectorizer,
+                config: v.moduleConfig
+                  ? ({
+                      ...(v.moduleConfig[v.vectorizer] as any),
+                      vectorizeCollectionName: (v.moduleConfig[v.vectorizer] as any).vectorizeClassName,
+                    } as VectorizerConfig)
+                  : undefined,
+              },
         indexConfig: ConfigMapping.vectorIndex(v.vectorIndexConfig, v.vectorIndexType),
         indexType: ConfigMapping.vectorIndexType(v.vectorIndexType),
       },

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -46,6 +46,7 @@ import {
   PQEncoderType,
   PropertyConfig,
   PropertyVectorizerConfig,
+  QuantizerConfig,
   RQConfig,
   ReferenceConfig,
   ReplicationConfig,
@@ -213,11 +214,11 @@ export const makeVectorsConfig = <TProperties extends Properties | undefined = u
   const vectorizersConfig = Array.isArray(configVectorizers)
     ? configVectorizers
     : [
-        {
-          ...configVectorizers,
-          name: configVectorizers.name || 'default',
-        },
-      ];
+      {
+        ...configVectorizers,
+        name: configVectorizers.name || 'default',
+      },
+    ];
   vectorizersConfig.forEach((v) => {
     if (v.vectorIndex.name === 'dynamic' && !supportsDynamicVectorIndex.supports) {
       throw new WeaviateUnsupportedFeatureError(supportsDynamicVectorIndex.message);
@@ -340,18 +341,18 @@ class ConfigMapping {
         vectorizer:
           v.vectorizer === 'none'
             ? {
-                name: 'none',
-                config: undefined,
-              }
+              name: 'none',
+              config: undefined,
+            }
             : {
-                name: v.vectorizer,
-                config: v.moduleConfig
-                  ? ({
-                      ...(v.moduleConfig[v.vectorizer] as any),
-                      vectorizeCollectionName: (v.moduleConfig[v.vectorizer] as any).vectorizeClassName,
-                    } as VectorizerConfig)
-                  : undefined,
-              },
+              name: v.vectorizer,
+              config: v.moduleConfig
+                ? ({
+                  ...(v.moduleConfig[v.vectorizer] as any),
+                  vectorizeCollectionName: (v.moduleConfig[v.vectorizer] as any).vectorizeClassName,
+                } as VectorizerConfig)
+                : undefined,
+            },
         indexConfig: ConfigMapping.vectorIndex(v.vectorIndexConfig, v.vectorIndexType),
         indexType: ConfigMapping.vectorIndexType(v.vectorIndexType),
       },
@@ -479,7 +480,7 @@ class ConfigMapping {
       throw new WeaviateDeserializationError(
         'Vector index vector cache max objects was not returned by Weaviate'
       );
-    let quantizer: PQConfig | BQConfig | SQConfig | RQConfig | undefined;
+    let quantizer: QuantizerConfig | undefined;
     if (exists<Record<string, any>>(v.pq) && v.pq.enabled === true) {
       quantizer = ConfigMapping.pq(v.pq);
     } else if (exists<Record<string, any>>(v.bq) && v.bq.enabled === true) {

--- a/src/collections/configure/parsing.ts
+++ b/src/collections/configure/parsing.ts
@@ -3,6 +3,8 @@ import {
   BQConfigUpdate,
   PQConfigCreate,
   PQConfigUpdate,
+  RQConfigCreate,
+  RQConfigUpdate,
   SQConfigCreate,
   SQConfigUpdate,
 } from './types/index.js';
@@ -13,7 +15,9 @@ type QuantizerConfig =
   | BQConfigCreate
   | BQConfigUpdate
   | SQConfigCreate
-  | SQConfigUpdate;
+  | SQConfigUpdate
+  | RQConfigCreate
+  | RQConfigUpdate;
 
 export class QuantizerGuards {
   static isPQCreate(config?: QuantizerConfig): config is PQConfigCreate {
@@ -33,6 +37,12 @@ export class QuantizerGuards {
   }
   static isSQUpdate(config?: QuantizerConfig): config is SQConfigUpdate {
     return (config as SQConfigUpdate)?.type === 'sq';
+  }
+  static isRQCreate(config?: QuantizerConfig): config is RQConfigCreate {
+    return (config as RQConfigCreate)?.type === 'rq';
+  }
+  static isRQUpdate(config?: QuantizerConfig): config is RQConfigUpdate {
+    return (config as RQConfigUpdate)?.type === 'rq';
   }
 }
 

--- a/src/collections/configure/types/vectorIndex.ts
+++ b/src/collections/configure/types/vectorIndex.ts
@@ -4,6 +4,7 @@ import {
   PQConfig,
   PQEncoderDistribution,
   PQEncoderType,
+  RQConfig,
   SQConfig,
   VectorDistance,
   VectorIndexConfigDynamic,
@@ -16,6 +17,13 @@ import { RecursivePartial } from './base.js';
 export type QuantizerRecursivePartial<T> = {
   [P in keyof T]: P extends 'type' ? T[P] : RecursivePartial<T[P]> | undefined;
 };
+
+export type RQConfigCreate = QuantizerRecursivePartial<RQConfig>;
+
+export type RQConfigUpdate = {
+  rescoreLimit?: number;
+  type: 'rq';
+}
 
 export type PQConfigCreate = QuantizerRecursivePartial<PQConfig>;
 
@@ -59,7 +67,7 @@ export type VectorIndexConfigHNSWUpdate = {
   ef?: number;
   filterStrategy?: VectorIndexFilterStrategy;
   flatSearchCutoff?: number;
-  quantizer?: PQConfigUpdate | BQConfigUpdate | SQConfigUpdate;
+  quantizer?: PQConfigUpdate | BQConfigUpdate | SQConfigUpdate | RQConfigUpdate;
   vectorCacheMaxObjects?: number;
 };
 
@@ -131,7 +139,7 @@ export type VectorIndexConfigHNSWCreateOptions = {
   /** The maximum number of connections. Default is 64. */
   maxConnections?: number;
   /** The quantizer configuration to use. Use `vectorIndex.quantizer.bq` or `vectorIndex.quantizer.pq` to make one. */
-  quantizer?: PQConfigCreate | BQConfigCreate | SQConfigCreate;
+  quantizer?: PQConfigCreate | BQConfigCreate | SQConfigCreate | RQConfigCreate;
   /** Whether to skip the index. Default is false. */
   skip?: boolean;
   /** The maximum number of objects to cache in the vector cache. Default is 1000000000000. */

--- a/src/collections/configure/types/vectorIndex.ts
+++ b/src/collections/configure/types/vectorIndex.ts
@@ -23,7 +23,7 @@ export type RQConfigCreate = QuantizerRecursivePartial<RQConfig>;
 export type RQConfigUpdate = {
   rescoreLimit?: number;
   type: 'rq';
-}
+};
 
 export type PQConfigCreate = QuantizerRecursivePartial<PQConfig>;
 

--- a/src/collections/configure/vectorIndex.ts
+++ b/src/collections/configure/vectorIndex.ts
@@ -9,6 +9,8 @@ import {
   BQConfigUpdate,
   PQConfigCreate,
   PQConfigUpdate,
+  RQConfigCreate,
+  RQConfigUpdate,
   SQConfigCreate,
   SQConfigUpdate,
   VectorIndexConfigDynamicCreate,
@@ -63,10 +65,9 @@ const configure = {
       name: 'hnsw',
       config: rest
         ? {
-            ...rest,
-            distance: distanceMetric,
-            quantizer: rest.quantizer,
-          }
+          ...rest,
+          distance: distanceMetric,
+        }
         : undefined,
     };
   },
@@ -85,11 +86,11 @@ const configure = {
       name: 'dynamic',
       config: opts
         ? {
-            distance: opts.distanceMetric,
-            threshold: opts.threshold,
-            hnsw: isModuleConfig(opts.hnsw) ? opts.hnsw.config : configure.hnsw(opts.hnsw).config,
-            flat: isModuleConfig(opts.flat) ? opts.flat.config : configure.flat(opts.flat).config,
-          }
+          distance: opts.distanceMetric,
+          threshold: opts.threshold,
+          hnsw: isModuleConfig(opts.hnsw) ? opts.hnsw.config : configure.hnsw(opts.hnsw).config,
+          flat: isModuleConfig(opts.flat) ? opts.flat.config : configure.flat(opts.flat).config,
+        }
         : undefined,
     };
   },
@@ -112,11 +113,25 @@ const configure = {
       };
     },
     /**
+     * Create an object of type `RQConfigCreate` to be used when defining the quantizer configuration of a vector index.
+     *
+     * @param {number} [options.bits] TODO: WRITE DOCS
+     * @param {number} [options.rescoreLimit] The rescore limit. Default is 1000.
+     * @returns {RQConfigCreate} The object of type `RQConfigCreate`.
+     */
+    rq: (options?: { bits?: number; rescoreLimit?: number }): RQConfigCreate => {
+      return {
+        bits: options?.bits,
+        rescoreLimit: options?.rescoreLimit,
+        type: 'rq',
+      };
+    },
+    /**
      * Create an object of type `PQConfigCreate` to be used when defining the quantizer configuration of a vector index.
      *
      * @param {boolean} [options.bitCompression] Whether to use bit compression.
-     * @param {number} [options.centroids] The number of centroids[.
-     * @param {PQEncoderDistribution} ]options.encoder.distribution The encoder distribution.
+     * @param {number} [options.centroids] The number of centroids.
+     * @param {PQEncoderDistribution} [options.encoder.distribution] The encoder distribution.
      * @param {PQEncoderType} [options.encoder.type] The encoder type.
      * @param {number} [options.segments] The number of segments.
      * @param {number} [options.trainingLimit] The training limit.
@@ -137,9 +152,9 @@ const configure = {
         centroids: options?.centroids,
         encoder: options?.encoder
           ? {
-              distribution: options.encoder.distribution,
-              type: options.encoder.type,
-            }
+            distribution: options.encoder.distribution,
+            type: options.encoder.type,
+          }
           : undefined,
         segments: options?.segments,
         trainingLimit: options?.trainingLimit,
@@ -194,7 +209,7 @@ const reconfigure = {
    * @param {number} [options.ef] The ef parameter. Default is -1.
    * @param {VectorIndexFilterStrategy} [options.filterStrategy] The filter strategy. Default is 'sweeping'.
    * @param {number} [options.flatSearchCutoff] The flat search cutoff. Default is 40000.
-   * @param {PQConfigUpdate | BQConfigUpdate} [options.quantizer] The quantizer configuration to use. Use `vectorIndex.quantizer.bq` or `vectorIndex.quantizer.pq` to make one.
+   * @param {PQConfigUpdate | BQConfigUpdate | SQConfigUpdate | RQConfigUpdate} [options.quantizer] The quantizer configuration to use. Use `vectorIndex.quantizer.bq` or `vectorIndex.quantizer.pq` to make one.
    * @param {number} [options.vectorCacheMaxObjects] The maximum number of objects to cache in the vector cache. Default is 1000000000000.
    * @returns {ModuleConfig<'hnsw', VectorIndexConfigHNSWUpdate>} The configuration object.
    */
@@ -205,7 +220,7 @@ const reconfigure = {
     ef?: number;
     filterStrategy?: VectorIndexFilterStrategy;
     flatSearchCutoff?: number;
-    quantizer?: PQConfigUpdate | BQConfigUpdate | SQConfigUpdate;
+    quantizer?: PQConfigUpdate | BQConfigUpdate | SQConfigUpdate | RQConfigUpdate;
     vectorCacheMaxObjects?: number;
   }): ModuleConfig<'hnsw', VectorIndexConfigHNSWUpdate> => {
     return {
@@ -225,12 +240,28 @@ const reconfigure = {
      *
      * @param {boolean} [options.cache] Whether to cache the quantizer.
      * @param {number} [options.rescoreLimit] The new rescore limit.
-     * @returns {BQConfigCreate} The configuration object.
+     * @returns {BQConfigUpdate} The configuration object.
      */
     bq: (options?: { cache?: boolean; rescoreLimit?: number }): BQConfigUpdate => {
       return {
         ...options,
         type: 'bq',
+      };
+    },
+    /**
+     * Create an object of type `RQConfigUpdate` to be used when updating the quantizer configuration of a vector index.
+     *
+     * NOTE: If the vector index already has a quantizer configured, you cannot change its quantizer type; only its values.
+     * So if you want to change the quantizer type, you must recreate the collection.
+     *
+     * @param {number} [options.bits] TODO: WRITE DOCS
+     * @param {number} [options.rescoreLimit] The new rescore limit.
+     * @returns {BQConfigUpdate} The configuration object.
+     */
+    rq: (options?: { rescoreLimit?: number }): RQConfigUpdate => {
+      return {
+        ...options,
+        type: 'rq',
       };
     },
     /**
@@ -259,9 +290,9 @@ const reconfigure = {
         encoder:
           pqEncoderDistribution || pqEncoderType
             ? {
-                distribution: pqEncoderDistribution,
-                type: pqEncoderType,
-              }
+              distribution: pqEncoderDistribution,
+              type: pqEncoderType,
+            }
             : undefined,
         type: 'pq',
       };

--- a/src/collections/configure/vectorIndex.ts
+++ b/src/collections/configure/vectorIndex.ts
@@ -65,9 +65,9 @@ const configure = {
       name: 'hnsw',
       config: rest
         ? {
-          ...rest,
-          distance: distanceMetric,
-        }
+            ...rest,
+            distance: distanceMetric,
+          }
         : undefined,
     };
   },
@@ -86,11 +86,11 @@ const configure = {
       name: 'dynamic',
       config: opts
         ? {
-          distance: opts.distanceMetric,
-          threshold: opts.threshold,
-          hnsw: isModuleConfig(opts.hnsw) ? opts.hnsw.config : configure.hnsw(opts.hnsw).config,
-          flat: isModuleConfig(opts.flat) ? opts.flat.config : configure.flat(opts.flat).config,
-        }
+            distance: opts.distanceMetric,
+            threshold: opts.threshold,
+            hnsw: isModuleConfig(opts.hnsw) ? opts.hnsw.config : configure.hnsw(opts.hnsw).config,
+            flat: isModuleConfig(opts.flat) ? opts.flat.config : configure.flat(opts.flat).config,
+          }
         : undefined,
     };
   },
@@ -115,7 +115,7 @@ const configure = {
     /**
      * Create an object of type `RQConfigCreate` to be used when defining the quantizer configuration of a vector index.
      *
-     * @param {number} [options.bits] TODO: WRITE DOCS
+     * @param {number} [options.bits] Number of bits to user per vector element.
      * @param {number} [options.rescoreLimit] The rescore limit. Default is 1000.
      * @returns {RQConfigCreate} The object of type `RQConfigCreate`.
      */
@@ -152,9 +152,9 @@ const configure = {
         centroids: options?.centroids,
         encoder: options?.encoder
           ? {
-            distribution: options.encoder.distribution,
-            type: options.encoder.type,
-          }
+              distribution: options.encoder.distribution,
+              type: options.encoder.type,
+            }
           : undefined,
         segments: options?.segments,
         trainingLimit: options?.trainingLimit,
@@ -254,7 +254,6 @@ const reconfigure = {
      * NOTE: If the vector index already has a quantizer configured, you cannot change its quantizer type; only its values.
      * So if you want to change the quantizer type, you must recreate the collection.
      *
-     * @param {number} [options.bits] TODO: WRITE DOCS
      * @param {number} [options.rescoreLimit] The new rescore limit.
      * @returns {BQConfigUpdate} The configuration object.
      */
@@ -290,9 +289,9 @@ const reconfigure = {
         encoder:
           pqEncoderDistribution || pqEncoderType
             ? {
-              distribution: pqEncoderDistribution,
-              type: pqEncoderType,
-            }
+                distribution: pqEncoderDistribution,
+                type: pqEncoderType,
+              }
             : undefined,
         type: 'pq',
       };

--- a/src/collections/data/integration.test.ts
+++ b/src/collections/data/integration.test.ts
@@ -31,15 +31,11 @@ describe('Testing of the collection.data methods with a single target reference'
   const toBeDeletedID = v4();
   const nonExistingID = v4();
 
-  afterAll(() => {
-    return client.collections.delete(collectionName).catch((err) => {
-      console.error(err);
-      throw err;
-    });
-  });
-
   beforeAll(async () => {
     client = await weaviate.connectToLocal();
+
+    await client.collections.delete(collectionName);
+
     collection = client.collections.use(collectionName);
     await client.collections
       .create<TestCollectionData>({
@@ -344,25 +340,43 @@ describe('Testing of the collection.data methods with a single target reference'
   });
 
   it('should be able to delete a reference between two objects', () => {
-    return Promise.all([
-      collection.data.referenceDelete({
-        fromProperty: 'ref',
-        fromUuid: toBeUpdatedID,
-        to: Reference.to(existingID),
-      }),
-      collection.data.referenceDelete({
-        fromProperty: 'ref',
-        fromUuid: toBeUpdatedID,
-        to: toBeUpdatedID,
-      }),
-      collection.data.referenceDelete({
-        fromProperty: 'ref',
-        fromUuid: toBeUpdatedID,
-        to: [toBeReplacedID],
-      }),
+    // Insert 2 objects
+    return collection.data.insertMany([
+      { testProp: "refLeft" }, { testProp: "refRight" },
     ])
-      .then(() =>
-        collection.query.fetchObjectById(toBeUpdatedID, {
+      // Create a reference between them
+      .then(inserted => collection.data.referenceAdd({
+        fromProperty: 'ref',
+        fromUuid: inserted.allResponses[0] as string,
+        to: inserted.allResponses[1] as string,
+      }).then(() => inserted))
+
+      // Assert that the reference exists
+      .then(inserted =>
+        collection.query.fetchObjectById(inserted.allResponses[0] as string, {
+          returnReferences: [{ linkOn: 'ref' }],
+        })
+          .then((obj) => {
+            expect(obj).not.toBeNull();
+            expect(obj?.references?.ref?.objects).toHaveLength(1);
+
+            // Propagate the list of inserted IDs
+            return Promise.resolve(inserted);
+          })
+      )
+
+      // Delete reference between them
+      .then(inserted =>
+        collection.data.referenceDelete({
+          fromProperty: 'ref',
+          fromUuid: inserted.allResponses[0] as string,
+          to: inserted.allResponses[1] as string,
+        })
+          .then(() => inserted))
+
+      // Assert the reference does not exist
+      .then(inserted =>
+        collection.query.fetchObjectById(inserted.allResponses[0] as string, {
           returnReferences: [{ linkOn: 'ref' }],
         })
       )

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -149,11 +149,11 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
         const configs = config.vectorizers
           ? makeLegacyVectorizer({ ...config.vectorizers, name: undefined })
           : {
-            vectorizer: undefined,
-            moduleConfig: undefined,
-            vectorIndexConfig: undefined,
-            vectorIndexType: undefined,
-          };
+              vectorizer: undefined,
+              moduleConfig: undefined,
+              vectorIndexConfig: undefined,
+              vectorIndexType: undefined,
+            };
         schema = {
           ...schema,
           moduleConfig: {
@@ -177,7 +177,7 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
       await new ClassCreator(connection).withClass(schema).do();
       return collection<TProperties, TName>(connection, name, dbVersionSupport);
     },
-    createFromSchema: async function(config: WeaviateClass) {
+    createFromSchema: async function (config: WeaviateClass) {
       const { class: name } = await new ClassCreator(connection).withClass(config).do();
       return collection<Properties, string>(connection, name as string, dbVersionSupport);
     },

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -149,11 +149,11 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
         const configs = config.vectorizers
           ? makeLegacyVectorizer({ ...config.vectorizers, name: undefined })
           : {
-              vectorizer: undefined,
-              moduleConfig: undefined,
-              vectorIndexConfig: undefined,
-              vectorIndexType: undefined,
-            };
+            vectorizer: undefined,
+            moduleConfig: undefined,
+            vectorIndexConfig: undefined,
+            vectorIndexType: undefined,
+          };
         schema = {
           ...schema,
           moduleConfig: {
@@ -177,7 +177,7 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
       await new ClassCreator(connection).withClass(schema).do();
       return collection<TProperties, TName>(connection, name, dbVersionSupport);
     },
-    createFromSchema: async function (config: WeaviateClass) {
+    createFromSchema: async function(config: WeaviateClass) {
       const { class: name } = await new ClassCreator(connection).withClass(config).do();
       return collection<Properties, string>(connection, name as string, dbVersionSupport);
     },

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -734,19 +734,19 @@ async function newClassObject(className: string, client: WeaviateClient): Promis
       maxConnections: 64,
       multivector: (await isVer(client, 29, 0))
         ? {
-            aggregation: 'maxSim',
-            enabled: false,
-            ...((await isVer(client, 31, 0))
-              ? {
-                  muvera: {
-                    enabled: false,
-                    dprojections: 16,
-                    ksim: 4,
-                    repetitions: 10,
-                  },
-                }
-              : {}),
-          }
+          aggregation: 'maxSim',
+          enabled: false,
+          ...((await isVer(client, 31, 0))
+            ? {
+              muvera: {
+                enabled: false,
+                dprojections: 16,
+                ksim: 4,
+                repetitions: 10,
+              },
+            }
+            : {}),
+        }
         : undefined,
       pq: {
         bitCompression: false,
@@ -764,17 +764,17 @@ async function newClassObject(className: string, client: WeaviateClient): Promis
       },
       sq: (await isVer(client, 26, 0))
         ? {
-            enabled: false,
-            rescoreLimit: 20,
-            trainingLimit: 100000,
-          }
+          enabled: false,
+          rescoreLimit: 20,
+          trainingLimit: 100000,
+        }
         : undefined,
       rq: (await isVer(client, 32, 0))
         ? {
-            enabled: false,
-            bits: 8,
-            rescoreLimit: 20,
-          }
+          enabled: false,
+          bits: 8,
+          rescoreLimit: 20,
+        }
         : undefined,
       skip: false,
       efConstruction: 128,

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -104,8 +104,8 @@ describe('schema', () => {
       .withProperty(prop)
       .do()
       .catch((err: Error) => {
-        expect(err.message).toEqual(
-          'The request to Weaviate failed with status code: 422 and message: {"error":[{"message":"Tokenization is not allowed for data type \'int[]\'"}]}'
+        expect(err.message.toLowerCase()).toEqual(
+          'The request to Weaviate failed with status code: 422 and message: {"error":[{"message":"tokenization is not allowed for data type \'int[]\'"}]}'.toLowerCase()
         );
       });
   });
@@ -736,6 +736,16 @@ async function newClassObject(className: string, client: WeaviateClient): Promis
         ? {
             aggregation: 'maxSim',
             enabled: false,
+            ...((await isVer(client, 31, 0))
+              ? {
+                  muvera: {
+                    enabled: false,
+                    dprojections: 16,
+                    ksim: 4,
+                    repetitions: 10,
+                  },
+                }
+              : {}),
           }
         : undefined,
       pq: {
@@ -757,6 +767,13 @@ async function newClassObject(className: string, client: WeaviateClient): Promis
             enabled: false,
             rescoreLimit: 20,
             trainingLimit: 100000,
+          }
+        : undefined,
+      rq: (await isVer(client, 32, 0))
+        ? {
+            enabled: false,
+            bits: 8,
+            rescoreLimit: 20,
           }
         : undefined,
       skip: false,

--- a/src/schema/journey.test.ts
+++ b/src/schema/journey.test.ts
@@ -734,19 +734,19 @@ async function newClassObject(className: string, client: WeaviateClient): Promis
       maxConnections: 64,
       multivector: (await isVer(client, 29, 0))
         ? {
-          aggregation: 'maxSim',
-          enabled: false,
-          ...((await isVer(client, 31, 0))
-            ? {
-              muvera: {
-                enabled: false,
-                dprojections: 16,
-                ksim: 4,
-                repetitions: 10,
-              },
-            }
-            : {}),
-        }
+            aggregation: 'maxSim',
+            enabled: false,
+            ...((await isVer(client, 31, 0))
+              ? {
+                  muvera: {
+                    enabled: false,
+                    dprojections: 16,
+                    ksim: 4,
+                    repetitions: 10,
+                  },
+                }
+              : {}),
+          }
         : undefined,
       pq: {
         bitCompression: false,
@@ -764,17 +764,17 @@ async function newClassObject(className: string, client: WeaviateClient): Promis
       },
       sq: (await isVer(client, 26, 0))
         ? {
-          enabled: false,
-          rescoreLimit: 20,
-          trainingLimit: 100000,
-        }
+            enabled: false,
+            rescoreLimit: 20,
+            trainingLimit: 100000,
+          }
         : undefined,
       rq: (await isVer(client, 32, 0))
         ? {
-          enabled: false,
-          bits: 8,
-          rescoreLimit: 20,
-        }
+            enabled: false,
+            bits: 8,
+            rescoreLimit: 20,
+          }
         : undefined,
       skip: false,
       efConstruction: 128,


### PR DESCRIPTION
RQ can be configured so:

```ts
weaviate.configure.vectorIndex.quantizer.rq({ bits: 6, rescoreLimit: 20 });
```

When updating, it is only possible to update `rescoreLimit`.