### PR TITLE
feat(generative): add configure.generative.deepseek() module config builder

### DIFF
--- a/src/collections/config/types/generative.ts
+++ b/src/collections/config/types/generative.ts
@@ -48,6 +48,17 @@ export type GenerativeDatabricksConfig = {
   topP?: number;
 };
 
+export type GenerativeDeepseekConfig = {
+  baseURL?: string;
+  frequencyPenalty?: number;
+  maxTokens?: number;
+  model?: string;
+  presencePenalty?: number;
+  stop?: string[];
+  temperature?: number;
+  topP?: number;
+};
+
 export type GenerativeFriendliAIConfig = {
   baseURL?: string;
   maxTokens?: number;
@@ -123,6 +134,7 @@ export type GenerativeConfig =
   | GenerativeCohereConfig
   | GenerativeContextualAIConfig
   | GenerativeDatabricksConfig
+  | GenerativeDeepseekConfig
   | GenerativeGoogleConfig
   | GenerativeFriendliAIConfig
   | GenerativeMistralConfig
@@ -147,6 +159,8 @@ export type GenerativeConfigType<G> = G extends 'generative-anthropic'
   ? GenerativeContextualAIConfig
   : G extends 'generative-databricks'
   ? GenerativeDatabricksConfig
+  : G extends 'generative-deepseek'
+  ? GenerativeDeepseekConfig
   : G extends 'generative-google'
   ? GenerativeGoogleConfig
   : G extends 'generative-friendliai'
@@ -176,6 +190,7 @@ export type GenerativeSearch =
   | 'generative-cohere'
   | 'generative-contextualai'
   | 'generative-databricks'
+  | 'generative-deepseek'
   | 'generative-google'
   | 'generative-friendliai'
   | 'generative-mistral'

--- a/src/collections/configure/generative.ts
+++ b/src/collections/configure/generative.ts
@@ -6,6 +6,7 @@ import {
   GenerativeCohereConfig,
   GenerativeContextualAIConfig,
   GenerativeDatabricksConfig,
+  GenerativeDeepseekConfig,
   GenerativeFriendliAIConfig,
   GenerativeGoogleConfig,
   GenerativeMistralConfig,
@@ -24,6 +25,7 @@ import {
   GenerativeCohereConfigCreate,
   GenerativeContextualAIConfigCreate,
   GenerativeDatabricksConfigCreate,
+  GenerativeDeepseekConfigCreate,
   GenerativeFriendliAIConfigCreate,
   GenerativeMistralConfigCreate,
   GenerativeNvidiaConfigCreate,
@@ -168,6 +170,22 @@ export default {
   ): ModuleConfig<'generative-databricks', GenerativeDatabricksConfig> => {
     return {
       name: 'generative-databricks',
+      config,
+    };
+  },
+  /**
+   * Create a `ModuleConfig<'generative-deepseek', GenerativeDeepseekConfig | undefined>` object for use when performing AI generation using the `generative-deepseek` module.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/deepseek/generative) for detailed usage.
+   *
+   * @param {GenerativeDeepseekConfigCreate} [config] The configuration for the `generative-deepseek` module.
+   * @returns {ModuleConfig<'generative-deepseek', GenerativeDeepseekConfig | undefined>} The configuration object.
+   */
+  deepseek(
+    config?: GenerativeDeepseekConfigCreate
+  ): ModuleConfig<'generative-deepseek', GenerativeDeepseekConfig | undefined> {
+    return {
+      name: 'generative-deepseek',
       config,
     };
   },

--- a/src/collections/configure/types/generative.ts
+++ b/src/collections/configure/types/generative.ts
@@ -3,6 +3,7 @@ import {
   GenerativeAnthropicConfig,
   GenerativeAnyscaleConfig,
   GenerativeDatabricksConfig,
+  GenerativeDeepseekConfig,
   GenerativeFriendliAIConfig,
   GenerativeMistralConfig,
   GenerativeNvidiaConfig,
@@ -42,6 +43,8 @@ export type GenerativeCohereConfigCreate = {
 
 export type GenerativeDatabricksConfigCreate = GenerativeDatabricksConfig;
 
+export type GenerativeDeepseekConfigCreate = GenerativeDeepseekConfig;
+
 export type GenerativeFriendliAIConfigCreate = GenerativeFriendliAIConfig;
 
 export type GenerativeMistralConfigCreate = GenerativeMistralConfig;
@@ -75,6 +78,7 @@ export type GenerativeConfigCreate =
   | GenerativeCohereConfigCreate
   | GenerativeContextualAIConfigCreate
   | GenerativeDatabricksConfigCreate
+  | GenerativeDeepseekConfigCreate
   | GenerativeFriendliAIConfigCreate
   | GenerativeMistralConfigCreate
   | GenerativeNvidiaConfigCreate
@@ -97,6 +101,8 @@ export type GenerativeConfigCreateType<G> = G extends 'generative-anthropic'
   ? GenerativeContextualAIConfigCreate
   : G extends 'generative-databricks'
   ? GenerativeDatabricksConfigCreate
+  : G extends 'generative-deepseek'
+  ? GenerativeDeepseekConfigCreate
   : G extends 'generative-friendliai'
   ? GenerativeFriendliAIConfigCreate
   : G extends 'generative-mistral'

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -8,6 +8,7 @@ import {
   GenerativeCohereConfig,
   GenerativeContextualAIConfig,
   GenerativeDatabricksConfig,
+  GenerativeDeepseekConfig,
   GenerativeFriendliAIConfig,
   GenerativeGoogleConfig,
   GenerativeMistralConfig,
@@ -2043,6 +2044,40 @@ describe('Unit testing of the generative factory class', () => {
         maxTokens: 100,
         temperature: 0.5,
         topK: 10,
+        topP: 0.8,
+      },
+    });
+  });
+
+  it('should create the correct GenerativeDeepseekConfig type with required & default values', () => {
+    const config = configure.generative.deepseek();
+    expect(config).toEqual<ModuleConfig<'generative-deepseek', GenerativeDeepseekConfig | undefined>>({
+      name: 'generative-deepseek',
+      config: undefined,
+    });
+  });
+
+  it('should create the correct GenerativeDeepseekConfig type with all values', () => {
+    const config = configure.generative.deepseek({
+      baseURL: 'base-url',
+      frequencyPenalty: 0.2,
+      maxTokens: 100,
+      model: 'model',
+      presencePenalty: 0.3,
+      stop: ['stop'],
+      temperature: 0.5,
+      topP: 0.8,
+    });
+    expect(config).toEqual<ModuleConfig<'generative-deepseek', GenerativeDeepseekConfig | undefined>>({
+      name: 'generative-deepseek',
+      config: {
+        baseURL: 'base-url',
+        frequencyPenalty: 0.2,
+        maxTokens: 100,
+        model: 'model',
+        presencePenalty: 0.3,
+        stop: ['stop'],
+        temperature: 0.5,
         topP: 0.8,
       },
     });


### PR DESCRIPTION
## Summary

Closes #446.

Adds `configure.generative.deepseek()`, a `ModuleConfig` builder for the `generative-deepseek` module (new in Weaviate v1.36+), matching the fields listed in the issue: `model`, `maxTokens`, `temperature`, `frequencyPenalty`, `presencePenalty`, `topP`, `baseURL`, `stop`.

## Approach

Mirrors the existing `xai`/`nvidia` builders: a plain passthrough config with no field renaming, consistent with how the other recently-added providers are wired (as opposed to the older `openai`/`cohere` builders, which rename fields with a `...Property` suffix for a legacy module-config shape). Scope is the `configure`-time module config only — this does not touch the per-query generative override switch in `serialize/index.ts`, which is missing several other recent providers too (e.g. `xai`, `contextualai`) and looked out of scope for this issue.

## Changes

- `src/collections/config/types/generative.ts` — `GenerativeDeepseekConfig` type, added to the `GenerativeConfig`/`GenerativeConfigType`/`GenerativeSearch` unions
- `src/collections/configure/types/generative.ts` — `GenerativeDeepseekConfigCreate` type, added to the corresponding create-side unions
- `src/collections/configure/generative.ts` — the `deepseek()` builder function
- `src/collections/configure/unit.test.ts` — 2 new tests (defaults, all values)

## Testing

`npx tsc --noEmit` clean. Full unit suite passes (335/335, including the 2 new tests) with `WEAVIATE_VERSION=1.36.0` set locally to satisfy `test/version.ts`'s `requireAtLeast` gate. `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)