### PR TITLE
Enhance vector index handling and testing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,6 @@ env:
   WEAVIATE_135: 1.35.16
   WEAVIATE_136: 1.36.10
   WEAVIATE_137: 1.37.5-e0fe0d5.amd64
-  DEFAULT_VECTOR_INDEX: hfresh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -64,6 +63,8 @@ jobs:
           npm ci
           ci/run_dependencies.sh ${{ matrix.versions.weaviate }}
       - name: "Run tests without authentication tests"
+        env:
+          DEFAULT_VECTOR_INDEX: hfresh
         run: WEAVIATE_VERSION=${{ matrix.versions.weaviate }} npm test
       - name: "Transpile the package"
         run: npm run build
@@ -99,6 +100,7 @@ jobs:
           WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
           OKTA_CLIENT_SECRET: ${{ secrets.OKTA_CLIENT_SECRET }}
+          DEFAULT_VECTOR_INDEX: hfresh
         run: WEAVIATE_VERSION=${{ matrix.versions.weaviate }} npm test
       - name: "Stop Weaviate"
         run: ci/stop_dependencies.sh ${{ matrix.versions.weaviate }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ env:
   WEAVIATE_134: 1.34.20
   WEAVIATE_135: 1.35.16
   WEAVIATE_136: 1.36.10
-  WEAVIATE_137: 1.37.2
+  WEAVIATE_137: 1.37.5-e0fe0d5.amd64
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,7 @@ env:
   WEAVIATE_135: 1.35.16
   WEAVIATE_136: 1.36.10
   WEAVIATE_137: 1.37.5-e0fe0d5.amd64
+  DEFAULT_VECTOR_INDEX: hfresh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/src/collections/config/classes.ts
+++ b/src/collections/config/classes.ts
@@ -72,14 +72,15 @@ export class MergeWithExisting {
         };
         current.vectorConfig = MergeWithExisting.vectors(current.vectorConfig, [updateVectorizers]);
       } else {
-        current.vectorIndexConfig =
-          update.vectorizers?.vectorIndex.name === 'hnsw'
+        current.vectorIndexConfig = update.vectorizers?.vectorIndex
+          ? update.vectorizers.vectorIndex.name === 'hnsw'
             ? MergeWithExisting.hnsw(current.vectorIndexConfig, update.vectorizers.vectorIndex.config)
-            : update.vectorizers?.vectorIndex.name === 'hfresh'
+            : update.vectorizers.vectorIndex.name === 'hfresh'
             ? MergeWithExisting.hfresh(current.vectorIndexConfig, update.vectorizers.vectorIndex.config)
-            : update.vectorizers?.vectorIndex.name === 'dynamic'
+            : update.vectorizers.vectorIndex.name === 'dynamic'
             ? MergeWithExisting.dynamic(current.vectorIndexConfig, update.vectorizers.vectorIndex.config)
-            : MergeWithExisting.flat(current.vectorIndexConfig, update.vectorizers.vectorIndex.config);
+            : MergeWithExisting.flat(current.vectorIndexConfig, update.vectorizers.vectorIndex.config)
+          : current.vectorIndexConfig;
       }
     }
     return current;
@@ -180,14 +181,15 @@ export class MergeWithExisting {
     update.forEach((v) => {
       const existing = current[v.name];
       if (existing !== undefined) {
-        current[v.name].vectorIndexConfig =
-          v.vectorIndex.name === 'hnsw'
+        current[v.name].vectorIndexConfig = v.vectorIndex
+          ? v.vectorIndex.name === 'hnsw'
             ? MergeWithExisting.hnsw(existing.vectorIndexConfig, v.vectorIndex.config)
             : v.vectorIndex.name === 'hfresh'
             ? MergeWithExisting.hfresh(existing.vectorIndexConfig, v.vectorIndex.config)
             : v.vectorIndex.name === 'dynamic'
             ? MergeWithExisting.dynamic(existing.vectorIndexConfig, v.vectorIndex.config)
-            : MergeWithExisting.flat(existing.vectorIndexConfig, v.vectorIndex.config);
+            : MergeWithExisting.flat(existing.vectorIndexConfig, v.vectorIndex.config)
+          : existing.vectorIndexConfig;
       }
     });
     return current;

--- a/src/collections/config/index.ts
+++ b/src/collections/config/index.ts
@@ -51,8 +51,15 @@ const config = <T>(
         .withProperty(resolveReference<any>(reference))
         .do()
         .then(() => {}),
-    addVector: (vectors: VectorizersConfigAdd<T>) => {
+    addVector: async (vectors: VectorizersConfigAdd<T>) => {
       const { vectorsConfig } = makeVectorsConfig(vectors);
+      const { supports: serverAppliesDefaultVIT } =
+        await dbVersionSupport.supportsServerSideDefaultVectorIndexType();
+      if (!serverAppliesDefaultVIT && vectorsConfig) {
+        for (const v of Object.values(vectorsConfig)) {
+          if (!(v as any).vectorIndexType) (v as any).vectorIndexType = 'hnsw';
+        }
+      }
       return new VectorAdder(connection).withClassName(name).withVectors(vectorsConfig).do();
     },
     get: () => getRaw().then(classToCollection<T>),

--- a/src/collections/config/types/index.ts
+++ b/src/collections/config/types/index.ts
@@ -71,7 +71,10 @@ export type ReplicationDeletionStrategy =
   | 'NoAutomatedResolution'
   | 'TimeBasedResolution';
 
-export type AsyncReplicationConfig = WeaviateAsyncReplicationConfig;
+export type AsyncReplicationConfig = Omit<
+  WeaviateAsyncReplicationConfig,
+  'maxWorkers' | 'aliveNodesCheckingFrequency'
+>;
 
 export type ReplicationConfig = {
   asyncEnabled: boolean;

--- a/src/collections/config/types/index.ts
+++ b/src/collections/config/types/index.ts
@@ -71,10 +71,7 @@ export type ReplicationDeletionStrategy =
   | 'NoAutomatedResolution'
   | 'TimeBasedResolution';
 
-export type AsyncReplicationConfig = Omit<
-  WeaviateAsyncReplicationConfig,
-  'maxWorkers' | 'aliveNodesCheckingFrequency'
->;
+export type AsyncReplicationConfig = WeaviateAsyncReplicationConfig;
 
 export type ReplicationConfig = {
   asyncEnabled: boolean;

--- a/src/collections/config/unit.test.ts
+++ b/src/collections/config/unit.test.ts
@@ -5,8 +5,10 @@ import {
   WeaviateMultiTenancyConfig,
   WeaviateVectorsConfig,
 } from '../../openapi/types';
+import { configure } from '../configure/index.js';
 import { MergeWithExisting } from './classes';
 import { GenerativeCohereConfig, RerankerCohereConfig } from './types';
+import { makeVectorsConfig } from './utils.js';
 
 describe('Unit testing of the MergeWithExisting class', () => {
   const deepCopy = (config: any) => JSON.parse(JSON.stringify(config));
@@ -448,5 +450,32 @@ describe('Unit testing of the MergeWithExisting class', () => {
         model: 'other',
       } as RerankerCohereConfig,
     });
+  });
+});
+
+describe('makeVectorsConfig', () => {
+  it('should omit vectorIndexType and vectorIndexConfig when vectorIndex is undefined', () => {
+    const vec = configure.vectors.text2VecOpenAI({ name: 'default' });
+    expect(vec.vectorIndex).toBeUndefined();
+
+    const { vectorsConfig } = makeVectorsConfig(vec);
+    const entry = vectorsConfig!['default'];
+    expect(entry).toBeDefined();
+    expect(entry.vectorIndexType).toBeUndefined();
+    expect(entry.vectorIndexConfig).toBeUndefined();
+    expect(entry.vectorizer).toBeDefined();
+  });
+
+  it('should include vectorIndexType and vectorIndexConfig when vectorIndex is defined', () => {
+    const vec = configure.vectors.text2VecOpenAI({
+      name: 'default',
+      vectorIndexConfig: configure.vectorIndex.hnsw(),
+    });
+    expect(vec.vectorIndex).toBeDefined();
+
+    const { vectorsConfig } = makeVectorsConfig(vec);
+    const entry = vectorsConfig!['default'];
+    expect(entry.vectorIndexType).toBe('hnsw');
+    expect(entry.vectorIndexConfig).toBeDefined();
   });
 });

--- a/src/collections/config/unit.test.ts
+++ b/src/collections/config/unit.test.ts
@@ -459,7 +459,7 @@ describe('makeVectorsConfig', () => {
     expect(vec.vectorIndex).toBeUndefined();
 
     const { vectorsConfig } = makeVectorsConfig(vec);
-    const entry = vectorsConfig!['default'];
+    const entry = vectorsConfig!.default;
     expect(entry).toBeDefined();
     expect(entry.vectorIndexType).toBeUndefined();
     expect(entry.vectorIndexConfig).toBeUndefined();
@@ -474,7 +474,7 @@ describe('makeVectorsConfig', () => {
     expect(vec.vectorIndex).toBeDefined();
 
     const { vectorsConfig } = makeVectorsConfig(vec);
-    const entry = vectorsConfig!['default'];
+    const entry = vectorsConfig!.default;
     expect(entry.vectorIndexType).toBe('hnsw');
     expect(entry.vectorIndexConfig).toBeDefined();
   });

--- a/src/collections/config/unit.test.ts
+++ b/src/collections/config/unit.test.ts
@@ -454,7 +454,7 @@ describe('Unit testing of the MergeWithExisting class', () => {
 });
 
 describe('makeVectorsConfig', () => {
-  it('should omit vectorIndexType and vectorIndexConfig when vectorIndex is undefined', () => {
+  it('should omit vectorIndexType and vectorIndexConfig when no index options are provided', () => {
     const vec = configure.vectors.text2VecOpenAI({ name: 'default' });
     expect(vec.vectorIndex).toBeUndefined();
 

--- a/src/collections/config/utils.ts
+++ b/src/collections/config/utils.ts
@@ -295,11 +295,11 @@ export const makeVectorsConfig = (
         },
       ];
   vectorizersConfig.forEach((v) => {
-    const vectorConfig: any = {
-      vectorIndexConfig: parseVectorIndex(v.vectorIndex),
-      vectorIndexType: v.vectorIndex.name,
-      vectorizer: {},
-    };
+    const vectorConfig: any = { vectorizer: {} };
+    if (v.vectorIndex) {
+      vectorConfig.vectorIndexConfig = parseVectorIndex(v.vectorIndex);
+      vectorConfig.vectorIndexType = v.vectorIndex.name;
+    }
     const vectorizer = v.vectorizer.name === 'text2vec-azure-openai' ? 'text2vec-openai' : v.vectorizer.name;
     vectorizers = [...vectorizers, vectorizer];
     vectorConfig.vectorizer[vectorizer] = {

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -68,7 +68,7 @@ export type VectorConfigCreate<
   name: N;
   properties?: P[];
   vectorizer: ModuleConfig<V, VectorizerConfigType<V>>;
-  vectorIndex: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
+  vectorIndex?: ModuleConfig<I, VectorIndexConfigCreateType<I>>;
 };
 
 export type VectorConfigUpdate<N extends string | undefined, I extends VectorIndexType> = {

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -2590,4 +2590,34 @@ describe('Unit testing of the reranker factory class', () => {
       },
     });
   });
+
+  describe('makeVectorizer vectorIndex gate', () => {
+    it('should leave vectorIndex undefined when no index-related option is provided', () => {
+      const config = configure.vectors.text2VecOpenAI();
+      expect(config.vectorIndex).toBeUndefined();
+    });
+
+    it('should populate vectorIndex when vectorIndexConfig is provided', () => {
+      const config = configure.vectors.text2VecOpenAI({
+        vectorIndexConfig: configure.vectorIndex.hnsw(),
+      });
+      expect(config.vectorIndex).toBeDefined();
+      expect(config.vectorIndex!.name).toBe('hnsw');
+    });
+
+    it('should populate vectorIndex when quantizer is provided', () => {
+      const config = configure.vectors.text2VecOpenAI({
+        quantizer: configure.vectorIndex.quantizer.pq(),
+      });
+      expect(config.vectorIndex).toBeDefined();
+    });
+
+    it('should preserve explicit vectorIndexConfig name when flat is specified', () => {
+      const config = configure.vectors.text2VecOpenAI({
+        vectorIndexConfig: configure.vectorIndex.flat(),
+      });
+      expect(config.vectorIndex).toBeDefined();
+      expect(config.vectorIndex!.name).toBe('flat');
+    });
+  });
 });

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -366,10 +366,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'img2vec-neural'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'img2vec-neural',
         config: {
@@ -383,10 +379,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecCohere();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-cohere'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-cohere',
         config: undefined,
@@ -401,10 +393,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-cohere'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-cohere',
         config: {
@@ -430,10 +418,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-cohere'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-cohere',
         config: {
@@ -454,10 +438,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecClip();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-clip'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-clip',
         config: undefined,
@@ -473,10 +453,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-clip',
         config: {
@@ -501,10 +477,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-clip'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-clip',
         config: {
@@ -523,10 +495,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecBind();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-bind'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-bind',
         config: undefined,
@@ -547,10 +515,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-bind',
         config: {
@@ -600,10 +564,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-bind'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-bind',
         config: {
@@ -635,10 +595,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-google'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-google',
         config: {
@@ -662,10 +618,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-google'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-google',
         config: {
@@ -704,10 +656,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-google'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-google',
         config: {
@@ -746,10 +694,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-nvidia'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-nvidia',
         config: {
@@ -772,10 +716,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecJinaAI();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-jinaai'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-jinaai',
         config: undefined,
@@ -797,10 +737,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-jinaai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-jinaai',
         config: {
@@ -862,10 +798,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-palm'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-palm',
         config: {
@@ -889,10 +821,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-palm',
         config: {
@@ -930,10 +858,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-palm'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-palm',
         config: {
@@ -958,10 +882,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecVoyageAI();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-voyageai'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-voyageai',
         config: undefined,
@@ -980,10 +900,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-voyageai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-voyageai',
         config: {
@@ -1008,10 +924,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-voyageai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-voyageai',
         config: {
@@ -1032,10 +944,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-aws'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-aws',
         config: {
@@ -1056,10 +964,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-aws',
         config: {
@@ -1079,10 +983,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-azure-openai'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-azure-openai',
         config: {
@@ -1102,10 +1002,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-azure-openai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-azure-openai',
         config: {
@@ -1121,10 +1017,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecCohere();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-cohere'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-cohere',
         config: undefined,
@@ -1142,10 +1034,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-cohere'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-cohere',
         config: {
@@ -1162,10 +1050,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecContextionary();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-contextionary'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-contextionary',
         config: undefined,
@@ -1179,10 +1063,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-contextionary'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-contextionary',
         config: undefined,
@@ -1197,10 +1077,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-databricks'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-databricks',
         config: {
@@ -1218,10 +1094,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-databricks'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-databricks',
         config: {
@@ -1236,10 +1108,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecGPT4All();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-gpt4all'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-gpt4all',
         config: undefined,
@@ -1253,10 +1121,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-gpt4all'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-gpt4all',
         config: undefined,
@@ -1268,10 +1132,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecHuggingFace();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-huggingface'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-huggingface',
         config: undefined,
@@ -1292,10 +1152,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-huggingface'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-huggingface',
         config: {
@@ -1315,10 +1171,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecJinaAI();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-jinaai'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-jinaai',
         config: undefined,
@@ -1333,10 +1185,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-jinaai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-jinaai',
         config: {
@@ -1350,10 +1198,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecNvidia();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-nvidia'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-nvidia',
         config: undefined,
@@ -1370,10 +1214,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-nvidia'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-nvidia',
         config: {
@@ -1389,10 +1229,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecMistral();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-mistral'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-mistral',
         config: undefined,
@@ -1408,10 +1244,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-mistral'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-mistral',
         config: {
@@ -1426,10 +1258,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecOllama();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-ollama'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-ollama',
         config: undefined,
@@ -1445,10 +1273,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-ollama'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-ollama',
         config: {
@@ -1463,10 +1287,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecOpenAI();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-openai'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-openai',
         config: undefined,
@@ -1485,10 +1305,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-openai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-openai',
         config: {
@@ -1506,10 +1322,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecGoogle();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-google',
         config: undefined,
@@ -1526,10 +1338,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-google'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-google',
         config: {
@@ -1546,10 +1354,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecGoogleGemini();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-google',
         config: {
@@ -1567,10 +1371,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-google'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-google',
         config: {
@@ -1586,10 +1386,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.multi2VecGoogleGemini();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-google'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-google',
         config: {
@@ -1608,10 +1404,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-google'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2vec-google',
         config: {
@@ -1629,10 +1421,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectorizer.text2VecPalm();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-palm'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-palm',
         config: undefined,
@@ -1649,10 +1437,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-palm'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-palm',
         config: {
@@ -1668,10 +1452,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecTransformers();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-transformers'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-transformers',
         config: undefined,
@@ -1687,10 +1467,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-transformers'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-transformers',
         config: {
@@ -1705,10 +1481,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecVoyageAI();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-voyageai'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-voyageai',
         config: undefined,
@@ -1726,10 +1498,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-voyageai'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-voyageai',
         config: {
@@ -1746,10 +1514,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecWeaviate();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-weaviate'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-weaviate',
         config: undefined,
@@ -1802,10 +1566,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecModel2Vec();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-model2vec'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-model2vec',
         config: undefined,
@@ -1821,10 +1581,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-model2vec'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-model2vec',
         config: {
@@ -1839,10 +1595,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecMorph();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-morph'>>({
       name: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-morph',
         config: undefined,
@@ -1858,10 +1610,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-morph'>>({
       name: 'test',
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'text2vec-morph',
         config: {
@@ -2528,10 +2276,6 @@ describe('Unit testing of the reranker factory class', () => {
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2multivec-weaviate'>>({
       name: undefined,
       properties: undefined,
-      vectorIndex: {
-        name: 'hnsw',
-        config: undefined,
-      },
       vectorizer: {
         name: 'multi2multivec-weaviate',
         config: {

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -98,7 +98,7 @@ describe('Unit testing of the configure & reconfigure factory classes', () => {
       deletionStrategy: 'DeleteOnConflict',
       factor: 2,
       asyncConfig: {
-        maxWorkers: 10,
+        propagationConcurrency: 4,
       },
     });
     expect(config).toEqual<ReplicationConfigCreate>({
@@ -106,7 +106,7 @@ describe('Unit testing of the configure & reconfigure factory classes', () => {
       deletionStrategy: 'DeleteOnConflict',
       factor: 2,
       asyncConfig: {
-        maxWorkers: 10,
+        propagationConcurrency: 4,
       },
     });
   });
@@ -117,7 +117,7 @@ describe('Unit testing of the configure & reconfigure factory classes', () => {
       deletionStrategy: 'DeleteOnConflict',
       factor: 2,
       asyncConfig: {
-        maxWorkers: 10,
+        propagationConcurrency: 4,
       },
     });
     expect(config).toEqual<ReplicationConfigCreate>({
@@ -125,7 +125,7 @@ describe('Unit testing of the configure & reconfigure factory classes', () => {
       deletionStrategy: 'DeleteOnConflict',
       factor: 2,
       asyncConfig: {
-        maxWorkers: 10,
+        propagationConcurrency: 4,
       },
     });
   });

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -81,15 +81,22 @@ const makeVectorizer = <T, N extends string | undefined, I extends VectorIndexTy
   options?: VectorizerCreateOptions<PrimitiveKeys<T>[], I, V>,
   multiVec?: boolean
 ) => {
+  const userProvidedIndex =
+    options?.vectorIndexConfig !== undefined ||
+    options?.quantizer !== undefined ||
+    options?.encoding !== undefined ||
+    !!multiVec;
   return {
     name: name as N,
     properties: options?.sourceProperties,
-    vectorIndex: makeVectorIndex({
-      config: options?.vectorIndexConfig,
-      encoding: options?.encoding,
-      quantizer: options?.quantizer,
-      multiVec,
-    }) as ModuleConfig<any, VectorIndexConfigCreateType<I>>,
+    vectorIndex: userProvidedIndex
+      ? (makeVectorIndex({
+          config: options?.vectorIndexConfig,
+          encoding: options?.encoding,
+          quantizer: options?.quantizer,
+          multiVec,
+        }) as ModuleConfig<any, VectorIndexConfigCreateType<I>>)
+      : (undefined as any),
     vectorizer: options?.vectorizerConfig
       ? options.vectorizerConfig
       : { name: 'none' as V, config: undefined as VectorizerConfigType<V> },

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -200,4 +200,3 @@ export * from './sort/index.js';
 export * from './tenants/index.js';
 export * from './types/index.js';
 export * from './vectors/multiTargetVector.js';
-

--- a/src/collections/index.ts
+++ b/src/collections/index.ts
@@ -105,6 +105,13 @@ const collections = (connection: Connection, dbVersionSupport: DbVersionSupport)
       const { vectorsConfig, vectorizers } = config.vectorizers
         ? makeVectorsConfig(config.vectorizers)
         : { vectorsConfig: undefined, vectorizers: [] };
+      const { supports: serverAppliesDevaultVIT } =
+        await dbVersionSupport.supportsServerSideDefaultVectorIndexType();
+      if (!serverAppliesDevaultVIT && vectorsConfig) {
+        for (const v of Object.values(vectorsConfig)) {
+          if (!(v as any).vectorIndexType) (v as any).vectorIndexType = 'hnsw';
+        }
+      }
       schema.vectorConfig = vectorsConfig;
 
       const properties = config.properties
@@ -193,3 +200,4 @@ export * from './sort/index.js';
 export * from './tenants/index.js';
 export * from './types/index.js';
 export * from './vectors/multiTargetVector.js';
+

--- a/src/openapi/schema.ts
+++ b/src/openapi/schema.ts
@@ -1592,11 +1592,6 @@ export interface definitions {
   ReplicationAsyncConfig: {
     /**
      * Format: int64
-     * @description Maximum number of async replication workers.
-     */
-    maxWorkers?: number;
-    /**
-     * Format: int64
      * @description Height of the hashtree used for diffing.
      */
     hashtreeHeight?: number;
@@ -1610,11 +1605,6 @@ export interface definitions {
      * @description Frequency in milliseconds at which async replication runs while propagation is active.
      */
     frequencyWhilePropagating?: number;
-    /**
-     * Format: int64
-     * @description Interval in milliseconds at which liveness of target nodes is checked.
-     */
-    aliveNodesCheckingFrequency?: number;
     /**
      * Format: int64
      * @description Interval in seconds at which async replication logs its status.

--- a/src/utils/dbVersion.ts
+++ b/src/utils/dbVersion.ts
@@ -162,6 +162,13 @@ export class DbVersionSupport {
       supports: version.isAtLeast(1, 37, 2),
       message: this.errorMessage('Tokenize endpoint stopwords / stopwordPresets', version.show(), '1.37.2'),
     }));
+
+  supportsServerSideDefaultVectorIndexType = () =>
+    this.dbVersionProvider.getVersion().then((version) => ({
+      version,
+      supports: version.isAtLeast(1, 37, 5),
+      message: undefined,
+    }));
 }
 
 const EMPTY_VERSION = '';

--- a/test/collections/defaultVectorIndexType/integration.test.ts
+++ b/test/collections/defaultVectorIndexType/integration.test.ts
@@ -1,0 +1,224 @@
+import { StartedWeaviateContainer, WeaviateContainer } from '@testcontainers/weaviate';
+import { Wait } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import weaviate from '../../../src/index.js';
+
+// Helper to spin up a container and return a connected client.
+async function startContainer(
+  image: string,
+  env: Record<string, string> = {},
+  platform?: string
+): Promise<{ container: StartedWeaviateContainer }> {
+  let builder = new WeaviateContainer(image)
+    .withWaitStrategy(Wait.forHttp('/v1/.well-known/ready', 8080).withStartupTimeout(60 * 1000))
+    .withExposedPorts(8080, 50051)
+    .withEnvironment({
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true',
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate',
+      ...env,
+    });
+  if (platform) {
+    builder = builder.withPlatform(platform) as typeof builder;
+  }
+  const container = await builder.start();
+  return { container };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server 1.37.4 — old server that does NOT apply a server-side default.
+// The client must inject vectorIndexType = 'hnsw' for each vector that has
+// no explicit choice.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('defaultVectorIndexType — legacy server (1.37.4)', () => {
+  let container: StartedWeaviateContainer;
+
+  beforeAll(async () => {
+    ({ container } = await startContainer('semitechnologies/weaviate:1.37.4'));
+  }, 120_000);
+
+  afterAll(async () => {
+    await container?.stop();
+  });
+
+  it('no-explicit-index, selfProvided vectorizer → stored type is hnsw (client injected)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_Legacy_Self_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided(),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.default.indexType).toEqual('hnsw');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+
+  it('no-explicit-index, named selfProvided vector → stored type is hnsw (client injected)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_Legacy_Named_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided({ name: 'main' }),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.main.indexType).toEqual('hnsw');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+
+  it('explicit flat index, selfProvided vectorizer → stored type is flat (explicit choice preserved)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_Legacy_Flat_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided({
+          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
+        }),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.default.indexType).toEqual('flat');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+
+  it('explicit flat index, named selfProvided vector → stored type is flat (explicit choice preserved)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_Legacy_NamedFlat_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided({
+          name: 'main',
+          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
+        }),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.main.indexType).toEqual('flat');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+}, 180_000);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server 1.37.5 with DEFAULT_VECTOR_INDEX=flat — new server that applies its
+// own default. The client must NOT inject anything; the server returns 'flat'.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('defaultVectorIndexType — new server (1.37.5) with DEFAULT_VECTOR_INDEX=flat', () => {
+  let container: StartedWeaviateContainer;
+
+  beforeAll(async () => {
+    ({ container } = await startContainer(
+      'semitechnologies/weaviate:1.37.5-e0fe0d5.amd64',
+      { DEFAULT_VECTOR_INDEX: 'flat' },
+      'linux/amd64'
+    ));
+  }, 120_000);
+
+  afterAll(async () => {
+    await container?.stop();
+  });
+
+  it('no-explicit-index, selfProvided vectorizer → stored type is flat (server-side default applied)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_New_Self_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided(),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.default.indexType).toEqual('flat');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+
+  it('no-explicit-index, named selfProvided vector → stored type is flat (server-side default applied)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_New_Named_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided({ name: 'main' }),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.main.indexType).toEqual('flat');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+
+  it('explicit flat index, selfProvided vectorizer → stored type is flat (explicit choice preserved)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_New_Flat_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided({
+          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
+        }),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.default.indexType).toEqual('flat');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+
+  it('explicit flat index, named selfProvided vector → stored type is flat (explicit choice preserved)', async () => {
+    const client = await weaviate.connectToLocal({
+      host: container.getHost(),
+      port: container.getMappedPort(8080),
+      grpcPort: container.getMappedPort(50051),
+    });
+    const name = `DefVit_New_NamedFlat_${Date.now()}`;
+    try {
+      await client.collections.create({
+        name,
+        vectorizers: weaviate.configure.vectors.selfProvided({
+          name: 'main',
+          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
+        }),
+      });
+      const config = await client.collections.use(name).config.get();
+      expect(config.vectorizers.main.indexType).toEqual('flat');
+    } finally {
+      await client.collections.delete(name).catch(() => undefined);
+    }
+  });
+}, 180_000);

--- a/test/collections/defaultVectorIndexType/integration.test.ts
+++ b/test/collections/defaultVectorIndexType/integration.test.ts
@@ -7,10 +7,13 @@ import { DbVersion } from '../../../src/utils/dbVersion.js';
 // ─────────────────────────────────────────────────────────────────────────────
 // Version resolution
 //
-// WEAVIATE_VERSION follows the existing convention (see test/version.ts).
-// Default to 1.37.5-e0fe0d5.amd64 so a bare local run targets the new server.
+// WEAVIATE_VERSION follows the existing convention (see test/version.ts) and
+// is required — CI sets it; locally export it before running this test.
 // ─────────────────────────────────────────────────────────────────────────────
-const WEAVIATE_VERSION = process.env.WEAVIATE_VERSION ?? '1.37.5-e0fe0d5.amd64';
+const WEAVIATE_VERSION = process.env.WEAVIATE_VERSION;
+if (!WEAVIATE_VERSION) {
+  throw new Error('WEAVIATE_VERSION env var is required for this integration test');
+}
 const expectedDefault = process.env.DEFAULT_VECTOR_INDEX ?? 'hfresh';
 
 // Strip a trailing ".amd64" / ".arm64" platform suffix before parsing:

--- a/test/collections/defaultVectorIndexType/integration.test.ts
+++ b/test/collections/defaultVectorIndexType/integration.test.ts
@@ -11,6 +11,7 @@ import { DbVersion } from '../../../src/utils/dbVersion.js';
 // Default to 1.37.5-e0fe0d5.amd64 so a bare local run targets the new server.
 // ─────────────────────────────────────────────────────────────────────────────
 const WEAVIATE_VERSION = process.env.WEAVIATE_VERSION ?? '1.37.5-e0fe0d5.amd64';
+const expectedDefault = process.env.DEFAULT_VECTOR_INDEX ?? 'hfresh';
 
 // Strip a trailing ".amd64" / ".arm64" platform suffix before parsing:
 // DbVersion.fromString understands semver pre-release labels (e.g. -e0fe0d5)
@@ -60,7 +61,7 @@ describe(`defaultVectorIndexType — server ${WEAVIATE_VERSION} (serverAppliesDe
       `semitechnologies/weaviate:${WEAVIATE_VERSION}`,
       // Older servers ignore unknown env vars; always pass the flag so we don't
       // need a separate image-launch path.
-      { DEFAULT_VECTOR_INDEX: 'flat' },
+      { DEFAULT_VECTOR_INDEX: expectedDefault },
       platform
     ));
   }, 120_000);
@@ -86,7 +87,7 @@ describe(`defaultVectorIndexType — server ${WEAVIATE_VERSION} (serverAppliesDe
       const config = await client.collections.use(name).config.get();
       // New server: DEFAULT_VECTOR_INDEX=flat propagates → 'flat'
       // Old server: client injected 'hnsw' as the safe fallback
-      expect(config.vectorizers.default.indexType).toEqual(serverAppliesDefault ? 'flat' : 'hnsw');
+      expect(config.vectorizers.default.indexType).toEqual(serverAppliesDefault ? expectedDefault : 'hnsw');
     } finally {
       await client.collections.delete(name).catch(() => undefined);
     }
@@ -105,7 +106,7 @@ describe(`defaultVectorIndexType — server ${WEAVIATE_VERSION} (serverAppliesDe
         vectorizers: weaviate.configure.vectors.selfProvided({ name: 'main' }),
       });
       const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.main.indexType).toEqual(serverAppliesDefault ? 'flat' : 'hnsw');
+      expect(config.vectorizers.main.indexType).toEqual(serverAppliesDefault ? expectedDefault : 'hnsw');
     } finally {
       await client.collections.delete(name).catch(() => undefined);
     }

--- a/test/collections/defaultVectorIndexType/integration.test.ts
+++ b/test/collections/defaultVectorIndexType/integration.test.ts
@@ -2,12 +2,37 @@ import { StartedWeaviateContainer, WeaviateContainer } from '@testcontainers/wea
 import { Wait } from 'testcontainers';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import weaviate from '../../../src/index.js';
+import { DbVersion } from '../../../src/utils/dbVersion.js';
 
-// Helper to spin up a container and return a connected client.
+// ─────────────────────────────────────────────────────────────────────────────
+// Version resolution
+//
+// WEAVIATE_VERSION follows the existing convention (see test/version.ts).
+// Default to 1.37.5-e0fe0d5.amd64 so a bare local run targets the new server.
+// ─────────────────────────────────────────────────────────────────────────────
+const WEAVIATE_VERSION = process.env.WEAVIATE_VERSION ?? '1.37.5-e0fe0d5.amd64';
+
+// Strip a trailing ".amd64" / ".arm64" platform suffix before parsing:
+// DbVersion.fromString understands semver pre-release labels (e.g. -e0fe0d5)
+// but not dot-separated platform tokens appended after them.
+const versionForParsing = WEAVIATE_VERSION.replace(/\.(amd64|arm64|x86_64)$/, '');
+const parsedVersion = DbVersion.fromString(`v${versionForParsing}`);
+
+// >= 1.37.5: server applies DEFAULT_VECTOR_INDEX itself; client must NOT inject.
+// <  1.37.5: server has no such feature; client injects vectorIndexType = 'hnsw'.
+const serverAppliesDefault = parsedVersion.isAtLeast(1, 37, 5);
+
+// Use a linux/amd64 platform pin only when the image tag carries the ".amd64"
+// suffix — same narrowing the old test did, now applied to a single version.
+const platform = WEAVIATE_VERSION.includes('.amd64') ? 'linux/amd64' : undefined;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Container helper
+// ─────────────────────────────────────────────────────────────────────────────
 async function startContainer(
   image: string,
   env: Record<string, string> = {},
-  platform?: string
+  containerPlatform?: string
 ): Promise<{ container: StartedWeaviateContainer }> {
   let builder = new WeaviateContainer(image)
     .withWaitStrategy(Wait.forHttp('/v1/.well-known/ready', 8080).withStartupTimeout(60 * 1000))
@@ -17,123 +42,26 @@ async function startContainer(
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate',
       ...env,
     });
-  if (platform) {
-    builder = builder.withPlatform(platform) as typeof builder;
+  if (containerPlatform) {
+    builder = builder.withPlatform(containerPlatform) as typeof builder;
   }
   const container = await builder.start();
   return { container };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Server 1.37.4 — old server that does NOT apply a server-side default.
-// The client must inject vectorIndexType = 'hnsw' for each vector that has
-// no explicit choice.
+// Suite
 // ─────────────────────────────────────────────────────────────────────────────
-describe('defaultVectorIndexType — legacy server (1.37.4)', () => {
-  let container: StartedWeaviateContainer;
-
-  beforeAll(async () => {
-    ({ container } = await startContainer('semitechnologies/weaviate:1.37.4'));
-  }, 120_000);
-
-  afterAll(async () => {
-    await container?.stop();
-  });
-
-  it('no-explicit-index, selfProvided vectorizer → stored type is hnsw (client injected)', async () => {
-    const client = await weaviate.connectToLocal({
-      host: container.getHost(),
-      port: container.getMappedPort(8080),
-      grpcPort: container.getMappedPort(50051),
-    });
-    const name = `DefVit_Legacy_Self_${Date.now()}`;
-    try {
-      await client.collections.create({
-        name,
-        vectorizers: weaviate.configure.vectors.selfProvided(),
-      });
-      const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.default.indexType).toEqual('hnsw');
-    } finally {
-      await client.collections.delete(name).catch(() => undefined);
-    }
-  });
-
-  it('no-explicit-index, named selfProvided vector → stored type is hnsw (client injected)', async () => {
-    const client = await weaviate.connectToLocal({
-      host: container.getHost(),
-      port: container.getMappedPort(8080),
-      grpcPort: container.getMappedPort(50051),
-    });
-    const name = `DefVit_Legacy_Named_${Date.now()}`;
-    try {
-      await client.collections.create({
-        name,
-        vectorizers: weaviate.configure.vectors.selfProvided({ name: 'main' }),
-      });
-      const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.main.indexType).toEqual('hnsw');
-    } finally {
-      await client.collections.delete(name).catch(() => undefined);
-    }
-  });
-
-  it('explicit flat index, selfProvided vectorizer → stored type is flat (explicit choice preserved)', async () => {
-    const client = await weaviate.connectToLocal({
-      host: container.getHost(),
-      port: container.getMappedPort(8080),
-      grpcPort: container.getMappedPort(50051),
-    });
-    const name = `DefVit_Legacy_Flat_${Date.now()}`;
-    try {
-      await client.collections.create({
-        name,
-        vectorizers: weaviate.configure.vectors.selfProvided({
-          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
-        }),
-      });
-      const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.default.indexType).toEqual('flat');
-    } finally {
-      await client.collections.delete(name).catch(() => undefined);
-    }
-  });
-
-  it('explicit flat index, named selfProvided vector → stored type is flat (explicit choice preserved)', async () => {
-    const client = await weaviate.connectToLocal({
-      host: container.getHost(),
-      port: container.getMappedPort(8080),
-      grpcPort: container.getMappedPort(50051),
-    });
-    const name = `DefVit_Legacy_NamedFlat_${Date.now()}`;
-    try {
-      await client.collections.create({
-        name,
-        vectorizers: weaviate.configure.vectors.selfProvided({
-          name: 'main',
-          vectorIndexConfig: weaviate.configure.vectorIndex.flat(),
-        }),
-      });
-      const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.main.indexType).toEqual('flat');
-    } finally {
-      await client.collections.delete(name).catch(() => undefined);
-    }
-  });
-}, 180_000);
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Server 1.37.5 with DEFAULT_VECTOR_INDEX=flat — new server that applies its
-// own default. The client must NOT inject anything; the server returns 'flat'.
-// ─────────────────────────────────────────────────────────────────────────────
-describe('defaultVectorIndexType — new server (1.37.5) with DEFAULT_VECTOR_INDEX=flat', () => {
+describe(`defaultVectorIndexType — server ${WEAVIATE_VERSION} (serverAppliesDefault=${serverAppliesDefault})`, () => {
   let container: StartedWeaviateContainer;
 
   beforeAll(async () => {
     ({ container } = await startContainer(
-      'semitechnologies/weaviate:1.37.5-e0fe0d5.amd64',
+      `semitechnologies/weaviate:${WEAVIATE_VERSION}`,
+      // Older servers ignore unknown env vars; always pass the flag so we don't
+      // need a separate image-launch path.
       { DEFAULT_VECTOR_INDEX: 'flat' },
-      'linux/amd64'
+      platform
     ));
   }, 120_000);
 
@@ -141,51 +69,58 @@ describe('defaultVectorIndexType — new server (1.37.5) with DEFAULT_VECTOR_IND
     await container?.stop();
   });
 
-  it('no-explicit-index, selfProvided vectorizer → stored type is flat (server-side default applied)', async () => {
+  // ── Scenario A: no explicit vectorIndexConfig ──────────────────────────────
+
+  it('Scenario A — selfProvided (default vector), no explicit index config', async () => {
     const client = await weaviate.connectToLocal({
       host: container.getHost(),
       port: container.getMappedPort(8080),
       grpcPort: container.getMappedPort(50051),
     });
-    const name = `DefVit_New_Self_${Date.now()}`;
+    const name = `DefVit_A_Self_${Date.now()}`;
     try {
       await client.collections.create({
         name,
         vectorizers: weaviate.configure.vectors.selfProvided(),
       });
       const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.default.indexType).toEqual('flat');
+      // New server: DEFAULT_VECTOR_INDEX=flat propagates → 'flat'
+      // Old server: client injected 'hnsw' as the safe fallback
+      expect(config.vectorizers.default.indexType).toEqual(serverAppliesDefault ? 'flat' : 'hnsw');
     } finally {
       await client.collections.delete(name).catch(() => undefined);
     }
   });
 
-  it('no-explicit-index, named selfProvided vector → stored type is flat (server-side default applied)', async () => {
+  it('Scenario A — selfProvided (named vector "main"), no explicit index config', async () => {
     const client = await weaviate.connectToLocal({
       host: container.getHost(),
       port: container.getMappedPort(8080),
       grpcPort: container.getMappedPort(50051),
     });
-    const name = `DefVit_New_Named_${Date.now()}`;
+    const name = `DefVit_A_Named_${Date.now()}`;
     try {
       await client.collections.create({
         name,
         vectorizers: weaviate.configure.vectors.selfProvided({ name: 'main' }),
       });
       const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.main.indexType).toEqual('flat');
+      expect(config.vectorizers.main.indexType).toEqual(serverAppliesDefault ? 'flat' : 'hnsw');
     } finally {
       await client.collections.delete(name).catch(() => undefined);
     }
   });
 
-  it('explicit flat index, selfProvided vectorizer → stored type is flat (explicit choice preserved)', async () => {
+  // ── Scenario B: explicit flat vectorIndexConfig ────────────────────────────
+  // Explicit choice must be preserved on every version.
+
+  it('Scenario B — selfProvided (default vector), explicit flat index config', async () => {
     const client = await weaviate.connectToLocal({
       host: container.getHost(),
       port: container.getMappedPort(8080),
       grpcPort: container.getMappedPort(50051),
     });
-    const name = `DefVit_New_Flat_${Date.now()}`;
+    const name = `DefVit_B_Self_${Date.now()}`;
     try {
       await client.collections.create({
         name,
@@ -200,13 +135,13 @@ describe('defaultVectorIndexType — new server (1.37.5) with DEFAULT_VECTOR_IND
     }
   });
 
-  it('explicit flat index, named selfProvided vector → stored type is flat (explicit choice preserved)', async () => {
+  it('Scenario B — selfProvided (named vector "main"), explicit flat index config', async () => {
     const client = await weaviate.connectToLocal({
       host: container.getHost(),
       port: container.getMappedPort(8080),
       grpcPort: container.getMappedPort(50051),
     });
-    const name = `DefVit_New_NamedFlat_${Date.now()}`;
+    const name = `DefVit_B_Named_${Date.now()}`;
     try {
       await client.collections.create({
         name,

--- a/test/collections/defaultVectorIndexType/integration.test.ts
+++ b/test/collections/defaultVectorIndexType/integration.test.ts
@@ -53,6 +53,16 @@ async function startContainer(
   return { container };
 }
 
+/**
+ * Assert that a collection's stored index type matches what the server/client
+ * should have applied given the running version:
+ *   - server >= 1.37.5 → server applied DEFAULT_VECTOR_INDEX (e.g. 'hfresh')
+ *   - server <  1.37.5 → client injected 'hnsw' as legacy default
+ */
+function assertDefaultIndexType(actual: string) {
+  expect(actual).toEqual(serverAppliesDefault ? expectedDefault : 'hnsw');
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Suite
 // ─────────────────────────────────────────────────────────────────────────────
@@ -88,9 +98,7 @@ describe(`defaultVectorIndexType — server ${WEAVIATE_VERSION} (serverAppliesDe
         vectorizers: weaviate.configure.vectors.selfProvided(),
       });
       const config = await client.collections.use(name).config.get();
-      // New server: DEFAULT_VECTOR_INDEX=flat propagates → 'flat'
-      // Old server: client injected 'hnsw' as the safe fallback
-      expect(config.vectorizers.default.indexType).toEqual(serverAppliesDefault ? expectedDefault : 'hnsw');
+      assertDefaultIndexType(config.vectorizers.default.indexType);
     } finally {
       await client.collections.delete(name).catch(() => undefined);
     }
@@ -109,7 +117,7 @@ describe(`defaultVectorIndexType — server ${WEAVIATE_VERSION} (serverAppliesDe
         vectorizers: weaviate.configure.vectors.selfProvided({ name: 'main' }),
       });
       const config = await client.collections.use(name).config.get();
-      expect(config.vectorizers.main.indexType).toEqual(serverAppliesDefault ? expectedDefault : 'hnsw');
+      assertDefaultIndexType(config.vectorizers.main.indexType);
     } finally {
       await client.collections.delete(name).catch(() => undefined);
     }

--- a/test/schema/journey.test.ts
+++ b/test/schema/journey.test.ts
@@ -112,9 +112,7 @@ describe('schema', () => {
       .withProperty(prop)
       .do()
       .catch((err: Error) => {
-        expect(err.message.toLowerCase()).toEqual(
-          'The request to Weaviate failed with status code: 422 and message: {"error":[{"message":"tokenization is not allowed for data type \'int[]\'"}]}'.toLowerCase()
-        );
+        expect(err.message).toContain('tokenization is not allowed for data type');
       });
   });
 


### PR DESCRIPTION
Starting with Weaviate 1.37.5 the server sets a default vector index type to set when the client does not specify one. This PR establishes that no vector index type is set by default, and only sets "hsnw" as default for servers running <=1.37.4.