### PR TITLE
fix: missing X-Weaviate-Cluster-Url header in gRPC aggregations

### DIFF
--- a/src/connection/grpc.ts
+++ b/src/connection/grpc.ts
@@ -193,7 +193,7 @@ export const grpcClient = (config: GrpcConnectionParams & { grpcMaxMessageLength
       Aggregator.use(
         client,
         collection,
-        new Metadata(bearerToken ? { ...config.headers, authorization: bearerToken } : config.headers),
+        getMetadataWithEmbeddingServiceAuth(config, bearerToken),
         config.timeout?.query || 30,
         consistencyLevel,
         tenant


### PR DESCRIPTION
- When using Weaviate Embedding service, gRPC aggregate calls were missing the required X-Weaviate-Cluster-Url header while search and batch operations included it correctly. This caused aggregate queries to fail with "no cluster URL found in request header" errors.