### PR TITLE
Re-export `WeaviateClass` from where it is used in the public API

### DIFF
--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -176,6 +176,7 @@ export interface Collections {
 }
 
 export default collections;
+export { WeaviateClass } from '../openapi/types.js';
 export * from './aggregate/index.js';
 export * from './backup/index.js';
 export * from './cluster/index.js';


### PR DESCRIPTION
Closes https://github.com/weaviate/typescript-client/issues/404