### PR TITLE
feat(generative): add configure.generative.digitalOcean() module config builder

### DIFF
--- a/src/collections/config/types/generative.ts
+++ b/src/collections/config/types/generative.ts
@@ -48,6 +48,17 @@ export type GenerativeDatabricksConfig = {
   topP?: number;
 };
 
+export type GenerativeDigitalOceanConfig = {
+  baseURL?: string;
+  frequencyPenalty?: number;
+  maxTokens?: number;
+  model?: string;
+  presencePenalty?: number;
+  stop?: string[];
+  temperature?: number;
+  topP?: number;
+};
+
 export type GenerativeFriendliAIConfig = {
   baseURL?: string;
   maxTokens?: number;
@@ -123,6 +134,7 @@ export type GenerativeConfig =
   | GenerativeCohereConfig
   | GenerativeContextualAIConfig
   | GenerativeDatabricksConfig
+  | GenerativeDigitalOceanConfig
   | GenerativeGoogleConfig
   | GenerativeFriendliAIConfig
   | GenerativeMistralConfig
@@ -147,6 +159,8 @@ export type GenerativeConfigType<G> = G extends 'generative-anthropic'
   ? GenerativeContextualAIConfig
   : G extends 'generative-databricks'
   ? GenerativeDatabricksConfig
+  : G extends 'generative-digitalocean'
+  ? GenerativeDigitalOceanConfig
   : G extends 'generative-google'
   ? GenerativeGoogleConfig
   : G extends 'generative-friendliai'
@@ -176,6 +190,7 @@ export type GenerativeSearch =
   | 'generative-cohere'
   | 'generative-contextualai'
   | 'generative-databricks'
+  | 'generative-digitalocean'
   | 'generative-google'
   | 'generative-friendliai'
   | 'generative-mistral'

--- a/src/collections/configure/generative.ts
+++ b/src/collections/configure/generative.ts
@@ -6,6 +6,7 @@ import {
   GenerativeCohereConfig,
   GenerativeContextualAIConfig,
   GenerativeDatabricksConfig,
+  GenerativeDigitalOceanConfig,
   GenerativeFriendliAIConfig,
   GenerativeGoogleConfig,
   GenerativeMistralConfig,
@@ -24,6 +25,7 @@ import {
   GenerativeCohereConfigCreate,
   GenerativeContextualAIConfigCreate,
   GenerativeDatabricksConfigCreate,
+  GenerativeDigitalOceanConfigCreate,
   GenerativeFriendliAIConfigCreate,
   GenerativeMistralConfigCreate,
   GenerativeNvidiaConfigCreate,
@@ -168,6 +170,22 @@ export default {
   ): ModuleConfig<'generative-databricks', GenerativeDatabricksConfig> => {
     return {
       name: 'generative-databricks',
+      config,
+    };
+  },
+  /**
+   * Create a `ModuleConfig<'generative-digitalocean', GenerativeDigitalOceanConfig | undefined>` object for use when performing AI generation using the `generative-digitalocean` module.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/digitalocean/generative) for detailed usage.
+   *
+   * @param {GenerativeDigitalOceanConfigCreate} [config] The configuration for the `generative-digitalocean` module.
+   * @returns {ModuleConfig<'generative-digitalocean', GenerativeDigitalOceanConfig | undefined>} The configuration object.
+   */
+  digitalOcean(
+    config?: GenerativeDigitalOceanConfigCreate
+  ): ModuleConfig<'generative-digitalocean', GenerativeDigitalOceanConfig | undefined> {
+    return {
+      name: 'generative-digitalocean',
       config,
     };
   },

--- a/src/collections/configure/types/generative.ts
+++ b/src/collections/configure/types/generative.ts
@@ -3,6 +3,7 @@ import {
   GenerativeAnthropicConfig,
   GenerativeAnyscaleConfig,
   GenerativeDatabricksConfig,
+  GenerativeDigitalOceanConfig,
   GenerativeFriendliAIConfig,
   GenerativeMistralConfig,
   GenerativeNvidiaConfig,
@@ -42,6 +43,8 @@ export type GenerativeCohereConfigCreate = {
 
 export type GenerativeDatabricksConfigCreate = GenerativeDatabricksConfig;
 
+export type GenerativeDigitalOceanConfigCreate = GenerativeDigitalOceanConfig;
+
 export type GenerativeFriendliAIConfigCreate = GenerativeFriendliAIConfig;
 
 export type GenerativeMistralConfigCreate = GenerativeMistralConfig;
@@ -75,6 +78,7 @@ export type GenerativeConfigCreate =
   | GenerativeCohereConfigCreate
   | GenerativeContextualAIConfigCreate
   | GenerativeDatabricksConfigCreate
+  | GenerativeDigitalOceanConfigCreate
   | GenerativeFriendliAIConfigCreate
   | GenerativeMistralConfigCreate
   | GenerativeNvidiaConfigCreate
@@ -97,6 +101,8 @@ export type GenerativeConfigCreateType<G> = G extends 'generative-anthropic'
   ? GenerativeContextualAIConfigCreate
   : G extends 'generative-databricks'
   ? GenerativeDatabricksConfigCreate
+  : G extends 'generative-digitalocean'
+  ? GenerativeDigitalOceanConfigCreate
   : G extends 'generative-friendliai'
   ? GenerativeFriendliAIConfigCreate
   : G extends 'generative-mistral'

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -8,6 +8,7 @@ import {
   GenerativeCohereConfig,
   GenerativeContextualAIConfig,
   GenerativeDatabricksConfig,
+  GenerativeDigitalOceanConfig,
   GenerativeFriendliAIConfig,
   GenerativeGoogleConfig,
   GenerativeMistralConfig,
@@ -2046,6 +2047,44 @@ describe('Unit testing of the generative factory class', () => {
         topP: 0.8,
       },
     });
+  });
+
+  it('should create the correct GenerativeDigitalOceanConfig type with required & default values', () => {
+    const config = configure.generative.digitalOcean();
+    expect(config).toEqual<ModuleConfig<'generative-digitalocean', GenerativeDigitalOceanConfig | undefined>>(
+      {
+        name: 'generative-digitalocean',
+        config: undefined,
+      }
+    );
+  });
+
+  it('should create the correct GenerativeDigitalOceanConfig type with all values', () => {
+    const config = configure.generative.digitalOcean({
+      baseURL: 'base-url',
+      frequencyPenalty: 0.2,
+      maxTokens: 100,
+      model: 'model',
+      presencePenalty: 0.3,
+      stop: ['stop'],
+      temperature: 0.5,
+      topP: 0.8,
+    });
+    expect(config).toEqual<ModuleConfig<'generative-digitalocean', GenerativeDigitalOceanConfig | undefined>>(
+      {
+        name: 'generative-digitalocean',
+        config: {
+          baseURL: 'base-url',
+          frequencyPenalty: 0.2,
+          maxTokens: 100,
+          model: 'model',
+          presencePenalty: 0.3,
+          stop: ['stop'],
+          temperature: 0.5,
+          topP: 0.8,
+        },
+      }
+    );
   });
 
   it('should create the correct GenerativeFriendliAIConfig type with required & default values', () => {


### PR DESCRIPTION
## Summary

Closes #463.

Adds `configure.generative.digitalOcean()`, a `ModuleConfig` builder for the `generative-digitalocean` module (new in Weaviate v1.37+), covering the settings listed in the issue: `baseURL`, `model`, `temperature`, `topP`, `maxTokens`, `frequencyPenalty`, `presencePenalty`, `stop`.

## Approach

Mirrors the recently-added `deepseek`/`xai`/`nvidia` builders: a plain passthrough config with no field renaming (as opposed to the older `openai`/`cohere` builders, which rename fields with a `...Property` suffix for a legacy module-config shape). The `GenerativeDigitalOcean` proto message has the same field set as `GenerativeDeepseek`, so the config shape matches #465. Naming follows the existing `text2vec-digitalocean` vectorizer precedent in this repo (`'generative-digitalocean'` module string, `GenerativeDigitalOceanConfig` type, `digitalOcean` factory method). Scope is the `configure`-time module config only.

## Changes

- `src/collections/config/types/generative.ts` — `GenerativeDigitalOceanConfig` type, added to the `GenerativeConfig`/`GenerativeConfigType`/`GenerativeSearch` unions
- `src/collections/configure/types/generative.ts` — `GenerativeDigitalOceanConfigCreate` type, added to the corresponding create-side unions
- `src/collections/configure/generative.ts` — the `digitalOcean()` builder function
- `src/collections/configure/unit.test.ts` — 2 new tests (defaults, all values)

## Testing

`npx tsc --noEmit` clean. Unit suite passes (138/138 in `unit.test.ts`, including the 2 new tests) with `WEAVIATE_VERSION=1.37.0` set locally to satisfy `test/version.ts`. `eslint` and `prettier --check` clean.