### PR TITLE
chore(integration): add WV_TEST_HOST/WV_TEST_*_PORT overrides

### DIFF
--- a/test/backup/journey.test.ts
+++ b/test/backup/journey.test.ts
@@ -7,6 +7,7 @@ import {
   SOUP_CLASS_NAME,
 } from '../../src/utils/testData';
 import weaviate, { WeaviateClient } from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 import {
   BackupCreateResponse,
   BackupCreateStatusResponse,
@@ -22,7 +23,7 @@ describe('create and restore backup with waiting', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -132,7 +133,7 @@ describe('create and restore backup without waiting', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -262,7 +263,7 @@ describe('create and restore 1 of 2 classes', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -375,7 +376,7 @@ describe('fail creating backup for not existing class', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -405,7 +406,7 @@ describe('fail restoring backup for existing class', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -447,7 +448,7 @@ describe('fail creating existing backup', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -490,7 +491,7 @@ describe('fail checking create status for not existing backup', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -519,7 +520,7 @@ describe('fail restoring not existing backup', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -549,7 +550,7 @@ describe('fail checking restore status for not started restore', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -591,7 +592,7 @@ describe('fail creating backup for both include and exclude classes', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -624,7 +625,7 @@ describe('fail restoring backup for both include and exclude classes', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -679,7 +680,7 @@ describe('creates backup with valid compression config values', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -710,7 +711,7 @@ describe('fails creating backup with invalid compression config', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -762,7 +763,7 @@ describe('restores backup with valid compression config values', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));
@@ -838,7 +839,7 @@ describe('fails restoring backup with invalid compression config', () => {
 
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up', () => createTestFoodSchemaAndData(client));

--- a/test/batch/journey.test.ts
+++ b/test/batch/journey.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, expect, it } from 'vitest';
 import weaviate, { WeaviateClient } from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 import {
   BatchDeleteResponse,
   BatchReference,
@@ -77,7 +78,7 @@ const someReferences = [
 describe('batch importing', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('can add objects with different methods', () => {
@@ -349,7 +350,7 @@ describe('batch importing', () => {
 describe('batch deleting', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('sets up schema', () => setup(client));
@@ -504,7 +505,7 @@ describe('batch deleting', () => {
 describe('multi tenancy', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   const passageClassName = 'Passage';

--- a/test/c11y/journey.test.ts
+++ b/test/c11y/journey.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { describe, expect, it } from 'vitest';
 import weaviate from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 import { C11yExtension, C11yWordsResponse } from '../openapi/types.js';
 
 describe('c11y endpoints', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('displays info about a concept', () => {

--- a/test/classifications/contextual.journey.test.ts
+++ b/test/classifications/contextual.journey.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Classification } from '../../src/openapi/types.js';
 import weaviate from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 
 const targetDessertId = '9f399d3e-45a4-44f4-b0fd-fa291abfb211';
 const targetSavoryId = 'b7a64fbd-7c22-44ac-afbb-8d1432b8061b';
@@ -14,7 +15,7 @@ describe('a classification journey', () => {
   describe("knn - using the client's wait method", () => {
     const client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
 
     it('setups the schema and data', () => setup(client));

--- a/test/classifications/knn.journey.test.ts
+++ b/test/classifications/knn.journey.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Classification } from '../../src/openapi/types.js';
 import weaviate, { WeaviateClient } from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 
 const targetDessertId = 'cd54852a-209d-423b-bf1c-884468215237';
 const targetSavoryId = 'e5da0127-327e-4184-85b8-7b9d1af4a850';
@@ -11,7 +12,7 @@ describe('a classification journey', () => {
   describe('knn - manually polling the status', () => {
     const client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
 
     it('setups the schema and data', () => setup(client));
@@ -104,7 +105,7 @@ describe('a classification journey', () => {
   describe("knn - using the client's wait method", () => {
     const client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
 
     it('setups the schema and data', () => setup(client));
@@ -169,7 +170,7 @@ describe('a classification journey', () => {
   describe('knn - running into a timeout', () => {
     const client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
 
     it('setups the schema and data', () => setup(client));

--- a/test/collections/config/integration.test.ts
+++ b/test/collections/config/integration.test.ts
@@ -16,6 +16,7 @@ import weaviate, {
 } from '../../../src/index.js';
 import { WeaviateClass } from '../../../src/openapi/types.js';
 import { requireAtLeast } from '../../../test/version.js';
+import { TEST_HOST, TEST_REST_PORT } from '../../env';
 
 describe('Testing of the collection.config namespace', () => {
   let client: WeaviateClient;
@@ -813,7 +814,7 @@ describe('Testing of the collection.config namespace', () => {
 
   it('should be able update the config of a collection with legacy vectors', async () => {
     const clientV2 = weaviateV2.client({
-      host: 'http://localhost:8080',
+      host: `http://${TEST_HOST}:${TEST_REST_PORT}`,
     });
     const collectionName = 'TestCollectionConfigUpdateLegacyVectors';
     await clientV2.schema
@@ -981,7 +982,7 @@ describe('Testing of the collection.config namespace', () => {
         .then((config) =>
           expect((config.vectorizers.default.indexConfig as VectorIndexConfigHNSW).quantizer).toBeUndefined()
         );
-      await fetch(`http://localhost:8080/v1/schema/${collectionName}`)
+      await fetch(`http://${TEST_HOST}:${TEST_REST_PORT}/v1/schema/${collectionName}`)
         .then((res) => res.json() as WeaviateClass)
         .then((schema) =>
           expect(schema.vectorConfig?.default.vectorIndexConfig?.skipDefaultQuantization).toBe(true)
@@ -1002,7 +1003,7 @@ describe('Testing of the collection.config namespace', () => {
         .then((config) =>
           expect((config.vectorizers.custom.indexConfig as VectorIndexConfigHNSW).quantizer).toBeUndefined()
         );
-      await fetch(`http://localhost:8080/v1/schema/${collectionName}`)
+      await fetch(`http://${TEST_HOST}:${TEST_REST_PORT}/v1/schema/${collectionName}`)
         .then((res) => res.json() as WeaviateClass)
         .then((schema) =>
           expect(schema.vectorConfig?.custom.vectorIndexConfig?.skipDefaultQuantization).toBe(true)

--- a/test/collections/data/integration.test.ts
+++ b/test/collections/data/integration.test.ts
@@ -17,6 +17,7 @@ import weaviate, {
   WeaviateObject,
   weaviateV2,
 } from '../../../src/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../../env.js';
 import { requireAtLeast } from '../../version.js';
 
 type TestCollectionData = {
@@ -1055,7 +1056,7 @@ describe('Testing of the collection.data methods with a vector index', () => {
 
 describe('Testing of BYOV insertion with legacy vectorizer', () => {
   const collectionName = 'TestBYOVEdgeCase';
-  const oldClient = weaviateV2.client({ scheme: 'http', host: 'localhost:8080' });
+  const oldClient = weaviateV2.client({ scheme: 'http', host: `${TEST_HOST}:${TEST_REST_PORT}` });
 
   beforeAll(() =>
     oldClient.schema

--- a/test/collections/generate/integration.test.ts
+++ b/test/collections/generate/integration.test.ts
@@ -9,13 +9,15 @@ import weaviate, {
   WeaviateClient,
   generativeParameters,
 } from '../../../src/index.js';
+import { TEST_VECTOR_GRPC_PORT, TEST_VECTOR_HOST, TEST_VECTOR_REST_PORT } from '../../env';
 
 const maybe = process.env.OPENAI_APIKEY ? describe : describe.skip;
 
 const makeOpenAIClient = () =>
   weaviate.connectToLocal({
-    port: 8086,
-    grpcPort: 50057,
+    host: TEST_VECTOR_HOST,
+    port: TEST_VECTOR_REST_PORT,
+    grpcPort: TEST_VECTOR_GRPC_PORT,
     headers: {
       'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,
     },
@@ -579,8 +581,9 @@ maybeContextualAI('Testing of the collection.generate methods with Contextual AI
 
   beforeAll(async () => {
     client = await weaviate.connectToLocal({
-      port: 8086,
-      grpcPort: 50057,
+      host: TEST_VECTOR_HOST,
+      port: TEST_VECTOR_REST_PORT,
+      grpcPort: TEST_VECTOR_GRPC_PORT,
       headers: {
         'X-Contextual-Api-Key': process.env.CONTEXTUALAI_API_KEY!,
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,

--- a/test/collections/integration.test.ts
+++ b/test/collections/integration.test.ts
@@ -11,6 +11,15 @@ import weaviate, {
   VectorIndexConfigHNSW,
   WeaviateClient,
 } from '../../src/index';
+import {
+  TEST_CLUSTER_HOST,
+  TEST_CLUSTER_REST_PORT,
+  TEST_GRPC_PORT,
+  TEST_HOST,
+  TEST_REST_PORT,
+  TEST_VECTOR_HOST,
+  TEST_VECTOR_REST_PORT,
+} from '../env';
 
 describe('Testing of the collections.create method', () => {
   let cluster: WeaviateClient;
@@ -19,16 +28,19 @@ describe('Testing of the collections.create method', () => {
 
   beforeAll(async () => {
     cluster = await weaviate.connectToLocal({
-      port: 8087,
-      grpcPort: 50051,
+      host: TEST_CLUSTER_HOST,
+      port: TEST_CLUSTER_REST_PORT,
+      grpcPort: TEST_GRPC_PORT,
     });
     contextionary = await weaviate.connectToLocal({
-      port: 8080,
-      grpcPort: 50051,
+      host: TEST_HOST,
+      port: TEST_REST_PORT,
+      grpcPort: TEST_GRPC_PORT,
     });
     openai = await weaviate.connectToLocal({
-      port: 8086,
-      grpcPort: 50051,
+      host: TEST_VECTOR_HOST,
+      port: TEST_VECTOR_REST_PORT,
+      grpcPort: TEST_GRPC_PORT,
     });
   });
 

--- a/test/collections/iterator/integration.test.ts
+++ b/test/collections/iterator/integration.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import weaviate, { Collection, WeaviateClient } from '../../../src/index.js';
+import { TEST_GRPC_PORT, TEST_HOST, TEST_REST_PORT } from '../../env.js';
 
 describe('Testing of the collection.iterator method with a simple collection', () => {
   let client: WeaviateClient;
@@ -22,7 +23,11 @@ describe('Testing of the collection.iterator method with a simple collection', (
   });
 
   beforeAll(async () => {
-    client = await weaviate.connectToLocal({ port: 8080, grpcPort: 50051 });
+    client = await weaviate.connectToLocal({
+      host: TEST_HOST,
+      port: TEST_REST_PORT,
+      grpcPort: TEST_GRPC_PORT,
+    });
     collection = client.collections.use(collectionName);
     id = await client.collections
       .create({

--- a/test/collections/query/integration.test.ts
+++ b/test/collections/query/integration.test.ts
@@ -12,6 +12,7 @@ import weaviate, {
   WeaviateClient,
 } from '../../../src/index.js';
 import { requireAtLeast } from '../../../test/version.js';
+import { TEST_VECTOR_GRPC_PORT, TEST_VECTOR_HOST, TEST_VECTOR_REST_PORT } from '../../env';
 
 describe('Testing of the collection.query methods with a simple collection', () => {
   let client: WeaviateClient;
@@ -1628,8 +1629,9 @@ maybeContextualAIReranker('Testing of the collection.query methods with Contextu
 
   beforeAll(async () => {
     client = await weaviate.connectToLocal({
-      port: 8086,
-      grpcPort: 50057,
+      host: TEST_VECTOR_HOST,
+      port: TEST_VECTOR_REST_PORT,
+      grpcPort: TEST_VECTOR_GRPC_PORT,
       headers: {
         'X-Contextual-Api-Key': process.env.CONTEXTUALAI_API_KEY!,
         'X-Openai-Api-Key': process.env.OPENAI_APIKEY!,

--- a/test/connection/journey.test.ts
+++ b/test/connection/journey.test.ts
@@ -9,6 +9,13 @@ import Connection from '../../src/connection/index.js';
 
 import { WeaviateStartUpError } from '../../src/errors.js';
 import weaviate from '../../src/index.js';
+import {
+  TEST_AUTH_GRPC_PORT,
+  TEST_AUTH_HOST,
+  TEST_AUTH_REST_PORT,
+  TEST_OIDC_OKTA_CC_PORT,
+  TEST_OIDC_OKTA_USERS_PORT,
+} from '../env.js';
 
 const check = (cred?: string) => {
   if (cred == undefined || cred == '') {
@@ -24,7 +31,8 @@ describe('connection', () => {
     'makes a logged-in request when client host param has trailing slashes',
     async () => {
       const client = await weaviate.connectToLocal({
-        port: 8085,
+        host: TEST_AUTH_HOST,
+        port: TEST_AUTH_REST_PORT,
         authCredentials: new AuthUserPasswordCredentials({
           username: 'oidc-test-user@weaviate.io',
           password: process.env.WCS_DUMMY_CI_PW,
@@ -71,7 +79,7 @@ describe('connection', () => {
     'makes an Okta logged-in request with client credentials',
     async () => {
       const client = await weaviate.connectToLocal({
-        port: 8082,
+        port: TEST_OIDC_OKTA_CC_PORT,
         authCredentials: new AuthClientCredentials({
           clientSecret: process.env.OKTA_CLIENT_SECRET!,
           scopes: ['some_scope'],
@@ -92,7 +100,7 @@ describe('connection', () => {
 
   check(process.env.OKTA_DUMMY_CI_PW)('makes an Okta logged-in request with username/password', async () => {
     const client = await weaviate.connectToLocal({
-      port: 8083,
+      port: TEST_OIDC_OKTA_USERS_PORT,
       authCredentials: new AuthUserPasswordCredentials({
         username: 'test@test.de',
         password: process.env.OKTA_DUMMY_CI_PW,
@@ -112,7 +120,8 @@ describe('connection', () => {
 
   check(process.env.WCS_DUMMY_CI_PW)('makes a WCS logged-in request with username/password', async () => {
     const client = await weaviate.connectToLocal({
-      port: 8085,
+      host: TEST_AUTH_HOST,
+      port: TEST_AUTH_REST_PORT,
       authCredentials: new AuthUserPasswordCredentials({
         username: 'oidc-test-user@weaviate.io',
         password: process.env.WCS_DUMMY_CI_PW,
@@ -132,8 +141,9 @@ describe('connection', () => {
 
   it('makes a logged-in request with API key', async () => {
     const client = await weaviate.connectToLocal({
-      port: 8085,
-      grpcPort: 50056,
+      host: TEST_AUTH_HOST,
+      port: TEST_AUTH_REST_PORT,
+      grpcPort: TEST_AUTH_GRPC_PORT,
       authCredentials: new ApiKey('my-secret-key'),
     });
 
@@ -149,8 +159,9 @@ describe('connection', () => {
 
   it('makes a logged-in request with API key as string', async () => {
     const client = await weaviate.connectToLocal({
-      port: 8085,
-      grpcPort: 50056,
+      host: TEST_AUTH_HOST,
+      port: TEST_AUTH_REST_PORT,
+      grpcPort: TEST_AUTH_GRPC_PORT,
       authCredentials: 'my-secret-key',
     });
 
@@ -167,7 +178,7 @@ describe('connection', () => {
   check(process.env.WCS_DUMMY_CI_PW)('makes a logged-in request with access token', async () => {
     const dummy = new Connection({
       scheme: 'http',
-      host: 'localhost:8085',
+      host: `${TEST_AUTH_HOST}:${TEST_AUTH_REST_PORT}`,
       authClientSecret: new AuthUserPasswordCredentials({
         username: 'oidc-test-user@weaviate.io',
         password: process.env.WCS_DUMMY_CI_PW,
@@ -180,8 +191,9 @@ describe('connection', () => {
 
     const accessToken = (dummy as any).oidcAuth?.accessToken || '';
     const client = await weaviate.connectToLocal({
-      port: 8085,
-      grpcPort: 50056,
+      host: TEST_AUTH_HOST,
+      port: TEST_AUTH_REST_PORT,
+      grpcPort: TEST_AUTH_GRPC_PORT,
       authCredentials: new AuthAccessTokenCredentials({
         accessToken: accessToken,
         expiresIn: 900,
@@ -202,7 +214,7 @@ describe('connection', () => {
   check(process.env.WCS_DUMMY_CI_PW)('uses refresh token to fetch new access token', async () => {
     const dummy = new Connection({
       scheme: 'http',
-      host: 'localhost:8085',
+      host: `${TEST_AUTH_HOST}:${TEST_AUTH_REST_PORT}`,
       authClientSecret: new AuthUserPasswordCredentials({
         username: 'oidc-test-user@weaviate.io',
         password: process.env.WCS_DUMMY_CI_PW,
@@ -216,7 +228,7 @@ describe('connection', () => {
     const accessToken = (dummy as any).oidcAuth?.accessToken || '';
     const conn = new Connection({
       scheme: 'http',
-      host: 'localhost:8085',
+      host: `${TEST_AUTH_HOST}:${TEST_AUTH_REST_PORT}`,
       authClientSecret: new AuthAccessTokenCredentials({
         accessToken: accessToken,
         expiresIn: 1,
@@ -240,8 +252,9 @@ describe('connection', () => {
     expect.assertions(3);
     try {
       await weaviate.connectToLocal({
-        port: 8085,
-        grpcPort: 50056,
+        host: TEST_AUTH_HOST,
+        port: TEST_AUTH_REST_PORT,
+        grpcPort: TEST_AUTH_GRPC_PORT,
       });
       throw new Error('Promise should have been rejected');
     } catch (error: any) {
@@ -278,7 +291,7 @@ describe('connection', () => {
 
     const conn = new Connection({
       scheme: 'http',
-      host: 'localhost:8085',
+      host: `${TEST_AUTH_HOST}:${TEST_AUTH_REST_PORT}`,
       authClientSecret: new AuthAccessTokenCredentials({
         accessToken: 'abcd1234',
         expiresIn: 1,
@@ -307,7 +320,7 @@ describe('connection', () => {
       // eslint-disable-next-line no-new
       new Connection({
         scheme: 'http',
-        host: 'localhost:8085',
+        host: `${TEST_AUTH_HOST}:${TEST_AUTH_REST_PORT}`,
         authClientSecret: new AuthAccessTokenCredentials({
           accessToken: 'abcd1234',
           expiresIn: 1,

--- a/test/data/journey.test.ts
+++ b/test/data/journey.test.ts
@@ -9,6 +9,7 @@ import {
   WeaviateObjectsList,
 } from '../../src/openapi/types.js';
 import weaviate, { WeaviateClient } from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 
 const thingClassName = 'DataJourneyTestThing';
 const refSourceClassName = 'DataJourneyTestRefSource';
@@ -21,7 +22,7 @@ const fail = (msg: string) => {
 describe('data', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('creates a schema class', () => {
@@ -1382,7 +1383,7 @@ describe('data', () => {
 describe('uuid support', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   it('creates class with properties of uuid and uuid[]', async () => {
@@ -1449,7 +1450,7 @@ describe('uuid support', () => {
 describe('multi tenancy', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   const documentClassName = 'Document';

--- a/test/env.ts
+++ b/test/env.ts
@@ -1,0 +1,32 @@
+// Test-only env-var resolution for the integration test suite.
+// Hosts default to "localhost"; ports default to the previously-hardcoded
+// values used by the docker-compose dev stacks.
+
+export const TEST_HOST = process.env.WV_TEST_HOST || 'localhost';
+export const TEST_REST_PORT = Number(process.env.WV_TEST_REST_PORT) || 8080;
+export const TEST_GRPC_PORT = Number(process.env.WV_TEST_GRPC_PORT) || 50051;
+
+export const TEST_AUTH_HOST = process.env.WV_TEST_AUTH_HOST || 'localhost';
+export const TEST_AUTH_REST_PORT = Number(process.env.WV_TEST_AUTH_REST_PORT) || 8085;
+export const TEST_AUTH_GRPC_PORT = Number(process.env.WV_TEST_AUTH_GRPC_PORT) || 50056;
+
+export const TEST_OIDC_HOST = process.env.WV_TEST_OIDC_HOST || 'localhost';
+export const TEST_OIDC_AZURE_PORT = Number(process.env.WV_TEST_OIDC_AZURE_PORT) || 8081;
+export const TEST_OIDC_OKTA_CC_PORT = Number(process.env.WV_TEST_OIDC_OKTA_CC_PORT) || 8082;
+export const TEST_OIDC_OKTA_USERS_PORT = Number(process.env.WV_TEST_OIDC_OKTA_USERS_PORT) || 8083;
+
+export const TEST_RBAC_HOST = process.env.WV_TEST_RBAC_HOST || 'localhost';
+export const TEST_RBAC_REST_PORT = Number(process.env.WV_TEST_RBAC_REST_PORT) || 8092;
+export const TEST_RBAC_GRPC_PORT = Number(process.env.WV_TEST_RBAC_GRPC_PORT) || 50063;
+
+export const TEST_VECTOR_HOST = process.env.WV_TEST_VECTOR_HOST || 'localhost';
+export const TEST_VECTOR_REST_PORT = Number(process.env.WV_TEST_VECTOR_REST_PORT) || 8086;
+export const TEST_VECTOR_GRPC_PORT = Number(process.env.WV_TEST_VECTOR_GRPC_PORT) || 50057;
+
+export const TEST_CLUSTER_HOST = process.env.WV_TEST_CLUSTER_HOST || 'localhost';
+export const TEST_CLUSTER_REST_PORT = Number(process.env.WV_TEST_CLUSTER_REST_PORT) || 8087;
+export const TEST_CLUSTER_GRPC_PORT = Number(process.env.WV_TEST_CLUSTER_GRPC_PORT) || 50058;
+
+export const TEST_BROKEN_HOST = process.env.WV_TEST_BROKEN_HOST || 'localhost';
+export const TEST_BROKEN_REST_PORT = Number(process.env.WV_TEST_BROKEN_REST_PORT) || 8888;
+export const TEST_BROKEN_GRPC_PORT = Number(process.env.WV_TEST_BROKEN_GRPC_PORT) || 55555;

--- a/test/graphql/journey.test.ts
+++ b/test/graphql/journey.test.ts
@@ -12,6 +12,14 @@ import weaviate, {
   WeaviateObject,
   WhereFilter,
 } from '../../src/v2/index.js';
+import {
+  TEST_CLUSTER_HOST,
+  TEST_CLUSTER_REST_PORT,
+  TEST_HOST,
+  TEST_REST_PORT,
+  TEST_VECTOR_HOST,
+  TEST_VECTOR_REST_PORT,
+} from '../env.js';
 
 describe('the graphql journey', () => {
   let client: WeaviateClient;
@@ -20,7 +28,7 @@ describe('the graphql journey', () => {
   beforeEach(async () => {
     client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
     versionLessThan125 = await client.misc
       .metaGetter()
@@ -1395,7 +1403,7 @@ describe('the graphql journey', () => {
   it('search object with uuid and uuid props', async () => {
     const client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
 
     const className = 'ClassUUID';
@@ -1480,7 +1488,7 @@ skip().describe(
   'query with generative search',
   () => {
     const client = weaviate.client({
-      host: 'localhost:8086',
+      host: `${TEST_VECTOR_HOST}:${TEST_VECTOR_REST_PORT}`,
       scheme: 'http',
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       headers: { 'X-OpenAI-Api-Key': process.env.OPENAI_APIKEY! },
@@ -1597,7 +1605,7 @@ Tastes like a fresh ocean breeze: {review}`,
 describe('query cluster with consistency level', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8087',
+    host: `${TEST_CLUSTER_HOST}:${TEST_CLUSTER_REST_PORT}`,
   });
 
   it('sets up replicated class', () => {
@@ -1670,7 +1678,7 @@ describe.skip('query with group by SKIPPED BECAUSE OF XREFS RETURN OPTIMISATION 
   beforeEach(() => {
     client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
   });
 
@@ -1761,7 +1769,7 @@ describe('multi tenancy', () => {
   beforeEach(() => {
     client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
   });
 
@@ -1883,7 +1891,7 @@ describe('where test', () => {
   beforeEach(() => {
     client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
   });
 
@@ -2261,7 +2269,7 @@ describe('named vectors test', () => {
   beforeEach(() => {
     client = weaviate.client({
       scheme: 'http',
-      host: 'localhost:8080',
+      host: `${TEST_HOST}:${TEST_REST_PORT}`,
     });
   });
 

--- a/test/misc/journey.test.ts
+++ b/test/misc/journey.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import weaviate from '../../src/v2/index.js';
+import { TEST_AUTH_HOST, TEST_AUTH_REST_PORT, TEST_HOST, TEST_REST_PORT } from '../env.js';
 
 describe('misc endpoints', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   const authClient = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8085',
+    host: `${TEST_AUTH_HOST}:${TEST_AUTH_REST_PORT}`,
   });
 
   it('reports as live', () => {

--- a/test/schema/journey.test.ts
+++ b/test/schema/journey.test.ts
@@ -9,6 +9,7 @@ import {
   WeaviateClass,
 } from '../../src/openapi/types.js';
 import weaviate, { WeaviateClient } from '../../src/v2/index.js';
+import { TEST_HOST, TEST_REST_PORT } from '../env.js';
 
 const isVer = (client: WeaviateClient, minor: number, patch: number) =>
   client.misc
@@ -29,7 +30,7 @@ const isVer = (client: WeaviateClient, minor: number, patch: number) =>
 describe('schema', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   const classObjPromise = newClassObject('MyThingClass', client);
@@ -340,7 +341,7 @@ describe('schema', () => {
 describe('property setting defaults and migrations', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
 
   test.each([
@@ -583,7 +584,7 @@ describe('property setting defaults and migrations', () => {
 describe('multi tenancy', () => {
   const client = weaviate.client({
     scheme: 'http',
-    host: 'localhost:8080',
+    host: `${TEST_HOST}:${TEST_REST_PORT}`,
   });
   const classObj: WeaviateClass = {
     class: 'MultiTenancy',


### PR DESCRIPTION
## Summary

- Allow integration suite host/port to be overridden via `WV_TEST_*` env vars; default to current docker-compose values
- Adds `test/env.ts` as the canonical source of resolved endpoints
- Covers primary, auth/wcs, OIDC (Azure/Okta CC/Okta Users), RBAC, vectorizer, cluster, and broken/no-Weaviate test groups

Part of cross-client consolidation aligning Python / Go / C# / TS / Java + server (`weaviate#11153`) on the same `WV_TEST_*` convention.

## Test plan

- [ ] Default run unchanged: `npm run test:integration` (suite resolves to localhost + previous hardcoded ports)
- [ ] Override run against parity proxy: `WV_TEST_REST_PORT=9080 WV_TEST_GRPC_PORT=50052 npm run test:integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)