### PR TITLE
feat: add multi2multivec-weaviate vectorizer with unit tests

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -27,6 +27,7 @@ export type Vectorizer =
   | 'multi2vec-google'
   | 'multi2vec-jinaai'
   | 'multi2multivec-jinaai'
+  | 'multi2multivec-weaviate'
   | 'multi2vec-voyageai'
   | 'ref2vec-centroid'
   | 'text2vec-aws'
@@ -261,6 +262,24 @@ export type Multi2MultivecJinaAIConfig = {
 
   /** The text fields used when vectorizing. */
   textFields?: string[];
+};
+
+/** The configuration for multi-media-to-multi-vector vectorization using
+ * the ModernVBERT/colmodernvbert model
+ *
+ * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/weaviate/embeddings-multimodal) for detailed usage.
+ */
+export type Multi2MultivecWeaviateConfig = {
+
+  /** The base URL to use where API requests should go. */
+  baseURL?: string;
+
+  /** The model to use. */
+  model?: 'ModernVBERT/colmodernvbert' | string;
+  
+  /** The image fields used when vectorizing. */
+  imageFields?: string[];
+
 };
 
 /** The configuration for multi-media vectorization using the Jina module.
@@ -643,6 +662,7 @@ export type VectorizerConfig =
   | Multi2VecGoogleConfig
   | Multi2VecJinaAIConfig
   | Multi2MultivecJinaAIConfig
+  | Multi2MultivecWeaviateConfig
   | Multi2VecPalmConfig
   | Multi2VecVoyageAIConfig
   | Ref2VecCentroidConfig
@@ -679,6 +699,8 @@ export type VectorizerConfigType<V> = V extends 'img2vec-neural'
   ? Multi2VecJinaAIConfig | undefined
   : V extends 'multi2multivec-jinaai'
   ? Multi2MultivecJinaAIConfig | undefined
+  : V extends 'multi2multivec-weaviate'
+  ? Multi2MultivecWeaviateConfig | undefined
   : V extends Multi2VecPalmVectorizer
   ? Multi2VecPalmConfig
   : V extends 'multi2vec-voyageai'

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -2,6 +2,7 @@ import {
   Img2VecNeuralConfig,
   ModuleConfig,
   Multi2MultivecJinaAIConfig,
+  Multi2MultivecWeaviateConfig,
   Multi2VecAWSConfig,
   Multi2VecBindConfig,
   Multi2VecClipConfig,
@@ -202,6 +203,11 @@ export type Multi2VecCohereConfigCreate = Omit<Multi2VecCohereConfig, Multi2VecO
 
 export type Multi2MultivecJinaAIConfigCreate = Multi2MultivecJinaAIConfig;
 
+export type Multi2MultivecWeaviateConfigCreate = Omit<Multi2MultivecWeaviateConfig, Multi2VecOmissions> & {
+  /** The image field to use in vectorization. */
+  imageField: string;
+};
+
 export type Multi2VecJinaAIConfigCreate = Omit<Multi2VecJinaAIConfig, Multi2VecOmissions> & {
   /** The image fields to use in vectorization. Can be string of `Multi2VecField` type. If string, weight 0 will be assumed. */
   imageFields?: string[] | Multi2VecField[];
@@ -290,6 +296,8 @@ export type VectorizerConfigCreateType<V> = V extends 'img2vec-neural'
   ? Multi2VecJinaAIConfigCreate | undefined
   : V extends 'multi2multivec-jinaai'
   ? Multi2MultivecJinaAIConfigCreate | undefined
+  : V extends 'multi2multivec-weaviate'
+  ? Multi2MultivecWeaviateConfigCreate | undefined
   : V extends 'multi2vec-palm'
   ? Multi2VecPalmConfigCreate
   : V extends 'multi2vec-google'

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -2372,4 +2372,64 @@ describe('Unit testing of the reranker factory class', () => {
       },
     });
   });
+
+  it('should create correct Multi2VecWeaviateConfig type with defaults', () => {
+    const config = configure.multiVectors.multi2VecWeaviate({
+      imageField: 'img',
+    });
+    expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2multivec-weaviate'>>({
+      name: undefined,
+      properties: undefined,
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'multi2multivec-weaviate',
+        config: {
+          imageFields: ['img'],
+        },
+      },
+    });
+  });
+
+  it('should create correct Multi2VecWeaviateConfig type with all values', () => {
+    const config = configure.multiVectors.multi2VecWeaviate({
+      name: 'test',
+      imageField: 'img',
+      model: 'model',
+      baseURL: 'base-url',
+      vectorIndexConfig: configure.vectorIndex.hnsw({
+        efConstruction: 256,
+        maxConnections: 128,
+      }),
+    });
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2multivec-weaviate'>>({
+      name: 'test',
+      properties: undefined,
+      vectorIndex: {
+        name: 'hnsw',
+        config: {
+          distance: undefined,
+          efConstruction: 256,
+          maxConnections: 128,
+          type: 'hnsw',
+        },
+      },
+      vectorizer: {
+        name: 'multi2multivec-weaviate',
+        config: {
+          imageFields: ['img'],
+          model: 'model',
+          baseURL: 'base-url',
+        },
+      },
+    });
+  });
+
+  it('should throw error when imageField is not provided for multi2VecWeaviate', () => {
+    expect(() => {
+      configure.multiVectors.multi2VecWeaviate({} as any);
+    }).toThrow('imageField is required for multi2VecWeaviate');
+  });
 });

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -1087,4 +1087,26 @@ export const multiVectors = {
       },
     });
   },
+
+  /**
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'multi2multivec-weaviate'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/weaviate/embeddings-multimodal) for detailed usage.
+   *
+   * @param {ConfigureNonTextVectorizerOptions<N, I, 'multi2multivec-weaviate'>} [opts] The configuration options for the `multi2multivec-weaviate` vectorizer.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2multivec-weaviate'>} The configuration object.
+   */
+  multi2VecWeaviate: <N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
+    opts: ConfigureNonTextVectorizerOptions<N, I, 'multi2multivec-weaviate'>
+  ): VectorConfigCreate<never, N, I, 'multi2multivec-weaviate'> => {
+    const { name, vectorIndexConfig, imageField, ...config } = opts;
+    if (!imageField) throw new WeaviateInvalidInputError('imageField is required for multi2VecWeaviate');
+    return makeVectorizer(name, {
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'multi2multivec-weaviate',
+        config: { ...config, imageFields: [imageField] },
+      },
+    });
+  },
 };


### PR DESCRIPTION
## Summary
Add support for the `multi2multivec-weaviate` vectorizer - issue #375.
  - Added TypeScript types and validation
  - Comprehensive unit tests

## Usage
```typescript
const config = configure.multiVectors.multi2VecWeaviate({
  name:'image',
  imageField: 'img',
});