### PR TITLE
Add `dimensions` property to Text2VecCohereConfig and update tests

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -153,6 +153,8 @@ export type Multi2VecCohereConfig = {
   imageFields?: string[];
   /** The specific model to use. */
   model?: string;
+  /** The number of dimensions for the generated embeddings. */
+  dimensions?: number;
   /** The text fields used when vectorizing. */
   textFields?: string[];
   /** The truncation strategy to use. */
@@ -371,6 +373,8 @@ export type Text2VecCohereConfig = {
   baseURL?: string;
   /** The model to use. */
   model?: string;
+  /** The number of dimensions for the generated embeddings. */
+  dimensions?: number;
   /** Whether to truncate the input texts to fit within the context length. */
   truncate?: boolean;
   /** Whether to vectorize the collection name. */

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -331,6 +331,7 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecCohere({
       name: 'test',
       model: 'model',
+      dimensions: 512,
       imageFields: [
         { name: 'field1', weight: 0.1 },
         { name: 'field2', weight: 0.2 },
@@ -350,6 +351,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         name: 'multi2vec-cohere',
         config: {
           model: 'model',
+          dimensions: 512,
           imageFields: ['field1', 'field2'],
           textFields: ['field3', 'field4'],
           weights: {
@@ -1002,6 +1004,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       name: 'test',
       baseURL: 'base-url',
       model: 'model',
+      dimensions: 512,
       truncate: true,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
@@ -1015,6 +1018,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         config: {
           baseURL: 'base-url',
           model: 'model',
+          dimensions: 512,
           truncate: true,
         },
       },


### PR DESCRIPTION
Add `dimensions` property to Text2VecCohereConfig and update tests

#365