### PR TITLE
feat: Collection aliasing

### DIFF
--- a/src/alias/index.ts
+++ b/src/alias/index.ts
@@ -1,6 +1,6 @@
 import { ConnectionREST } from '../index.js';
 import { WeaviateAlias, WeaviateAliasResponse } from '../openapi/types.js';
-import { Alias, AliasListAllOpts, CreateAliasArgs, UpdateAliasArgs } from './types.js';
+import { Alias, AliasListAllOptions, CreateAliasArgs, UpdateAliasArgs } from './types.js';
 
 export interface Aliases {
   /**
@@ -21,7 +21,7 @@ export interface Aliases {
    * @param {string | undefined} [opts.collection] Get all aliases defined for this collection.
    * @returns {Promise<Alias[] | undefined>} An array of aliases.
    */
-  listAll: (opts?: AliasListAllOpts) => Promise<Alias[] | undefined>;
+  listAll: (opts?: AliasListAllOptions) => Promise<Alias[] | undefined>;
 
   /**
    * Get information about an alias.
@@ -56,7 +56,7 @@ const alias = (connection: ConnectionREST): Aliases => {
   return {
     create: (args: CreateAliasArgs) =>
       connection.postReturn<WeaviateAlias, void>(`/aliases/`, { ...args, class: args.collection }),
-    listAll: (opts?: AliasListAllOpts) =>
+    listAll: (opts?: AliasListAllOptions) =>
       connection
         .get<WeaviateAliasResponse>(
           `/aliases${opts?.collection !== undefined ? '/?class=' + opts.collection : ''}`

--- a/src/alias/index.ts
+++ b/src/alias/index.ts
@@ -3,10 +3,52 @@ import { WeaviateAlias, WeaviateAliasResponse } from '../openapi/types.js';
 import { Alias, CreateAliasInput, UpdateAliasInput } from './types.js';
 
 export interface Aliases {
+  /**
+   * Create alias for a collection.
+   *
+   * The collection must exist prior to aliasing it.
+   * One alias cannot be created for multiple collections simultaneously.
+   *
+   * @param {string} [opt.collection] Original collection name.
+   * @param {string} [opt.alias] Alias for collection.
+   * @returns {Promise<void>} Awaitable promise.
+   * */
   create: (opt: CreateAliasInput) => Promise<void>;
+
+  /**
+   * List all aliases defined in the schema.
+   *
+   * @param {string | undefined} collection Get all aliases defined for this collection.
+   * @returns {Promise<Alias[] | undefined>} An array of aliases.
+   */
   listAll: (collection?: string) => Promise<Alias[] | undefined>;
+
+  /**
+   * Get information about an alias.
+   *
+   * @param {string} alias Alias to fetch.
+   * @return {Promise<Alias>} Alias definition.
+   */
   get: (alias: string) => Promise<Alias>;
+
+  /**
+   * Replace target collection the alias points to.
+   *
+   * To change the alias that points to the collection,
+   * delete the alias and create a new one.
+   *
+   * @param {string} [opt.alias] Alias to update.
+   * @param {string} [opt.collection] New collection the alias should point to.
+   * @return {Promise<void>} Awaitable promise.
+   */
   update: (opt: UpdateAliasInput) => Promise<void>;
+
+  /**
+   * Delete a collection alias.
+   *
+   * @param {string} alias Alias definition to delete.
+   * @return {Promise<void>} Awaitable promise.
+   */
   delete: (alias: string) => Promise<void>;
 }
 

--- a/src/alias/index.ts
+++ b/src/alias/index.ts
@@ -1,0 +1,31 @@
+import { ConnectionREST } from "../index.js";
+import { WeaviateAlias, WeaviateAliasResponse } from "../openapi/types.js";
+import { Alias, CreateAliasInput, UpdateAliasInput } from "./types.js";
+
+export interface Aliases {
+  create: (opt: CreateAliasInput) => Promise<void>;
+  listAll: (collection?: string) => Promise<Alias[] | undefined>
+  get: (alias: string) => Promise<Alias>;
+  update: (opt: UpdateAliasInput) => Promise<void>;
+  delete: (alias: string) => Promise<void>;
+}
+
+const alias = (connection: ConnectionREST): Aliases => {
+  return {
+    create: (opt: CreateAliasInput) => connection.postReturn<WeaviateAlias, void>(
+      `/aliases/`, { ...opt, class: opt.collection }),
+    listAll: (collection?: string) => connection.get<WeaviateAliasResponse>(
+      `/aliases${collection !== undefined ? "/?class=" + collection : ""}`)
+      .then(aliases => aliases.aliases !== undefined
+        ? aliases.aliases.map(alias => ({ alias: alias.alias, collection: alias.class }))
+        : []),
+    get: (alias: string) => connection.get<WeaviateAlias>(`/aliases/${alias}`)
+      .then(alias => ({ alias: alias.alias!, collection: alias.class! })),
+    update: (opt: UpdateAliasInput) => connection.put(
+      `/aliases/${opt.alias}`, { class: opt.newTargetCollection }),
+    delete: (alias: string) => connection.delete(
+      `/aliases/${alias}`, null),
+  }
+}
+
+export default alias;

--- a/src/alias/index.ts
+++ b/src/alias/index.ts
@@ -1,10 +1,10 @@
-import { ConnectionREST } from "../index.js";
-import { WeaviateAlias, WeaviateAliasResponse } from "../openapi/types.js";
-import { Alias, CreateAliasInput, UpdateAliasInput } from "./types.js";
+import { ConnectionREST } from '../index.js';
+import { WeaviateAlias, WeaviateAliasResponse } from '../openapi/types.js';
+import { Alias, CreateAliasInput, UpdateAliasInput } from './types.js';
 
 export interface Aliases {
   create: (opt: CreateAliasInput) => Promise<void>;
-  listAll: (collection?: string) => Promise<Alias[] | undefined>
+  listAll: (collection?: string) => Promise<Alias[] | undefined>;
   get: (alias: string) => Promise<Alias>;
   update: (opt: UpdateAliasInput) => Promise<void>;
   delete: (alias: string) => Promise<void>;
@@ -12,20 +12,24 @@ export interface Aliases {
 
 const alias = (connection: ConnectionREST): Aliases => {
   return {
-    create: (opt: CreateAliasInput) => connection.postReturn<WeaviateAlias, void>(
-      `/aliases/`, { ...opt, class: opt.collection }),
-    listAll: (collection?: string) => connection.get<WeaviateAliasResponse>(
-      `/aliases${collection !== undefined ? "/?class=" + collection : ""}`)
-      .then(aliases => aliases.aliases !== undefined
-        ? aliases.aliases.map(alias => ({ alias: alias.alias, collection: alias.class }))
-        : []),
-    get: (alias: string) => connection.get<WeaviateAlias>(`/aliases/${alias}`)
-      .then(alias => ({ alias: alias.alias!, collection: alias.class! })),
-    update: (opt: UpdateAliasInput) => connection.put(
-      `/aliases/${opt.alias}`, { class: opt.newTargetCollection }),
-    delete: (alias: string) => connection.delete(
-      `/aliases/${alias}`, null),
-  }
-}
+    create: (opt: CreateAliasInput) =>
+      connection.postReturn<WeaviateAlias, void>(`/aliases/`, { ...opt, class: opt.collection }),
+    listAll: (collection?: string) =>
+      connection
+        .get<WeaviateAliasResponse>(`/aliases${collection !== undefined ? '/?class=' + collection : ''}`)
+        .then((aliases) =>
+          aliases.aliases !== undefined
+            ? aliases.aliases.map((alias) => ({ alias: alias.alias, collection: alias.class }))
+            : []
+        ),
+    get: (alias: string) =>
+      connection
+        .get<WeaviateAlias>(`/aliases/${alias}`)
+        .then((alias) => ({ alias: alias.alias!, collection: alias.class! })),
+    update: (opt: UpdateAliasInput) =>
+      connection.put(`/aliases/${opt.alias}`, { class: opt.newTargetCollection }),
+    delete: (alias: string) => connection.delete(`/aliases/${alias}`, null),
+  };
+};
 
 export default alias;

--- a/src/alias/index.ts
+++ b/src/alias/index.ts
@@ -1,6 +1,6 @@
 import { ConnectionREST } from '../index.js';
 import { WeaviateAlias, WeaviateAliasResponse } from '../openapi/types.js';
-import { Alias, CreateAliasInput, UpdateAliasInput } from './types.js';
+import { Alias, AliasListAllOpts, CreateAliasArgs, UpdateAliasArgs } from './types.js';
 
 export interface Aliases {
   /**
@@ -9,19 +9,19 @@ export interface Aliases {
    * The collection must exist prior to aliasing it.
    * One alias cannot be created for multiple collections simultaneously.
    *
-   * @param {string} [opt.collection] Original collection name.
-   * @param {string} [opt.alias] Alias for collection.
+   * @param {string} args.collection Original collection name.
+   * @param {string} args.alias Alias for collection.
    * @returns {Promise<void>} Awaitable promise.
    * */
-  create: (opt: CreateAliasInput) => Promise<void>;
+  create: (args: CreateAliasArgs) => Promise<void>;
 
   /**
    * List all aliases defined in the schema.
    *
-   * @param {string | undefined} collection Get all aliases defined for this collection.
+   * @param {string | undefined} [opts.collection] Get all aliases defined for this collection.
    * @returns {Promise<Alias[] | undefined>} An array of aliases.
    */
-  listAll: (collection?: string) => Promise<Alias[] | undefined>;
+  listAll: (opts?: AliasListAllOpts) => Promise<Alias[] | undefined>;
 
   /**
    * Get information about an alias.
@@ -37,11 +37,11 @@ export interface Aliases {
    * To change the alias that points to the collection,
    * delete the alias and create a new one.
    *
-   * @param {string} [opt.alias] Alias to update.
-   * @param {string} [opt.collection] New collection the alias should point to.
+   * @param {string} args.alias Alias to update.
+   * @param {string} args.collection New collection the alias should point to.
    * @return {Promise<void>} Awaitable promise.
    */
-  update: (opt: UpdateAliasInput) => Promise<void>;
+  update: (args: UpdateAliasArgs) => Promise<void>;
 
   /**
    * Delete a collection alias.
@@ -54,11 +54,13 @@ export interface Aliases {
 
 const alias = (connection: ConnectionREST): Aliases => {
   return {
-    create: (opt: CreateAliasInput) =>
-      connection.postReturn<WeaviateAlias, void>(`/aliases/`, { ...opt, class: opt.collection }),
-    listAll: (collection?: string) =>
+    create: (args: CreateAliasArgs) =>
+      connection.postReturn<WeaviateAlias, void>(`/aliases/`, { ...args, class: args.collection }),
+    listAll: (opts?: AliasListAllOpts) =>
       connection
-        .get<WeaviateAliasResponse>(`/aliases${collection !== undefined ? '/?class=' + collection : ''}`)
+        .get<WeaviateAliasResponse>(
+          `/aliases${opts?.collection !== undefined ? '/?class=' + opts.collection : ''}`
+        )
         .then((aliases) =>
           aliases.aliases !== undefined
             ? aliases.aliases.map((alias) => ({ alias: alias.alias, collection: alias.class }))
@@ -68,8 +70,8 @@ const alias = (connection: ConnectionREST): Aliases => {
       connection
         .get<WeaviateAlias>(`/aliases/${alias}`)
         .then((alias) => ({ alias: alias.alias!, collection: alias.class! })),
-    update: (opt: UpdateAliasInput) =>
-      connection.put(`/aliases/${opt.alias}`, { class: opt.newTargetCollection }),
+    update: (args: UpdateAliasArgs) =>
+      connection.put(`/aliases/${args.alias}`, { class: args.newTargetCollection }),
     delete: (alias: string) => connection.delete(`/aliases/${alias}`, null),
   };
 };

--- a/src/alias/journey.test.ts
+++ b/src/alias/journey.test.ts
@@ -1,0 +1,53 @@
+import { assert } from 'console';
+import weaviate, {
+  WeaviateClient,
+} from '..';
+import { requireAtLeast } from '../../test/version';
+import { Alias } from './types';
+
+requireAtLeast(1, 32, 0).describe("manages collection aliases", () => {
+  let client: WeaviateClient;
+  const collectionsWithAliases = ["PaulHewson", "GeorgeBarnes", "ColsonBaker"];
+
+  beforeAll(async () => {
+    client = await weaviate.connectToLocal();
+    await Promise.all(collectionsWithAliases.map(client.collections.delete));
+    await Promise.all(collectionsWithAliases.map(name => client.collections.create({ name })));
+  });
+
+  it("should create alias", () => {
+    return Promise.all([
+      client.alias.create({ collection: "PaulHewson", alias: "Bono" }),
+      client.alias.create({ collection: "GeorgeBarnes", alias: "MachineGunKelly" }),
+    ])
+      .then(() => client.alias.listAll())
+      .then(aliases => {
+        expect(aliases).not.toBeUndefined();
+        expect(aliases).toHaveLength(2);
+        expect(aliases).toEqual<Alias[]>([
+          { collection: "PaulHewson", alias: "Bono" },
+          { collection: "GeorgeBarnes", alias: "MachineGunKelly" },
+        ]);
+      });
+  })
+
+  it("should update alias", () => {
+    return client.alias.update({ alias: "MachineGunKelly", newTargetCollection: "ColsonBaker" })
+      .then(() => client.alias.get("MachineGunKelly"))
+      .then(alias => {
+        expect(alias.collection).toEqual("ColsonBaker");
+      })
+  })
+
+  it("should delete alias Bono", () => {
+    return client.alias.delete("Bono")
+      .then(() => client.alias.listAll("PaulHewson"))
+      .then(aliases => expect(aliases).toEqual([]));
+  })
+
+  it("should delete alias MachineGunKelly", () => {
+    return client.alias.delete("MachineGunKelly")
+      .then(() => client.alias.listAll("ColsonBaker"))
+      .then(aliases => expect(aliases).toEqual([]));
+  })
+})

--- a/src/alias/journey.test.ts
+++ b/src/alias/journey.test.ts
@@ -1,53 +1,53 @@
-import { assert } from 'console';
-import weaviate, {
-  WeaviateClient,
-} from '..';
+import weaviate, { WeaviateClient } from '..';
 import { requireAtLeast } from '../../test/version';
 import { Alias } from './types';
 
-requireAtLeast(1, 32, 0).describe("manages collection aliases", () => {
+requireAtLeast(1, 32, 0).describe('manages collection aliases', () => {
   let client: WeaviateClient;
-  const collectionsWithAliases = ["PaulHewson", "GeorgeBarnes", "ColsonBaker"];
+  const collectionsWithAliases = ['PaulHewson', 'GeorgeBarnes', 'ColsonBaker'];
 
   beforeAll(async () => {
     client = await weaviate.connectToLocal();
     await Promise.all(collectionsWithAliases.map(client.collections.delete));
-    await Promise.all(collectionsWithAliases.map(name => client.collections.create({ name })));
+    await Promise.all(collectionsWithAliases.map((name) => client.collections.create({ name })));
   });
 
-  it("should create alias", () => {
+  it('should create alias', () => {
     return Promise.all([
-      client.alias.create({ collection: "PaulHewson", alias: "Bono" }),
-      client.alias.create({ collection: "GeorgeBarnes", alias: "MachineGunKelly" }),
+      client.alias.create({ collection: 'PaulHewson', alias: 'Bono' }),
+      client.alias.create({ collection: 'GeorgeBarnes', alias: 'MachineGunKelly' }),
     ])
       .then(() => client.alias.listAll())
-      .then(aliases => {
+      .then((aliases) => {
         expect(aliases).not.toBeUndefined();
         expect(aliases).toHaveLength(2);
         expect(aliases).toEqual<Alias[]>([
-          { collection: "PaulHewson", alias: "Bono" },
-          { collection: "GeorgeBarnes", alias: "MachineGunKelly" },
+          { collection: 'PaulHewson', alias: 'Bono' },
+          { collection: 'GeorgeBarnes', alias: 'MachineGunKelly' },
         ]);
       });
-  })
+  });
 
-  it("should update alias", () => {
-    return client.alias.update({ alias: "MachineGunKelly", newTargetCollection: "ColsonBaker" })
-      .then(() => client.alias.get("MachineGunKelly"))
-      .then(alias => {
-        expect(alias.collection).toEqual("ColsonBaker");
-      })
-  })
+  it('should update alias', () => {
+    return client.alias
+      .update({ alias: 'MachineGunKelly', newTargetCollection: 'ColsonBaker' })
+      .then(() => client.alias.get('MachineGunKelly'))
+      .then((alias) => {
+        expect(alias.collection).toEqual('ColsonBaker');
+      });
+  });
 
-  it("should delete alias Bono", () => {
-    return client.alias.delete("Bono")
-      .then(() => client.alias.listAll("PaulHewson"))
-      .then(aliases => expect(aliases).toEqual([]));
-  })
+  it('should delete alias Bono', () => {
+    return client.alias
+      .delete('Bono')
+      .then(() => client.alias.listAll('PaulHewson'))
+      .then((aliases) => expect(aliases).toEqual([]));
+  });
 
-  it("should delete alias MachineGunKelly", () => {
-    return client.alias.delete("MachineGunKelly")
-      .then(() => client.alias.listAll("ColsonBaker"))
-      .then(aliases => expect(aliases).toEqual([]));
-  })
-})
+  it('should delete alias MachineGunKelly', () => {
+    return client.alias
+      .delete('MachineGunKelly')
+      .then(() => client.alias.listAll('ColsonBaker'))
+      .then((aliases) => expect(aliases).toEqual([]));
+  });
+});

--- a/src/alias/journey.test.ts
+++ b/src/alias/journey.test.ts
@@ -40,14 +40,14 @@ requireAtLeast(1, 32, 0).describe('manages collection aliases', () => {
   it('should delete alias Bono', () => {
     return client.alias
       .delete('Bono')
-      .then(() => client.alias.listAll('PaulHewson'))
+      .then(() => client.alias.listAll({ collection: 'PaulHewson' }))
       .then((aliases) => expect(aliases).toEqual([]));
   });
 
   it('should delete alias MachineGunKelly', () => {
     return client.alias
       .delete('MachineGunKelly')
-      .then(() => client.alias.listAll('ColsonBaker'))
+      .then(() => client.alias.listAll({ collection: 'ColsonBaker' }))
       .then((aliases) => expect(aliases).toEqual([]));
   });
 });

--- a/src/alias/types.ts
+++ b/src/alias/types.ts
@@ -3,12 +3,16 @@ export type Alias = {
   alias: string;
 };
 
-export type CreateAliasInput = {
+export type CreateAliasArgs = {
   collection: string;
   alias: string;
 };
 
-export type UpdateAliasInput = {
+export type UpdateAliasArgs = {
   newTargetCollection: string;
   alias: string;
+};
+
+export type AliasListAllOpts = {
+  collection?: string | undefined;
 };

--- a/src/alias/types.ts
+++ b/src/alias/types.ts
@@ -1,0 +1,14 @@
+export type Alias = {
+  collection: string;
+  alias: string;
+}
+
+export type CreateAliasInput = {
+  collection: string;
+  alias: string;
+};
+
+export type UpdateAliasInput = {
+  newTargetCollection: string;
+  alias: string;
+};

--- a/src/alias/types.ts
+++ b/src/alias/types.ts
@@ -1,7 +1,7 @@
 export type Alias = {
   collection: string;
   alias: string;
-}
+};
 
 export type CreateAliasInput = {
   collection: string;

--- a/src/alias/types.ts
+++ b/src/alias/types.ts
@@ -13,6 +13,6 @@ export type UpdateAliasArgs = {
   alias: string;
 };
 
-export type AliasListAllOpts = {
+export type AliasListAllOptions = {
   collection?: string | undefined;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,10 @@ import { LiveChecker, OpenidConfigurationGetter, ReadyChecker } from './misc/ind
 
 import weaviateV2 from './v2/index.js';
 
+import alias, { Aliases } from './alias/index.js';
 import filter from './collections/filters/index.js';
 import { ConsistencyLevel } from './data/replication.js';
 import users, { Users } from './users/index.js';
-import alias, { Aliases } from './alias/index.js';
 
 export type ProtocolParams = {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import weaviateV2 from './v2/index.js';
 import filter from './collections/filters/index.js';
 import { ConsistencyLevel } from './data/replication.js';
 import users, { Users } from './users/index.js';
+import alias, { Aliases } from './alias/index.js';
 
 export type ProtocolParams = {
   /**
@@ -102,6 +103,7 @@ export type ClientParams = {
 };
 
 export interface WeaviateClient {
+  alias: Aliases;
   backup: Backup;
   cluster: Cluster;
   collections: Collections;
@@ -224,6 +226,7 @@ async function client(params: ClientParams): Promise<WeaviateClient> {
   });
 
   const ifc: WeaviateClient = {
+    alias: alias(connection),
     backup: backup(connection),
     cluster: cluster(connection),
     collections: collections(connection, dbVersionSupport),

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -74,3 +74,8 @@ export type WeaviateUserType = definitions['UserTypeOutput'];
 export type WeaviateUserTypeInternal = definitions['UserTypeInput'];
 export type WeaviateUserTypeDB = definitions['DBUserInfo']['dbUserType'];
 export type WeaviateAssignedUser = operations['getUsersForRole']['responses']['200']['schema'][0];
+// Alias
+export type WeaviateAlias = definitions['Alias'];
+export type WeaviateAliasResponse = {
+  aliases?: Required<Exclude<definitions['AliasResponse']['aliases'], undefined>[0]>[] | undefined;
+};

--- a/src/roles/index.ts
+++ b/src/roles/index.ts
@@ -154,10 +154,8 @@ export const permissions = {
   /**
    * Create a set of permissions specific to Weaviate's collection aliasing functionality.
    *
-   * For all collections, provide the `collection` argument as `'*'`.
-   *
-   * @param {string | string[]} [args.alias] Aliases to create permissions for.
-   * @returns {BackupsPermission[]} The permissions for the specified collections.
+   * @param {string | string[]} [args.alias] Aliases that will be associated with these permissions.
+   * @returns {AliasPermission[]} The permissions for the specified aliases.
    */
   aliases: (args: {
     alias: string | string[];

--- a/src/roles/index.ts
+++ b/src/roles/index.ts
@@ -159,14 +159,17 @@ export const permissions = {
    */
   aliases: (args: {
     alias: string | string[];
+    collection: string | string[];
     create?: boolean;
     read?: boolean;
     update?: boolean;
     delete?: boolean;
   }): AliasPermission[] => {
     const aliases = Array.isArray(args.alias) ? args.alias : [args.alias];
-    return aliases.flatMap((alias) => {
-      const out: AliasPermission = { alias, actions: [] };
+    const collections = Array.isArray(args.collection) ? args.collection : [args.collection];
+    const combinations = aliases.flatMap((alias) => collections.map((collection) => ({ alias, collection })));
+    return combinations.map(({ collection, alias }) => {
+      const out: AliasPermission = { alias, collection, actions: [] };
       if (args.create) out.actions.push('create_aliases');
       if (args.read) out.actions.push('read_aliases');
       if (args.update) out.actions.push('update_aliases');

--- a/src/roles/index.ts
+++ b/src/roles/index.ts
@@ -5,6 +5,7 @@ import {
   Role as WeaviateRole,
 } from '../openapi/types.js';
 import {
+  AliasPermission,
   BackupsPermission,
   ClusterPermission,
   CollectionsPermission,
@@ -150,6 +151,32 @@ const roles = (connection: ConnectionREST): Roles => {
 };
 
 export const permissions = {
+  /**
+   * Create a set of permissions specific to Weaviate's collection aliasing functionality.
+   *
+   * For all collections, provide the `collection` argument as `'*'`.
+   *
+   * @param {string | string[]} [args.alias] Aliases to create permissions for.
+   * @returns {BackupsPermission[]} The permissions for the specified collections.
+   */
+  aliases: (args: {
+    alias: string | string[];
+    create?: boolean;
+    read?: boolean;
+    update?: boolean;
+    delete?: boolean;
+  }): AliasPermission[] => {
+    const aliases = Array.isArray(args.alias) ? args.alias : [args.alias];
+    return aliases.flatMap((alias) => {
+      const out: AliasPermission = { alias, actions: [] };
+      if (args.create) out.actions.push('create_aliases');
+      if (args.read) out.actions.push('read_aliases');
+      if (args.update) out.actions.push('update_aliases');
+      if (args.delete) out.actions.push('delete_aliases');
+      return out;
+    });
+  },
+
   /**
    * Create a set of permissions specific to Weaviate's backup functionality.
    *

--- a/src/roles/integration.test.ts
+++ b/src/roles/integration.test.ts
@@ -291,7 +291,7 @@ const testCases: TestCase[] = [
       name: 'aliases',
       ...emptyPermissions,
       aliasPermissions: [{ alias: 'SomeAlias', actions: ['create_aliases', 'delete_aliases'] }],
-    }
+    },
   },
 ];
 
@@ -361,13 +361,14 @@ requireAtLeast(1, 29, 0).describe('Integration testing of the roles namespace', 
 
   describe('should be able to create roles using the permissions factory', () => {
     testCases.forEach((testCase) => {
-      (testCase.requireVersion !== undefined
-        ? requireAtLeast(...testCase.requireVersion).it
-        : it)(`with ${testCase.roleName} permissions`, async () => {
+      (testCase.requireVersion !== undefined ? requireAtLeast(...testCase.requireVersion).it : it)(
+        `with ${testCase.roleName} permissions`,
+        async () => {
           await client.roles.create(testCase.roleName, testCase.permissions);
           const role = await client.roles.byName(testCase.roleName);
           expect(role).toEqual(testCase.expected);
-        });
+        }
+      );
     });
   });
 

--- a/src/roles/integration.test.ts
+++ b/src/roles/integration.test.ts
@@ -284,13 +284,16 @@ const testCases: TestCase[] = [
     requireVersion: [1, 32, 0],
     permissions: weaviate.permissions.aliases({
       alias: 'SomeAlias',
+      collection: 'SomeCollection',
       create: true,
       delete: true,
     }),
     expected: {
       name: 'aliases',
       ...emptyPermissions,
-      aliasPermissions: [{ alias: 'SomeAlias', actions: ['create_aliases', 'delete_aliases'] }],
+      aliasPermissions: [
+        { alias: 'SomeAlias', collection: 'SomeCollection', actions: ['create_aliases', 'delete_aliases'] },
+      ],
     },
   },
 ];

--- a/src/roles/types.ts
+++ b/src/roles/types.ts
@@ -33,6 +33,7 @@ export type UserAssignment = {
 
 export type AliasPermission = {
   alias: string;
+  collection: string;
   actions: AliasAction[];
 };
 

--- a/src/roles/types.ts
+++ b/src/roles/types.ts
@@ -1,6 +1,9 @@
 import { Action, WeaviateUserType } from '../openapi/types.js';
 
-export type AliasAction = Extract<Action, 'create_aliases' | 'read_aliases' | 'update_aliases' | 'delete_aliases'>;
+export type AliasAction = Extract<
+  Action,
+  'create_aliases' | 'read_aliases' | 'update_aliases' | 'delete_aliases'
+>;
 export type BackupsAction = Extract<Action, 'manage_backups'>;
 export type ClusterAction = Extract<Action, 'read_cluster'>;
 export type CollectionsAction = Extract<
@@ -31,7 +34,7 @@ export type UserAssignment = {
 export type AliasPermission = {
   alias: string;
   actions: AliasAction[];
-}
+};
 
 export type BackupsPermission = {
   collection: string;

--- a/src/roles/types.ts
+++ b/src/roles/types.ts
@@ -1,5 +1,6 @@
 import { Action, WeaviateUserType } from '../openapi/types.js';
 
+export type AliasAction = Extract<Action, 'create_aliases' | 'read_aliases' | 'update_aliases' | 'delete_aliases'>;
 export type BackupsAction = Extract<Action, 'manage_backups'>;
 export type ClusterAction = Extract<Action, 'read_cluster'>;
 export type CollectionsAction = Extract<
@@ -26,6 +27,11 @@ export type UserAssignment = {
   id: string;
   userType: WeaviateUserType;
 };
+
+export type AliasPermission = {
+  alias: string;
+  actions: AliasAction[];
+}
 
 export type BackupsPermission = {
   collection: string;
@@ -71,6 +77,7 @@ export type UsersPermission = {
 
 export type Role = {
   name: string;
+  aliasPermissions: AliasPermission[];
   backupsPermissions: BackupsPermission[];
   clusterPermissions: ClusterPermission[];
   collectionsPermissions: CollectionsPermission[];
@@ -82,6 +89,7 @@ export type Role = {
 };
 
 export type Permission =
+  | AliasPermission
   | BackupsPermission
   | ClusterPermission
   | CollectionsPermission

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -43,7 +43,7 @@ export class PermissionGuards {
       'create_aliases',
       'read_aliases',
       'update_aliases',
-      'delete_aliases',
+      'delete_aliases'
     );
   static isBackups = (permission: Permission): permission is BackupsPermission =>
     PermissionGuards.includes<BackupsAction>(permission, 'manage_backups');
@@ -236,7 +236,7 @@ class PermissionsMapping {
       if (this.mappings.aliases[key] === undefined) this.mappings.aliases[key] = { alias: key, actions: [] };
       this.mappings.aliases[key].actions.push(permission.action as AliasAction);
     }
-  }
+  };
 
   private backups = (permission: WeaviatePermission) => {
     if (permission.backups !== undefined) {

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -7,6 +7,8 @@ import {
 } from '../openapi/types.js';
 import { User, UserDB } from '../users/types.js';
 import {
+  AliasAction,
+  AliasPermission,
   BackupsAction,
   BackupsPermission,
   ClusterAction,
@@ -35,6 +37,14 @@ const ZERO_TIME = '0001-01-01T00:00:00.000Z';
 export class PermissionGuards {
   private static includes = <A extends string>(permission: Permission, ...actions: A[]): boolean =>
     actions.filter((a) => Array.from<string>(permission.actions).includes(a)).length > 0;
+  static isAlias = (permission: Permission): permission is AliasPermission =>
+    PermissionGuards.includes<AliasAction>(
+      permission,
+      'create_aliases',
+      'read_aliases',
+      'update_aliases',
+      'delete_aliases',
+    );
   static isBackups = (permission: Permission): permission is BackupsPermission =>
     PermissionGuards.includes<BackupsAction>(permission, 'manage_backups');
   static isCluster = (permission: Permission): permission is ClusterPermission =>
@@ -94,6 +104,12 @@ export class Map {
     !Array.isArray(permissions) ? [permissions] : permissions.flat(2);
 
   static permissionToWeaviate = (permission: Permission): WeaviatePermission[] => {
+    if (PermissionGuards.isAlias(permission)) {
+      return Array.from(permission.actions).map((action) => ({
+        aliases: permission,
+        action,
+      }));
+    }
     if (PermissionGuards.isBackups(permission)) {
       return Array.from(permission.actions).map((action) => ({
         backups: permission,
@@ -178,6 +194,7 @@ class PermissionsMapping {
 
   private constructor(role: WeaviateRole) {
     this.mappings = {
+      aliases: {},
       backups: {},
       cluster: {},
       collections: {},
@@ -200,6 +217,7 @@ class PermissionsMapping {
     }
     return {
       name: this.role.name,
+      aliasPermissions: Object.values(this.mappings.aliases),
       backupsPermissions: Object.values(this.mappings.backups),
       clusterPermissions: Object.values(this.mappings.cluster),
       collectionsPermissions: Object.values(this.mappings.collections),
@@ -210,6 +228,15 @@ class PermissionsMapping {
       usersPermissions: Object.values(this.mappings.users),
     };
   };
+
+  private aliases = (permission: WeaviatePermission) => {
+    if (permission.aliases !== undefined) {
+      const key = permission.aliases.alias;
+      if (key === undefined) throw new Error('Alias permission missing an alias');
+      if (this.mappings.aliases[key] === undefined) this.mappings.aliases[key] = { alias: key, actions: [] };
+      this.mappings.aliases[key].actions.push(permission.action as AliasAction);
+    }
+  }
 
   private backups = (permission: WeaviatePermission) => {
     if (permission.backups !== undefined) {
@@ -295,6 +322,7 @@ class PermissionsMapping {
   };
 
   private permissionFromWeaviate = (permission: WeaviatePermission) => {
+    this.aliases(permission);
     this.backups(permission);
     this.cluster(permission);
     this.collections(permission);
@@ -307,6 +335,7 @@ class PermissionsMapping {
 }
 
 type PermissionMappings = {
+  aliases: Record<string, AliasPermission>;
   backups: Record<string, BackupsPermission>;
   cluster: Record<string, ClusterPermission>;
   collections: Record<string, CollectionsPermission>;

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -234,7 +234,7 @@ class PermissionsMapping {
       const { alias, collection } = permission.aliases;
       if (alias === undefined) throw new Error('Alias permission missing an alias');
       if (this.mappings.aliases[alias] === undefined) {
-        this.mappings.aliases[alias] = { alias, collection: collection || "*", actions: [] };
+        this.mappings.aliases[alias] = { alias, collection: collection || '*', actions: [] };
       }
       this.mappings.aliases[alias].actions.push(permission.action as AliasAction);
     }

--- a/src/roles/util.ts
+++ b/src/roles/util.ts
@@ -231,10 +231,12 @@ class PermissionsMapping {
 
   private aliases = (permission: WeaviatePermission) => {
     if (permission.aliases !== undefined) {
-      const key = permission.aliases.alias;
-      if (key === undefined) throw new Error('Alias permission missing an alias');
-      if (this.mappings.aliases[key] === undefined) this.mappings.aliases[key] = { alias: key, actions: [] };
-      this.mappings.aliases[key].actions.push(permission.action as AliasAction);
+      const { alias, collection } = permission.aliases;
+      if (alias === undefined) throw new Error('Alias permission missing an alias');
+      if (this.mappings.aliases[alias] === undefined) {
+        this.mappings.aliases[alias] = { alias, collection: collection || "*", actions: [] };
+      }
+      this.mappings.aliases[alias].actions.push(permission.action as AliasAction);
     }
   };
 


### PR DESCRIPTION
> ➡️ Merge after #315. There are some CI configuration updates and test fixes.

This PR adds API for managing collection aliases and extends the set of permissions with AliasPermission.

Manage aliases

```ts
client.alias.create({ collection: "Pizza", alias: "PizzaPie" });
client.alias.listAll();
client.alias.listAll("Pizza"); // list aliases defined for Pizza collection
client.alias.get("PizzaPie");
client.alias.update({ alias: "PizzaPie", newTargetCollectionName: "Langos" });
client.alias.delete("PizzaPie");
```

Manage alias permissions

```ts
weaviate.permissions.aliases({
    alias: ["PizzaPie", "PizzaWhy"],
    create: true,
    read: true,
    update: true,
    delete: true,
})
```
