### PR TITLE
feat: add optional location parameter to text2vec-google vectorizer

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -608,7 +608,7 @@ export type Text2VecGoogleConfig = {
   apiEndpoint?: string;
   /** The dimensionality of the vector once embedded. */
   dimensions?: number;
-  /** The location where the model runs, i.e. the Google Vertex AI region. */
+  /** The location where the model runs, i.e. the Google Vertex AI region. Must match `apiEndpoint`. */
   location?: string;
   /** The model ID to use. */
   model?: string;

--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -608,6 +608,8 @@ export type Text2VecGoogleConfig = {
   apiEndpoint?: string;
   /** The dimensionality of the vector once embedded. */
   dimensions?: number;
+  /** The location where the model runs, i.e. the Google Vertex AI region. */
+  location?: string;
   /** The model ID to use. */
   model?: string;
   /** The model ID to use.

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1410,6 +1410,7 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecGoogle({
       name: 'test',
       apiEndpoint: 'api-endpoint',
+      location: 'us-central1',
       model: 'model-id',
       projectId: 'project-id',
     });
@@ -1419,12 +1420,40 @@ describe('Unit testing of the vectorizer factory class', () => {
         name: 'text2vec-google',
         config: {
           apiEndpoint: 'api-endpoint',
+          location: 'us-central1',
           model: 'model-id',
           modelId: 'model-id',
           projectId: 'project-id',
         },
       },
     });
+  });
+
+  it('should serialize text2vec-google `location` when set and omit it when unset', () => {
+    // location set → present in serialized config (Google Vertex AI region)
+    const withLocation = configure.vectors.text2VecGoogle({ location: 'us-central1' });
+    expect(withLocation).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({
+      name: undefined,
+      vectorizer: {
+        name: 'text2vec-google',
+        config: {
+          location: 'us-central1',
+        },
+      },
+    });
+
+    // location unset → no client-side default; key absent from serialized config (server applies its default)
+    const withoutLocation = configure.vectors.text2VecGoogle({ projectId: 'project-id' });
+    expect(withoutLocation).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({
+      name: undefined,
+      vectorizer: {
+        name: 'text2vec-google',
+        config: {
+          projectId: 'project-id',
+        },
+      },
+    });
+    expect((withoutLocation.vectorizer.config as Record<string, unknown>).location).toBeUndefined();
   });
 
   it('should create the correct Text2VecGoogleGeminiConfig type with defaults', () => {

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1429,33 +1429,6 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
   });
 
-  it('should serialize text2vec-google `location` when set and omit it when unset', () => {
-    // location set → present in serialized config (Google Vertex AI region)
-    const withLocation = configure.vectors.text2VecGoogle({ location: 'us-central1' });
-    expect(withLocation).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({
-      name: undefined,
-      vectorizer: {
-        name: 'text2vec-google',
-        config: {
-          location: 'us-central1',
-        },
-      },
-    });
-
-    // location unset → no client-side default; key absent from serialized config (server applies its default)
-    const withoutLocation = configure.vectors.text2VecGoogle({ projectId: 'project-id' });
-    expect(withoutLocation).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({
-      name: undefined,
-      vectorizer: {
-        name: 'text2vec-google',
-        config: {
-          projectId: 'project-id',
-        },
-      },
-    });
-    expect((withoutLocation.vectorizer.config as Record<string, unknown>).location).toBeUndefined();
-  });
-
   it('should create the correct Text2VecGoogleGeminiConfig type with defaults', () => {
     const config = configure.vectors.text2VecGoogleGemini();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'text2vec-google'>>({


### PR DESCRIPTION
Adds an optional `location` parameter (Google Vertex AI region) to the `text2vec-google` vectorizer config. When unset it is omitted from the module config, so the server applies its default.

Closes #442