### PR TITLE
feat(backup): support incremental backups via baseBackupId

### DIFF
--- a/src/backup/backupCreator.ts
+++ b/src/backup/backupCreator.ts
@@ -12,6 +12,7 @@ import { Backend } from './index.js';
 import {
   validateBackend,
   validateBackupId,
+  validateBaseBackupId,
   validateExcludeClassNames,
   validateIncludeClassNames,
 } from './validation.js';
@@ -21,6 +22,7 @@ const WAIT_INTERVAL = 1000;
 export default class BackupCreator extends CommandBase {
   private backend!: Backend;
   private backupId!: string;
+  private baseBackupId?: string;
   private excludeClassNames?: string[];
   private includeClassNames?: string[];
   private statusGetter: BackupCreateStatusGetter;
@@ -60,6 +62,11 @@ export default class BackupCreator extends CommandBase {
     return this;
   }
 
+  withBaseBackupId(baseBackupId?: string) {
+    this.baseBackupId = baseBackupId;
+    return this;
+  }
+
   withWaitForCompletion(waitForCompletion: boolean) {
     this.waitForCompletion = waitForCompletion;
     return this;
@@ -76,6 +83,7 @@ export default class BackupCreator extends CommandBase {
       ...validateExcludeClassNames(this.excludeClassNames),
       ...validateBackend(this.backend),
       ...validateBackupId(this.backupId),
+      ...validateBaseBackupId(this.baseBackupId),
     ]);
   };
 
@@ -90,6 +98,7 @@ export default class BackupCreator extends CommandBase {
       config: this.config,
       include: this.includeClassNames,
       exclude: this.excludeClassNames,
+      incremental_base_backup_id: this.baseBackupId,
     } as BackupCreateRequest;
 
     if (this.waitForCompletion) {

--- a/src/backup/validation.ts
+++ b/src/backup/validation.ts
@@ -45,3 +45,13 @@ export function validateBackupId(backupId?: string) {
   }
   return [];
 }
+
+export function validateBaseBackupId(baseBackupId?: string) {
+  if (baseBackupId === undefined) {
+    return [];
+  }
+  if (!isValidStringProperty(baseBackupId)) {
+    return ['string baseBackupId invalid - set with .withBaseBackupId(baseBackupId)'];
+  }
+  return [];
+}

--- a/src/collections/backup/client.ts
+++ b/src/collections/backup/client.ts
@@ -23,8 +23,8 @@ import {
 import {
   BackupArgs,
   BackupCancelArgs,
-  BackupConfigCreate,
   BackupConfigRestore,
+  BackupCreateArgs,
   BackupReturn,
   BackupStatusArgs,
   BackupStatusReturn,
@@ -47,6 +47,7 @@ export const backup = (connection: Connection): Backup => {
       error: res.error,
       path: res.path,
       status: res.status,
+      baseBackupId: 'incremental_base_backup_id' in res ? res.incremental_base_backup_id : undefined,
     };
   };
   const parseResponse = (res: BackupCreateResponse | BackupRestoreResponse): BackupReturn => {
@@ -109,10 +110,11 @@ export const backup = (connection: Connection): Backup => {
 
       return true;
     },
-    create: async (args: BackupArgs<BackupConfigCreate>): Promise<BackupReturn> => {
+    create: async (args: BackupCreateArgs): Promise<BackupReturn> => {
       let builder = new BackupCreator(connection, new BackupCreateStatusGetter(connection))
         .withBackupId(args.backupId)
-        .withBackend(args.backend);
+        .withBackend(args.backend)
+        .withBaseBackupId(args.baseBackupId);
       if (args.includeCollections) {
         builder = builder.withIncludeClassNames(...args.includeCollections);
       }
@@ -208,12 +210,15 @@ export const backup = (connection: Connection): Backup => {
           }
         : parseResponse(res);
     },
-    list: (backend: Backend, opts?: ListBackupOptions): Promise<BackupReturn[]> => {
+    list: async (backend: Backend, opts?: ListBackupOptions): Promise<BackupReturn[]> => {
       let url = `/backups/${backend}`;
       if (opts?.startedAtAsc) {
         url += '?order=asc';
       }
-      return connection.get<BackupReturn[]>(url);
+      const res = await connection.get<(BackupReturn & { incremental_base_backup_id?: string })[]>(url);
+      return res.map(({ incremental_base_backup_id: baseBackupId, ...rest }) =>
+        baseBackupId !== undefined ? { ...rest, baseBackupId } : rest
+      );
     },
   };
 };
@@ -231,13 +236,16 @@ export interface Backup {
   /**
    * Create a backup of the database.
    *
-   * @param {BackupArgs} args The arguments for the request.
+   * Pass `baseBackupId` to create an incremental backup on top of an existing one;
+   * only files that changed since the base backup are written.
+   *
+   * @param {BackupCreateArgs} args The arguments for the request.
    * @returns {Promise<BackupReturn>} The response from Weaviate.
    * @throws {WeaviateInvalidInputError} If the input is invalid.
    * @throws {WeaviateBackupFailed} If the backup creation fails.
    * @throws {WeaviateBackupCanceled} If the backup creation is canceled.
    */
-  create(args: BackupArgs<BackupConfigCreate>): Promise<BackupReturn>;
+  create(args: BackupCreateArgs): Promise<BackupReturn>;
   /**
    * Get the status of a backup creation.
    *

--- a/src/collections/backup/collection.ts
+++ b/src/collections/backup/collection.ts
@@ -13,10 +13,21 @@ export type BackupCollectionArgs = {
   waitForCompletion?: boolean;
 };
 
+/** The arguments required to create a backup of a single collection. */
+export type BackupCollectionCreateArgs = BackupCollectionArgs & {
+  /**
+   * The ID of an existing backup to use as the base for a file-based incremental backup.
+   * If set, only files that have changed since the base backup are included in the new backup.
+   *
+   * Requires Weaviate `1.34.18`/`1.35.13`/`1.36.3` or higher.
+   */
+  baseBackupId?: string;
+};
+
 export const backupCollection = (connection: Connection, name: string) => {
   const handler = backup(connection);
   return {
-    create: (args: BackupCollectionArgs) =>
+    create: (args: BackupCollectionCreateArgs) =>
       handler.create({
         ...args,
         includeCollections: [name],
@@ -35,13 +46,16 @@ export interface BackupCollection {
   /**
    * Create a backup of this collection.
    *
-   * @param {BackupArgs} args The arguments for the request.
+   * Pass `baseBackupId` to create an incremental backup on top of an existing one;
+   * only files that changed since the base backup are written.
+   *
+   * @param {BackupCollectionCreateArgs} args The arguments for the request.
    * @returns {Promise<BackupReturn>} The response from Weaviate.
    * @throws {WeaviateInvalidInputError} If the input is invalid.
    * @throws {WeaviateBackupFailed} If the backup creation fails.
    * @throws {WeaviateBackupCanceled} If the backup creation is canceled.
    */
-  create(args: BackupCollectionArgs): Promise<BackupReturn>;
+  create(args: BackupCollectionCreateArgs): Promise<BackupReturn>;
   /**
    * Get the status of a backup.
    *

--- a/src/collections/backup/index.ts
+++ b/src/collections/backup/index.ts
@@ -1,3 +1,9 @@
 export type { Backup } from './client.js';
-export type { BackupCollection, BackupCollectionArgs } from './collection.js';
-export type { BackupArgs, BackupConfigCreate, BackupConfigRestore, BackupStatusArgs } from './types.js';
+export type { BackupCollection, BackupCollectionArgs, BackupCollectionCreateArgs } from './collection.js';
+export type {
+  BackupArgs,
+  BackupConfigCreate,
+  BackupConfigRestore,
+  BackupCreateArgs,
+  BackupStatusArgs,
+} from './types.js';

--- a/src/collections/backup/types.ts
+++ b/src/collections/backup/types.ts
@@ -16,6 +16,13 @@ export type BackupStatusReturn = {
   status: BackupStatus;
   /** Size of the backup in Gibs */
   size?: number;
+  /**
+   * The ID of the backup this incremental backup was built on.
+   * Empty if the backup is not incremental.
+   *
+   * Only populated for callers that Weaviate has confirmed as root users.
+   */
+  baseBackupId?: string;
 };
 
 /** The return type of a backup creation or restoration operation */
@@ -62,6 +69,17 @@ export type BackupArgs<C extends BackupConfigCreate | BackupConfigRestore> = {
   waitForCompletion?: boolean;
   /** The configuration options for the backup. */
   config?: C;
+};
+
+/** The arguments required to create a backup. */
+export type BackupCreateArgs = BackupArgs<BackupConfigCreate> & {
+  /**
+   * The ID of an existing backup to use as the base for a file-based incremental backup.
+   * If set, only files that have changed since the base backup are included in the new backup.
+   *
+   * Requires Weaviate `1.34.18`/`1.35.13`/`1.36.3` or higher.
+   */
+  baseBackupId?: string;
 };
 
 /** The arguments required to get the status of a backup. */

--- a/test/collections/backup/integration.test.ts
+++ b/test/collections/backup/integration.test.ts
@@ -258,6 +258,66 @@ describe('Integration testing of backups', () => {
     });
   });
 
+  // Incremental backups landed in 1.34.18 / 1.35.13 / 1.36.3 / 1.37.0. The patch-level
+  // gate below is only exact for the 1.34 line; the CI matrix pins later patches of the
+  // other minors, so the intermediate versions that lack the feature are never exercised.
+  requireAtLeast(1, 34, 18).describe('incremental backups', () => {
+    const collectionName = 'TestIncrementalBackup';
+
+    it('creates an incremental backup on top of a base and restores it', async () => {
+      const client = await clientPromise;
+      const collection = await client.collections.create({ name: collectionName });
+      await collection.data.insert();
+
+      const base = await client.backup.create({
+        backupId: randomBackupId(),
+        backend: 'filesystem',
+        includeCollections: [collectionName],
+        waitForCompletion: true,
+      });
+      expect(base.status).toBe('SUCCESS');
+
+      await collection.data.insert();
+
+      const incremental = await client.backup.create({
+        backupId: randomBackupId(),
+        backend: 'filesystem',
+        includeCollections: [collectionName],
+        baseBackupId: base.id,
+        waitForCompletion: true,
+      });
+      expect(incremental.status).toBe('SUCCESS');
+
+      await client.collections.delete(collectionName);
+
+      const restored = await client.backup.restore({
+        backupId: incremental.id,
+        backend: 'filesystem',
+        includeCollections: [collectionName],
+        waitForCompletion: true,
+      });
+      expect(restored.status).toBe('SUCCESS');
+
+      // Both objects are present: the one from the base and the one added afterwards.
+      const { totalCount } = await client.collections.use(collectionName).aggregate.overAll();
+      expect(totalCount).toBe(2);
+    });
+
+    it('rejects an unknown base backup', async () => {
+      const client = await clientPromise;
+      const created = client.backup.create({
+        backupId: randomBackupId(),
+        backend: 'filesystem',
+        includeCollections: [collectionName],
+        baseBackupId: 'this-base-backup-does-not-exist',
+        waitForCompletion: true,
+      });
+      await expect(created).rejects.toThrowError(WeaviateBackupFailed);
+    });
+
+    it('cleanup', () => clientPromise.then((c) => c.collections.delete(collectionName).catch(() => {})));
+  });
+
   function randomBackupId() {
     return 'backup-id-' + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
   }

--- a/test/collections/backup/mock.test.ts
+++ b/test/collections/backup/mock.test.ts
@@ -186,3 +186,120 @@ describe('Mock testing of backup cancellation', () => {
 
   afterAll(() => mock.close());
 });
+
+const BASE_BACKUP_ID = 'test-base-backup-456';
+
+class IncrementalMock {
+  private grpc: GrpcServer;
+  private http: HttpServer;
+  /** Body of the most recent backup creation request. */
+  static createRequest: Record<string, any>;
+
+  constructor(grpc: GrpcServer, http: HttpServer) {
+    this.grpc = grpc;
+    this.http = http;
+  }
+
+  public static use = async (version: string, httpPort: number, grpcPort: number) => {
+    const httpApp = express();
+    httpApp.use(express.json());
+    httpApp.get('/v1/meta', (req, res) => res.send({ version }));
+
+    httpApp.post(`/v1/backups/${BACKEND}`, (req, res: Response<BackupCreateResponse, any>) => {
+      IncrementalMock.createRequest = req.body;
+      res.send({
+        id: BACKUP_ID,
+        backend: BACKEND,
+        path: 'path/to/backup',
+        status: 'STARTED',
+      });
+    });
+
+    // Weaviate only returns incremental_base_backup_id to root users.
+    httpApp.get(`/v1/backups/${BACKEND}/${BACKUP_ID}`, (req, res) =>
+      res.send({
+        id: BACKUP_ID,
+        backend: BACKEND,
+        path: 'path/to/backup',
+        status: 'SUCCESS',
+        incremental_base_backup_id: BASE_BACKUP_ID,
+      })
+    );
+
+    httpApp.get(`/v1/backups/${BACKEND}`, (req, res) =>
+      res.send([
+        {
+          id: BASE_BACKUP_ID,
+          backend: BACKEND,
+          path: 'path/to/base',
+          status: 'SUCCESS',
+        },
+        {
+          id: BACKUP_ID,
+          backend: BACKEND,
+          path: 'path/to/backup',
+          status: 'SUCCESS',
+          incremental_base_backup_id: BASE_BACKUP_ID,
+        },
+      ])
+    );
+
+    const healthMockImpl: HealthServiceImplementation = {
+      check: (request: HealthCheckRequest): Promise<HealthCheckResponse> =>
+        Promise.resolve(HealthCheckResponse.create({ status: HealthCheckResponse_ServingStatus.SERVING })),
+      watch: vi.fn(),
+    };
+
+    const grpc = createServer();
+    grpc.add(HealthDefinition, healthMockImpl);
+
+    httpApp.on('error', (error) => console.error('HTTP Server Error:', error));
+
+    await grpc.listen(`localhost:${grpcPort}`);
+    const http = await httpApp.listen(httpPort);
+    return new IncrementalMock(grpc, http);
+  };
+
+  public close = () => Promise.all([this.http.close(), this.grpc.shutdown()]);
+}
+
+describe('Mock testing of incremental backups', () => {
+  let client: WeaviateClient;
+  let mock: IncrementalMock;
+
+  beforeAll(async () => {
+    mock = await IncrementalMock.use('1.36.3', 8914, 8915);
+    client = await weaviate.connectToLocal({ port: 8914, grpcPort: 8915 });
+  });
+
+  it('should send the base backup ID when creating an incremental backup', async () => {
+    await client.backup.create({
+      backupId: BACKUP_ID,
+      backend: BACKEND,
+      baseBackupId: BASE_BACKUP_ID,
+    });
+    expect(IncrementalMock.createRequest.incremental_base_backup_id).toBe(BASE_BACKUP_ID);
+  });
+
+  it('should not send a base backup ID for a full backup', async () => {
+    await client.backup.create({
+      backupId: BACKUP_ID,
+      backend: BACKEND,
+    });
+    expect(IncrementalMock.createRequest.incremental_base_backup_id).toBeUndefined();
+  });
+
+  it('should return the base backup ID from the creation status', async () => {
+    const status = await client.backup.getCreateStatus({ backupId: BACKUP_ID, backend: BACKEND });
+    expect(status.baseBackupId).toBe(BASE_BACKUP_ID);
+  });
+
+  it('should return the base backup ID when listing backups', async () => {
+    const backups = await client.backup.list(BACKEND);
+    expect(backups.find((b) => b.id === BASE_BACKUP_ID)?.baseBackupId).toBeUndefined();
+    expect(backups.find((b) => b.id === BACKUP_ID)?.baseBackupId).toBe(BASE_BACKUP_ID);
+    expect(backups.every((b) => !('incremental_base_backup_id' in b))).toBe(true);
+  });
+
+  afterAll(() => mock.close());
+});


### PR DESCRIPTION
## What

Weaviate accepts `incremental_base_backup_id` on `POST /v1/backups/{backend}` to build a file-based incremental backup on top of an existing one (added in [weaviate#10275](https://github.com/weaviate/weaviate/pull/10275), released in `1.34.18` / `1.35.13` / `1.36.3` / `1.37.0`). The client had no way to set it, and dropped the field from list/status responses, so incremental backups were unreachable from TypeScript.

This mirrors the Go v6 client, which exposes it as a top-level `CreateOptions.BaseBackupID` (not nested under config) and surfaces `Info.BaseBackupID` on returned backups.

## Changes

- `client.backup.create` and `collection.backup.create` accept an optional `baseBackupId`, via the new `BackupCreateArgs` / `BackupCollectionCreateArgs` types. Restore args are untouched — the field is create-only, as in Go.
- `BackupCreator.withBaseBackupId()` puts it on the request as `incremental_base_backup_id`.
- `BackupStatusReturn` gains `baseBackupId`; `getCreateStatus` and `list` map `incremental_base_backup_id` onto it.

All additive — no existing signature changes meaning, and `BackupCreateArgs` is a superset of `BackupArgs<BackupConfigCreate>`.

## Notes

- Weaviate only returns `incremental_base_backup_id` to callers it has confirmed as **root users**, so `baseBackupId` is often absent on reads even when the backup is incremental. Documented on the type.
- The server validates the base: it must exist, be `SUCCESS`, be strictly older, share the same compression type, and the whole ancestor chain is walked for cycles. No client-side duplication of that.

## Testing

- `test/collections/backup/mock.test.ts`: asserts the create request carries `incremental_base_backup_id` (and omits it for a full backup), and that status/list responses map it to `baseBackupId`.
- `test/collections/backup/integration.test.ts`: full backup → insert more data → incremental backup on that base → restore → assert both objects are present. Also asserts an unknown base is rejected. Gated with `requireAtLeast(1, 34, 18)`.

Verified locally against Weaviate `1.36.10`: all backup mock + integration tests pass. `npm run lint`, `npm run format:check` and `npm run docs` are clean (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ2p2CzXLS92ThnvDjnxAE