### PR TITLE
Make Multi Tenancy config more resilient

### DIFF
--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -395,7 +395,13 @@ class ConfigMapping {
     };
   }
   static multiTenancy(v?: WeaviateMultiTenancyConfig): MultiTenancyConfig {
-    if (v === undefined) throw new WeaviateDeserializationError('Multi tenancy was not returned by Weaviate');
+    if (v === undefined) {
+      return {
+        autoTenantActivation: false,
+        autoTenantCreation: false,
+        enabled: false,
+      };
+    }
     return {
       autoTenantActivation: v.autoTenantActivation ? v.autoTenantActivation : false,
       autoTenantCreation: v.autoTenantCreation ? v.autoTenantCreation : false,


### PR DESCRIPTION
In some edge cases the cluster may not have Multi Tenancy configuration. This will return false for those cases.