### PR TITLE
test(journey): tolerate server default RQ quantizer

### DIFF
--- a/test/collections/journey.test.ts
+++ b/test/collections/journey.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import weaviate, { CollectionConfig, WeaviateClient } from '../../src/index.js';
+import weaviate, { CollectionConfig, VectorIndexConfigHNSW, WeaviateClient } from '../../src/index.js';
 import { GeoCoordinate } from '../../src/proto/v1/properties.js';
 
 describe('Journey testing of the client using a WCD cluster', () => {
@@ -56,6 +56,9 @@ describe('Journey testing of the client using a WCD cluster', () => {
       .get(collectionName)
       .config.get()
       .then(async (config) => {
+        // Defaults on the shared WCD cluster change over time; keep assertions here tolerant.
+        const { quantizer } = config.vectorizers.default.indexConfig as VectorIndexConfigHNSW;
+        expect(['rq', undefined]).toContain(quantizer?.type);
         expect(config).toEqual<CollectionConfig>({
           name: collectionName,
           description: undefined,
@@ -202,7 +205,7 @@ describe('Journey testing of the client using a WCD cluster', () => {
                 multiVector: undefined,
                 skip: false,
                 vectorCacheMaxObjects: 1000000000000,
-                quantizer: undefined,
+                quantizer,
                 type: 'hnsw',
               },
               indexType: 'hnsw',


### PR DESCRIPTION
## Motivation

`test/collections/journey.test.ts` connects to a **fixed WCD cluster** (`piblpmmdsiknacjnm1ltla.c1.europe-west3.gcp.weaviate.cloud`), not the local container spun up for CI. That cluster was upgraded to a server version that applies a default RQ quantizer to HNSW indexes, so the strict `toEqual<CollectionConfig>` on the returned config started failing with `quantizer: undefined` (expected) vs `{ type: 'rq', bits: 8, rescoreLimit: 20 }` (actual).

Because the cluster is external and shared, this failed *every* `tests-without-auth` matrix job simultaneously — all seven Node/Weaviate combinations, on every open PR — regardless of the Weaviate version under test. The red CI is not caused by anything in this repo, and it blocks all other work (e.g. #459, #466).

## Approach

Pull `quantizer` out of the deep-equal, assert its shape loosely (`expect(['rq', undefined]).toContain(quantizer?.type)`), and feed the actual value back into the deep-equal so **everything else in the config is still compared strictly**. This keeps the test meaningful — it still catches a config field going wrong — while making it agnostic to which side of the default-quantizer change the cluster happens to be on.

This mirrors the approach already taken in fa9c488f for the openai hfresh expectation in `integration.test.ts`, so the codebase now handles the same server-side variability consistently in both places.

Alternatives rejected:
- **Pinning the expectation to RQ**: would break again the moment the journey test runs against an older server, and would break contributors running the suite locally.
- **Configuring an explicit quantizer in the test's `collections.create`**: changes what the test covers — the point of this assertion is the *default* config the server returns, not one the client dictated.

## Key areas for review

- `test/collections/journey.test.ts:59-63` — the destructure + loose assertion. Worth confirming the `VectorIndexConfigHNSW` cast is right here (the collection is created with default HNSW, not hfresh) and that `quantizer?.type` is the narrowest thing we can usefully assert.
- `test/collections/journey.test.ts:210` — `quantizer` is now threaded into the deep-equal; this is what preserves strictness for the remaining fields.

## Risks and mitigations

Low risk — test-only, one file, no `src/` changes.

- **Weakened coverage**: the only thing no longer strictly asserted is the quantizer's `bits`/`rescoreLimit`; its presence and type are still checked, and `integration.test.ts` covers quantizer configuration against the local container where the server version is known.
- **Masking a real regression**: `undefined` is still an accepted value, so a client-side bug that drops the quantizer entirely would pass here. Accepted deliberately — the journey test targets an external cluster we don't version-control, so it can't be the place that pins quantizer behaviour.

## Testing

Verified against the live WCD cluster the test targets: `should get the config for the created collection` now passes where it previously failed on the `quantizer` mismatch, with the rest of the config deep-equal unchanged. No changes to `src/`, so no other suites are affected.

## Follow-up (not in this PR)

The cluster URL and API key are hardcoded in plaintext at `test/collections/journey.test.ts:19-23` and have been in this public repo since 2024-05-23. Worth a separate issue to move them to Actions secrets — and to reconsider whether a shared, externally-mutable cluster belongs in the blocking CI path at all, given this failure mode (an external upgrade reddens every PR at once) will recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXVS2uKtuEH91QEVka8zWV
