### PR TITLE
feat: add optional dimensions to text2vec-aws vectorizer

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -403,7 +403,7 @@ export type Text2VecAWSConfig = {
   region: string;
   /** The AWS service to use. */
   service: 'sagemaker' | 'bedrock' | string;
-  /** The number of dimensions for the generated embeddings. */
+  /** The number of dimensions for the generated embeddings. ONLY for service `bedrock` with `amazon.*` models. */
   dimensions?: number;
   /** Whether the collection name is vectorized. */
   vectorizeCollectionName?: boolean;

--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -403,6 +403,8 @@ export type Text2VecAWSConfig = {
   region: string;
   /** The AWS service to use. */
   service: 'sagemaker' | 'bedrock' | string;
+  /** The number of dimensions for the generated embeddings. */
+  dimensions?: number;
   /** Whether the collection name is vectorized. */
   vectorizeCollectionName?: boolean;
 };

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1004,6 +1004,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       model: 'model',
       region: 'region',
       service: 'service',
+      dimensions: 512,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
       name: 'test',
@@ -1014,6 +1015,7 @@ describe('Unit testing of the vectorizer factory class', () => {
           model: 'model',
           region: 'region',
           service: 'service',
+          dimensions: 512,
         },
       },
     });

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -997,13 +997,12 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
   });
 
-  it('should create the correct Text2VecAWSConfig type with all values', () => {
+  it('should create the correct Text2VecAWSConfig type for the bedrock service', () => {
     const config = configure.vectors.text2VecAWS({
       name: 'test',
-      endpoint: 'endpoint',
-      model: 'model',
-      region: 'region',
-      service: 'service',
+      model: 'amazon.titan-embed-text-v2:0',
+      region: 'us-east-1',
+      service: 'bedrock',
       dimensions: 512,
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
@@ -1011,11 +1010,30 @@ describe('Unit testing of the vectorizer factory class', () => {
       vectorizer: {
         name: 'text2vec-aws',
         config: {
-          endpoint: 'endpoint',
-          model: 'model',
-          region: 'region',
-          service: 'service',
+          model: 'amazon.titan-embed-text-v2:0',
+          region: 'us-east-1',
+          service: 'bedrock',
           dimensions: 512,
+        },
+      },
+    });
+  });
+
+  it('should create the correct Text2VecAWSConfig type for the sagemaker service', () => {
+    const config = configure.vectors.text2VecAWS({
+      name: 'test',
+      endpoint: 'my-tei-embeddings-endpoint',
+      region: 'us-east-1',
+      service: 'sagemaker',
+    });
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-aws'>>({
+      name: 'test',
+      vectorizer: {
+        name: 'text2vec-aws',
+        config: {
+          endpoint: 'my-tei-embeddings-endpoint',
+          region: 'us-east-1',
+          service: 'sagemaker',
         },
       },
     });


### PR DESCRIPTION
Adds an optional `dimensions` parameter (output embedding dimensionality) to the `text2vec-aws` vectorizer config. Omitted when unset, so the server applies its default.

Closes #443