### PR TITLE
chore(agent): remove node https module from web bundle

### DIFF
--- a/packages/core/src/connection/auth.ts
+++ b/packages/core/src/connection/auth.ts
@@ -183,7 +183,6 @@ class UserPasswordAuthenticator implements OidcAuthFlow {
   }
 
   refresh = () => {
-    this.validateOpenidConfig();
     return this.requestAccessToken()
       .then((tokenResp: RequestAccessTokenResponse) => {
         return {
@@ -195,22 +194,6 @@ class UserPasswordAuthenticator implements OidcAuthFlow {
       .catch((err: any) => {
         return Promise.reject(new Error(`failed to refresh access token: ${err}`));
       });
-  };
-
-  validateOpenidConfig = () => {
-    if (
-      this.openidConfig.provider.grant_types_supported !== undefined &&
-      !this.openidConfig.provider.grant_types_supported.includes('password')
-    ) {
-      throw new Error('grant_type password not supported');
-    }
-    if (this.openidConfig.provider.token_endpoint.includes('https://login.microsoftonline.com')) {
-      throw new Error(
-        'microsoft/azure recommends to avoid authentication using ' +
-          'username and password, so this method is not supported by this client'
-      );
-    }
-    this.openidConfig.scopes.push('offline_access');
   };
 
   requestAccessToken = () => {

--- a/packages/core/src/connection/auth.ts
+++ b/packages/core/src/connection/auth.ts
@@ -183,6 +183,7 @@ class UserPasswordAuthenticator implements OidcAuthFlow {
   }
 
   refresh = () => {
+    this.openidConfig.scopes.push('offline_access');
     return this.requestAccessToken()
       .then((tokenResp: RequestAccessTokenResponse) => {
         return {

--- a/packages/core/src/connection/http.ts
+++ b/packages/core/src/connection/http.ts
@@ -1,7 +1,7 @@
 import OpenidConfigurationGetter from '../v2/misc/openidConfigurationGetter.js';
 
 import { isAbortError } from 'abort-controller-x';
-import { Agent } from 'http';
+import type { Agent } from 'http';
 import {
   WeaviateInsufficientPermissionsError,
   WeaviateInvalidInputError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,8 +23,7 @@ import { DbVersion } from './utils/dbVersion.js';
 import { Backend, BackupCompressionLevel, BackupStatus } from './v2/backup/index.js';
 import MetaGetter from './v2/misc/metaGetter.js';
 
-import { Agent as HttpAgent } from 'http';
-import { Agent as HttpsAgent } from 'https';
+import type { Agent } from 'http';
 import { LiveChecker, OpenidConfigurationGetter, ReadyChecker } from './v2/misc/index.js';
 
 import weaviateV2 from './v2/index.js';
@@ -133,6 +132,12 @@ export const cleanHost = (host: string, protocol: 'rest' | 'grpc') => {
 export type Context<TMedia> = {
   transportsMaker: TransportsMaker;
   toBase64FromMedia: ToBase64FromMedia<TMedia>;
+  /**
+   * Creates the HTTP(S) keep-alive agent for the REST/GraphQL connection. Supplied by the Node shim
+   * (`@weaviate/node`); omitted by the browser shim (`@weaviate/web`) so no Node `http`/`https`
+   * builtins are pulled into the browser bundle. When undefined, `fetch` runs without a custom agent.
+   */
+  agentMaker?: (secure: boolean) => Agent | undefined;
 };
 
 const client = async <TMedia>(
@@ -151,7 +156,7 @@ const client = async <TMedia>(
   if (!params.headers) params.headers = {};
 
   const scheme = httpSecure ? 'https' : 'http';
-  const agent = httpSecure ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true });
+  const agent = context.agentMaker?.(httpSecure);
 
   const { connection, dbVersionProvider, dbVersionSupport } = await ConnectionGRPC.use(
     context.transportsMaker,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -28,8 +28,7 @@ import { transportsMaker } from './transports.js';
 const context: Context<string | Buffer> = {
   transportsMaker,
   toBase64FromMedia,
-  agentMaker: (secure) =>
-    secure ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true }),
+  agentMaker: (secure) => (secure ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true })),
 };
 
 /**

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -20,12 +20,16 @@ import weaviate, {
   permissions,
   reconfigure,
 } from '@weaviate/core';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import { toBase64FromMedia } from './base64.js';
 import { transportsMaker } from './transports.js';
 
 const context: Context<string | Buffer> = {
   transportsMaker,
   toBase64FromMedia,
+  agentMaker: (secure) =>
+    secure ? new HttpsAgent({ keepAlive: true }) : new HttpAgent({ keepAlive: true }),
 };
 
 /**

--- a/packages/test/web/connect.test.ts
+++ b/packages/test/web/connect.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import weaviate from '@weaviate/web';
-import { requireAtLeast } from '../../version';
+import { requireAtLeast } from '../version';
 
 requireAtLeast(1, 39, 0).describe('connectToLocal', () => {
   it('should connect to a local Weaviate instance using grpc-web', async () => {

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -24,6 +24,8 @@ import { transportsMaker } from './transports.js';
 const context: Context<string | Blob> = {
   transportsMaker,
   toBase64FromMedia,
+  // No `agentMaker` on purpose: the browser uses fetch-based gRPC-Web (and fetch for REST), so no Node
+  // `http`/`https` Agent is needed. Omitting it keeps those Node builtins out of the browser bundle.
 };
 
 export type ConnectToLocalOptions = Omit<ConnectToLocalOptionsCore, 'grpcPort'>;


### PR DESCRIPTION
Imports in `core/src/connection` were unintentionally bringing node's `http`/`https` module into the web bundle.
This change imports only the type in `core/`, imports the module in `node/`, and omits in `web/` (which falls back to `fetch`).
