### PR TITLE
fix(data): normalize unwrapped NonReferenceInputs in data.ingest to prevent silent data loss

### DIFF
--- a/src/collections/data/index.ts
+++ b/src/collections/data/index.ts
@@ -180,6 +180,14 @@ type ParseObject<T> = {
   vectors?: number[] | Vectors;
 };
 
+/**
+ * Normalizes an object passed to `data.ingest` / `data.insertMany` into the wrapped
+ * `DataObject` shape. Without this, an unwrapped `NonReferenceInputs` value (e.g. `{ title: 'x' }`)
+ * has no `properties` key and is silently stored as an empty object.
+ */
+export const normalizeBatchInput = <T>(obj: DataObject<T> | NonReferenceInputs<T>): DataObject<T> =>
+  DataGuards.isDataObject(obj) ? obj : ({ properties: obj } as DataObject<T>);
+
 const data = <T>(
   connection: Connection,
   name: string,
@@ -252,7 +260,7 @@ const data = <T>(
         // eslint-disable-next-line no-await-in-loop
         await batching.addObject({
           collection: name,
-          ...obj,
+          ...normalizeBatchInput(obj),
           tenant,
         });
       }

--- a/src/collections/data/unit.test.ts
+++ b/src/collections/data/unit.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import { describe, expect, it } from 'vitest';
 import { Queue } from './batch';
+import { normalizeBatchInput } from './index';
 
 describe('Unit testing of the Queue class', () => {
   it('should push and pull items in FIFO order', async () => {
@@ -84,5 +85,34 @@ describe('Unit testing of the Queue class', () => {
     expect(await queue.pull(100)).toBeNull();
     queue.push(99);
     expect(await queue.pull(0)).toBe(99);
+  });
+});
+
+describe('Unit testing of normalizeBatchInput (data.ingest metadata-loss regression)', () => {
+  it('wraps an unwrapped NonReferenceInputs object into a properties field', () => {
+    expect(normalizeBatchInput({ title: 'alpha' })).toEqual({
+      properties: { title: 'alpha' },
+    });
+  });
+
+  it('leaves an already-wrapped DataObject untouched', () => {
+    const wrapped = { id: 'fixed-id', properties: { title: 'alpha' } };
+    expect(normalizeBatchInput(wrapped)).toBe(wrapped);
+  });
+
+  it('treats an object carrying only references as already wrapped', () => {
+    const wrapped = { references: { relatedTo: ['some-uuid'] } };
+    expect(normalizeBatchInput(wrapped as any)).toBe(wrapped);
+  });
+
+  it('treats an object carrying only vectors as already wrapped', () => {
+    const wrapped = { vectors: [0.1, 0.2, 0.3] };
+    expect(normalizeBatchInput(wrapped as any)).toBe(wrapped);
+  });
+
+  it('produces the same properties shape for the ingest() and insertMany() input forms', () => {
+    const unwrapped = normalizeBatchInput({ title: 'alpha' });
+    const wrapped = normalizeBatchInput({ properties: { title: 'alpha' } });
+    expect(unwrapped.properties).toEqual(wrapped.properties);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #456.

`collection.data.ingest()` accepts `NonReferenceInputs<T>` (the unwrapped `{ title: 'x' }` form) per its own type signature, but the implementation spread the object directly into the `BatchObject` payload without normalizing it into a `properties` field first. `insert()` already does this correctly via `DataGuards.isDataObject(...) ? obj : { properties: obj }` — `ingest()` was the one call site that skipped it, so a caller following the documented type signature got a clean success response (valid UUIDs, no errors) while the object was actually stored empty.

## Fix

Extracted the same normalization `insert()` already uses into a small exported helper, `normalizeBatchInput`, and used it in the `ingest()` loop instead of the raw spread.

## Testing

Added 5 unit tests covering:
- an unwrapped `NonReferenceInputs` object gets wrapped into `properties`
- an already-wrapped `DataObject` (by `id`, `properties`, `references`, or `vectors`) is left untouched
- the unwrapped and wrapped forms produce identical `properties` after normalization

All existing unit tests continue to pass. I wasn't able to run the `integration`/`journey` test suites locally (they require a live Weaviate server via `docker-compose`, not available in this environment) — happy to have those validated in CI, or to add an integration test case mirroring the issue's repro script if useful.

