### PR TITLE
feat(generative): add location setting to generative-google config

### DIFF
--- a/src/collections/config/types/generative.ts
+++ b/src/collections/config/types/generative.ts
@@ -88,6 +88,7 @@ export type GenerativePaLMConfig = GenerativeGoogleConfig;
 
 export type GenerativeGoogleConfig = {
   apiEndpoint?: string;
+  location?: string;
   maxOutputTokens?: number;
   model?: string;
   /** @deprecated Use `model` instead. */

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -2226,6 +2226,7 @@ describe('Unit testing of the generative factory class', () => {
   it('should create the correct GenerativeGoogleConfig type with all values', () => {
     const config = configure.generative.google({
       apiEndpoint: 'api-endpoint',
+      location: 'europe-west4',
       maxOutputTokens: 100,
       model: 'model-id',
       projectId: 'project-id',
@@ -2237,6 +2238,7 @@ describe('Unit testing of the generative factory class', () => {
       name: 'generative-google',
       config: {
         apiEndpoint: 'api-endpoint',
+        location: 'europe-west4',
         maxOutputTokens: 100,
         model: 'model-id',
         modelId: 'model-id',

--- a/src/collections/types/generate.ts
+++ b/src/collections/types/generate.ts
@@ -300,6 +300,7 @@ export type GenerativeGoogleConfigRuntime = {
   projectId?: string | undefined;
   endpointId?: string | undefined;
   region?: string | undefined;
+  location?: string | undefined;
 };
 
 export type GenerativeMistralConfigRuntime = {


### PR DESCRIPTION
## Summary

Closes #445.

Adds the optional `location` setting to the `generative-google` module (defaults to `us-central1` server-side). Mirrors weaviate-python-client#2118 / #2130.

## Approach

`location` is a plain pass-through field on both existing `generative-google` config surfaces, so no builder logic changes are needed:

- **Config time** — `configure.generative.google()` already spreads `...config`, so adding `location` to `GenerativeGoogleConfig` is enough.
- **Query time** — `generativeParameters.google()` already spreads `...rest`, and the vendored `GenerativeGoogle` proto message already carries `location` (`src/proto/v1/generative.ts`), so adding `location` to `GenerativeGoogleConfigRuntime` completes the runtime path without touching `serialize/index.ts`.

## Changes

- `src/collections/config/types/generative.ts` — `location?: string` on `GenerativeGoogleConfig`
- `src/collections/types/generate.ts` — `location?: string` on `GenerativeGoogleConfigRuntime`
- `src/collections/configure/unit.test.ts` — `location` added to the existing `generative.google` all-values test

No new test in `generate/unit.test.ts`: per that file's header comment it only covers fields that are renamed to a gRPC name, and `location` passes through unchanged.

## Testing

`npx tsc --noEmit` clean. `eslint` and `prettier --check` clean. Unit suite passes (160/160 across `configure/unit.test.ts` + `generate/unit.test.ts`) with `WEAVIATE_VERSION` set locally for `test/version.ts`.