### PR TITLE
Add text2vec-digitalocean vectorizer module

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -40,6 +40,7 @@ export type Vectorizer =
   | 'text2vec-huggingface'
   | 'text2vec-jinaai'
   | 'text2vec-nvidia'
+  | 'text2vec-digitalocean'
   | 'text2vec-mistral'
   | 'text2vec-model2vec'
   | 'text2vec-morph'
@@ -525,6 +526,20 @@ export type Text2VecMistralConfig = {
 };
 
 /**
+ * The configuration for text vectorization using the DigitalOcean module.
+ *
+ * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings) for detailed usage.
+ */
+export type Text2VecDigitalOceanConfig = {
+  /** The base URL to use where API requests should go. */
+  baseURL?: string;
+  /** The model to use. */
+  model?: string;
+  /** Whether to vectorize the collection name. */
+  vectorizeCollectionName?: boolean;
+};
+
+/**
  * The configuration for text vectorization using the Ollama module.
  *
  * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/ollama/embeddings) for detailed usage.
@@ -741,6 +756,8 @@ export type VectorizerConfigType<V> = V extends 'img2vec-neural'
   ? Text2VecJinaAIConfig | undefined
   : V extends 'text2vec-nvidia'
   ? Text2VecNvidiaConfig | undefined
+  : V extends 'text2vec-digitalocean'
+  ? Text2VecDigitalOceanConfig | undefined
   : V extends 'text2vec-mistral'
   ? Text2VecMistralConfig | undefined
   : V extends 'text2vec-model2vec'

--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -531,10 +531,10 @@ export type Text2VecMistralConfig = {
  * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings) for detailed usage.
  */
 export type Text2VecDigitalOceanConfig = {
-  /** The base URL to use where API requests should go. */
+  /** The base URL to use where API requests should go. Defaults to `https://inference.do-ai.run` on the server. */
   baseURL?: string;
-  /** The model to use. */
-  model?: string;
+  /** The model to use, e.g. `qwen3-embedding-0.6b`. Required by the server. */
+  model: string;
   /** Whether to vectorize the collection name. */
   vectorizeCollectionName?: boolean;
 };

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -20,6 +20,7 @@ import {
   Text2VecCohereConfig,
   Text2VecContextionaryConfig,
   Text2VecDatabricksConfig,
+  Text2VecDigitalOceanConfig,
   Text2VecGPT4AllConfig,
   Text2VecGoogleConfig,
   Text2VecGoogleGeminiConfig,
@@ -268,6 +269,8 @@ export type Text2VecJinaAIConfigCreate = Text2VecJinaAIConfig;
 
 export type Text2VecNvidiaConfigCreate = Text2VecNvidiaConfig;
 
+export type Text2VecDigitalOceanConfigCreate = Text2VecDigitalOceanConfig;
+
 export type Text2VecMistralConfigCreate = Text2VecMistralConfig;
 
 export type Text2VecModel2VecConfigCreate = Text2VecModel2Vec;
@@ -338,6 +341,8 @@ export type VectorizerConfigCreateType<V> = V extends 'img2vec-neural'
   ? Text2VecJinaAIConfigCreate | undefined
   : V extends 'text2vec-nvidia'
   ? Text2VecNvidiaConfigCreate | undefined
+  : V extends 'text2vec-digitalocean'
+  ? Text2VecDigitalOceanConfigCreate | undefined
   : V extends 'text2vec-mistral'
   ? Text2VecMistralConfigCreate | undefined
   : V extends 'text2vec-model2vec'

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1422,6 +1422,43 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
   });
 
+  it('should create the correct Text2VecDigitalOceanConfig type with defaults', () => {
+    const config = configure.vectors.text2VecDigitalOcean();
+    expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-digitalocean'>>({
+      name: undefined,
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-digitalocean',
+        config: undefined,
+      },
+    });
+  });
+
+  it('should create the correct Text2VecDigitalOceanConfig type with all values', () => {
+    const config = configure.vectors.text2VecDigitalOcean({
+      baseURL: 'https://inference.do-ai.run',
+      name: 'test',
+      model: 'qwen3-embedding-0.6b',
+    });
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-digitalocean'>>({
+      name: 'test',
+      vectorIndex: {
+        name: 'hnsw',
+        config: undefined,
+      },
+      vectorizer: {
+        name: 'text2vec-digitalocean',
+        config: {
+          baseURL: 'https://inference.do-ai.run',
+          model: 'qwen3-embedding-0.6b',
+        },
+      },
+    });
+  });
+
   it('should create the correct Text2VecOllamaConfig type with defaults', () => {
     const config = configure.vectors.text2VecOllama();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-ollama'>>({

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1422,8 +1422,8 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
   });
 
-  it('should create the correct Text2VecDigitalOceanConfig type with defaults', () => {
-    const config = configure.vectors.text2VecDigitalOcean();
+  it('should create the correct Text2VecDigitalOceanConfig type with only the required model', () => {
+    const config = configure.vectors.text2VecDigitalOcean({ model: 'qwen3-embedding-0.6b' });
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-digitalocean'>>({
       name: undefined,
       vectorIndex: {
@@ -1432,7 +1432,9 @@ describe('Unit testing of the vectorizer factory class', () => {
       },
       vectorizer: {
         name: 'text2vec-digitalocean',
-        config: undefined,
+        config: {
+          model: 'qwen3-embedding-0.6b',
+        },
       },
     });
   });

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -638,6 +638,28 @@ const legacyVectors = {
     });
   },
   /**
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-digitalocean'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings) for detailed usage.
+   *
+   * @param {ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>} [opts] The configuration for the `text2vec-digitalocean` vectorizer.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-digitalocean'>} The configuration object.
+   */
+  text2VecDigitalOcean: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
+    opts?: ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>
+  ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-digitalocean'> => {
+    const { name, quantizer, sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    return makeVectorizer(name, {
+      quantizer,
+      sourceProperties,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'text2vec-digitalocean',
+        config: Object.keys(config).length === 0 ? undefined : config,
+      },
+    });
+  },
+  /**
    * Create a `VectorConfigCreate` object with the vectorizer set to `'text2vec-mistral'`.
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/mistral/embeddings) for detailed usage.
@@ -882,6 +904,9 @@ const __vectors_shaded = {
   text2VecOllama: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
     opts?: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-ollama'>, 'vectorizeCollectionName'>
   ) => legacyVectors.text2VecOllama(opts),
+  text2VecDigitalOcean: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
+    opts?: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>, 'vectorizeCollectionName'>
+  ) => legacyVectors.text2VecDigitalOcean(opts),
   text2VecMistral: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
     opts?: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-mistral'>, 'vectorizeCollectionName'>
   ) => legacyVectors.text2VecMistral(opts),

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -642,13 +642,13 @@ const legacyVectors = {
    *
    * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/embeddings) for detailed usage.
    *
-   * @param {ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>} [opts] The configuration for the `text2vec-digitalocean` vectorizer.
+   * @param {ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>} opts The configuration for the `text2vec-digitalocean` vectorizer. `model` is required by the server.
    * @returns {VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-digitalocean'>} The configuration object.
    */
   text2VecDigitalOcean: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
-    opts?: ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>
+    opts: ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>
   ): VectorConfigCreate<PrimitiveKeys<T>, N, I, 'text2vec-digitalocean'> => {
-    const { name, quantizer, sourceProperties, vectorIndexConfig, ...config } = opts || {};
+    const { name, quantizer, sourceProperties, vectorIndexConfig, ...config } = opts;
     return makeVectorizer(name, {
       quantizer,
       sourceProperties,
@@ -905,7 +905,7 @@ const __vectors_shaded = {
     opts?: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-ollama'>, 'vectorizeCollectionName'>
   ) => legacyVectors.text2VecOllama(opts),
   text2VecDigitalOcean: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
-    opts?: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>, 'vectorizeCollectionName'>
+    opts: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-digitalocean'>, 'vectorizeCollectionName'>
   ) => legacyVectors.text2VecDigitalOcean(opts),
   text2VecMistral: <T, N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
     opts?: Omit<ConfigureTextVectorizerOptions<T, N, I, 'text2vec-mistral'>, 'vectorizeCollectionName'>


### PR DESCRIPTION
## Summary

- Adds support for the new `text2vec-digitalocean` vectorizer module
- Mirrors `text2vec-mistral` (shared shape: `model` + `baseURL` + `vectorizeClassName`)
- No changes to generated proto/gRPC files; existing serialization path reused unchanged
- `model` is **required** on the factory — the server requires it, so the client surface enforces it at compile time

## API surface added

- `Text2VecDigitalOceanConfig` — runtime config type with **`model: string`** (required) and optional `baseURL` / `vectorizeCollectionName` (`src/collections/config/types/vectorizer.ts`)
- `Text2VecDigitalOceanConfigCreate` — create-time alias (`src/collections/configure/types/vectorizer.ts`)
- `configure.vectors.text2VecDigitalOcean(opts)` — factory, **`opts` required** (calling without it is a TS error since `model` must be supplied)
- Legacy/wrapper entry also added so the existing namespace pattern stays consistent, with the same required-`opts` shape
- `'text2vec-digitalocean'` added to the `Vectorizer` union and both `VectorizerConfigType` / `VectorizerConfigCreateType` conditional maps

## Test plan

- [x] Unit tests added in `src/collections/configure/unit.test.ts`:
  - `should create the correct Text2VecDigitalOceanConfig type with only the required model` — minimum-required-input case
  - `should create the correct Text2VecDigitalOceanConfig type with all values` — full-payload case asserting `text2vec-digitalocean` key with `baseURL` + `model`
- [x] All 128 unit tests pass (`vitest run --project unit src/collections/configure/unit.test.ts`)
- [x] `tsc --noEmit` clean across the entire project — no new type errors
- [x] Lint/format clean on changed files

## Review-feedback changes

Second commit (`c2fbd92`) tightens `model` from optional to required, matching the Python sibling PR (weaviate/weaviate-python-client#2041) and the server contract.

Closes #430

Sibling PR (Python): weaviate/weaviate-python-client#2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)