### PR TITLE
fix: export vectorizer from configure/index.js

### DIFF
--- a/src/collections/configure/index.ts
+++ b/src/collections/configure/index.ts
@@ -311,5 +311,7 @@ export {
   tokenization,
   vectorDistances,
   configureVectorIndex as vectorIndex,
+  /** @deprecated Use `vectors` instead. */
+  vectors as vectorizer,
   vectors,
 };


### PR DESCRIPTION
In https://github.com/weaviate/typescript-client/pull/264 we've unintentionally removed `vectorizer` from the list of exports in `collections/configure/index.js`, which is a breaking change.

This PR brings it back and marks the export as deprecated. 