### PR TITLE
feat(vectorizer): add endpoint setting to text2vec-openai and text2vec-morph

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -587,6 +587,8 @@ export type Text2VecOpenAIConfig = {
   baseURL?: string;
   /** The dimensionality of the vector once embedded. */
   dimensions?: number;
+  /** The endpoint path to use for embedding requests. Defaults to `/v1/embeddings` in Weaviate. */
+  endpoint?: string;
   /** The model to use. */
   model?: 'text-embedding-3-small' | 'text-embedding-3-large' | 'text-embedding-ada-002' | string;
   /** The model version to use. */
@@ -702,6 +704,8 @@ export type Text2VecModel2Vec = {
 export type Text2VecMorphConfig = {
   /** The base URL to use where API requests should go. */
   baseURL?: string;
+  /** The endpoint path to use for embedding requests. Defaults to `/v1/embeddings` in Weaviate. */
+  endpoint?: string;
   /** The model to use. */
   model?: string;
 };

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -1396,6 +1396,7 @@ describe('Unit testing of the vectorizer factory class', () => {
       name: 'test',
       baseURL: 'base-url',
       dimensions: 256,
+      endpoint: '/v1/embeddings',
       model: 'model',
       modelVersion: 'model-version',
       type: 'type',
@@ -1407,6 +1408,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         config: {
           baseURL: 'base-url',
           dimensions: 256,
+          endpoint: '/v1/embeddings',
           model: 'model',
           modelVersion: 'model-version',
           type: 'type',
@@ -1705,6 +1707,7 @@ describe('Unit testing of the vectorizer factory class', () => {
     const config = configure.vectors.text2VecMorph({
       name: 'test',
       baseURL: 'base-url',
+      endpoint: '/v1/embeddings',
       model: 'model',
     });
     expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'text2vec-morph'>>({
@@ -1713,6 +1716,7 @@ describe('Unit testing of the vectorizer factory class', () => {
         name: 'text2vec-morph',
         config: {
           baseURL: 'base-url',
+          endpoint: '/v1/embeddings',
           model: 'model',
         },
       },


### PR DESCRIPTION
Closes #444

Adds an optional `endpoint` field to `Text2VecOpenAIConfig` and `Text2VecMorphConfig`, matching what the issue requested — an override for the embeddings endpoint path, defaulting to `/v1/embeddings` in Weaviate when not set.

## Why this was low-risk

Both vectorizer builders (`text2VecOpenAI`, `text2VecMorph`) already spread all config fields through as-is (`config: Object.keys(config).length === 0 ? undefined : config`), so no builder logic needed to change — this is purely additive to the two config type definitions.

## Testing

- Extended the existing "with all values" unit tests for both configs to cover `endpoint`.
- `tsc --noEmit`: clean.
- `vitest run src/collections/configure/unit.test.ts`: 136/136 passing.