### PR TITLE
feat(vectorIndex): add centered RQ4 quantization support

### DIFF
--- a/src/collections/config/types/vectorIndex.ts
+++ b/src/collections/config/types/vectorIndex.ts
@@ -79,7 +79,10 @@ export type PQConfig = {
 
 export type RQConfig = {
   bits?: number;
+  /** Whether to center vectors before rotation (centered RQ4). Requires Weaviate 1.39.2+. */
+  centering?: boolean;
   rescoreLimit?: number;
+  trainingLimit?: number;
   type: 'rq';
 };
 

--- a/src/collections/configure/types/vectorIndex.ts
+++ b/src/collections/configure/types/vectorIndex.ts
@@ -26,7 +26,10 @@ export type RQConfigCreate = QuantizerRecursivePartial<RQConfig>;
 
 export type RQConfigUpdate = {
   bit?: number;
+  /** Whether to center vectors before rotation (centered RQ4). Requires Weaviate 1.39.2+. */
+  centering?: boolean;
   rescoreLimit?: number;
+  trainingLimit?: number;
   type: 'rq';
 };
 

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -286,6 +286,36 @@ describe('Unit testing of the configure & reconfigure factory classes', () => {
     });
   });
 
+  it('should create the correct RQConfigCreate type with all values including centering', () => {
+    const quantizer = configure.vectorIndex.quantizer.rq({
+      bits: 4,
+      centering: true,
+      rescoreLimit: 500,
+      trainingLimit: 1000,
+    });
+    expect(quantizer).toEqual({
+      bits: 4,
+      centering: true,
+      rescoreLimit: 500,
+      trainingLimit: 1000,
+      type: 'rq',
+    });
+  });
+
+  it('should create the correct RQConfigUpdate type with all values including centering', () => {
+    const quantizer = reconfigure.vectorIndex.quantizer.rq({
+      centering: false,
+      rescoreLimit: 750,
+      trainingLimit: 2000,
+    });
+    expect(quantizer).toEqual({
+      centering: false,
+      rescoreLimit: 750,
+      trainingLimit: 2000,
+      type: 'rq',
+    });
+  });
+
   it('should create the correct hfresh VectorIndexConfig type with defaults', () => {
     const config = configure.vectorIndex.hfresh({ quantizer: configure.vectorIndex.quantizer.rq() });
     expect(config).toEqual<ModuleConfig<'hfresh', VectorIndexConfigHFreshCreate | undefined>>({

--- a/src/collections/configure/vectorIndex.ts
+++ b/src/collections/configure/vectorIndex.ts
@@ -206,13 +206,22 @@ const configure = {
      * Create an object of type `RQConfigCreate` to be used when defining the quantizer configuration of a vector index.
      *
      * @param {number} [options.bits] Number of bits to user per vector element.
+     * @param {boolean} [options.centering] Whether to center vectors before rotation (centered RQ4). Requires Weaviate 1.39.2+.
      * @param {number} [options.rescoreLimit] The rescore limit. Default is 1000.
+     * @param {number} [options.trainingLimit] The training limit.
      * @returns {RQConfigCreate} The object of type `RQConfigCreate`.
      */
-    rq: (options?: { bits?: number; rescoreLimit?: number }): RQConfigCreate => {
+    rq: (options?: {
+      bits?: number;
+      centering?: boolean;
+      rescoreLimit?: number;
+      trainingLimit?: number;
+    }): RQConfigCreate => {
       return {
         bits: options?.bits,
+        centering: options?.centering,
         rescoreLimit: options?.rescoreLimit,
+        trainingLimit: options?.trainingLimit,
         type: 'rq',
       };
     },
@@ -374,10 +383,16 @@ const reconfigure = {
      * NOTE: If the vector index already has a quantizer configured, you cannot change its quantizer type; only its values.
      * So if you want to change the quantizer type, you must recreate the collection.
      *
+     * @param {boolean} [options.centering] Whether to center vectors before rotation (centered RQ4). Requires Weaviate 1.39.2+.
      * @param {number} [options.rescoreLimit] The new rescore limit.
+     * @param {number} [options.trainingLimit] The new training limit.
      * @returns {RQConfigUpdate} The configuration object.
      */
-    rq: (options?: { rescoreLimit?: number }): RQConfigUpdate => {
+    rq: (options?: {
+      centering?: boolean;
+      rescoreLimit?: number;
+      trainingLimit?: number;
+    }): RQConfigUpdate => {
       return {
         ...options,
         type: 'rq',


### PR DESCRIPTION
Closes #467

Adds `centering?: boolean` and `trainingLimit?: number` to the RQ quantizer config, for both `configure.vectorIndex.quantizer.rq()` (create) and `reconfigure.vectorIndex.quantizer.rq()` (update).

## Field shape

Cross-referenced the already-merged Python client implementation ([weaviate-python-client#2148](https://github.com/weaviate/weaviate-python-client/pull/2148)) for the exact fields, since the linked server PR (weaviate/weaviate#12502) doesn't expose the REST schema naming directly in its diff. `trainingLimit` matches the naming convention this client already uses for PQ/SQ quantizers.

## Why this was low-risk

RQ quantizer config is a plain hand-written TS type (`RQConfig`) sent through the REST schema API, not a gRPC message — so no protobuf regeneration was needed, unlike some other "add support for X" issues in this repo where the client-side type can't be safely added until the server's proto is vendored in.

## Testing

- Added dedicated unit tests for both the create and reconfigure `rq()` builders covering all fields including the two new ones.
- `tsc --noEmit`: clean.
- `vitest run src/collections/configure/unit.test.ts`: 138/138 passing.