### PR TITLE
feat(backup): surface incrementalBaseBackupId on backup status and list

### DIFF
--- a/src/collections/backup/client.ts
+++ b/src/collections/backup/client.ts
@@ -18,6 +18,7 @@ import {
 import {
   BackupCreateResponse,
   BackupCreateStatusResponse,
+  BackupListResponse,
   BackupRestoreResponse,
 } from '../../openapi/types.js';
 import {
@@ -47,6 +48,8 @@ export const backup = (connection: Connection): Backup => {
       error: res.error,
       path: res.path,
       status: res.status,
+      incrementalBaseBackupId:
+        'incremental_base_backup_id' in res ? res.incremental_base_backup_id : undefined,
     };
   };
   const parseResponse = (res: BackupCreateResponse | BackupRestoreResponse): BackupReturn => {
@@ -213,7 +216,12 @@ export const backup = (connection: Connection): Backup => {
       if (opts?.startedAtAsc) {
         url += '?order=asc';
       }
-      return connection.get<BackupReturn[]>(url);
+      return connection.get<BackupListResponse>(url).then((backups) =>
+        (backups ?? []).map((backup) => ({
+          ...(backup as unknown as BackupReturn),
+          incrementalBaseBackupId: backup.incremental_base_backup_id,
+        }))
+      );
     },
   };
 };

--- a/src/collections/backup/types.ts
+++ b/src/collections/backup/types.ts
@@ -16,6 +16,8 @@ export type BackupStatusReturn = {
   status: BackupStatus;
   /** Size of the backup in Gibs */
   size?: number;
+  /** The ID of the base backup this incremental backup was built on; absent when the backup is not incremental. */
+  incrementalBaseBackupId?: string;
 };
 
 /** The return type of a backup creation or restoration operation */

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -18,6 +18,7 @@ export type BackupCreateStatusResponse = definitions['BackupCreateStatusResponse
 export type BackupRestoreRequest = definitions['BackupRestoreRequest'];
 export type BackupRestoreResponse = definitions['BackupRestoreResponse'];
 export type BackupRestoreStatusResponse = definitions['BackupRestoreStatusResponse'];
+export type BackupListResponse = definitions['BackupListResponse'];
 export type BackupConfig = definitions['BackupConfig'];
 export type RestoreConfig = definitions['RestoreConfig'];
 export type WeaviateBackupStatus =

--- a/test/collections/backup/mock.test.ts
+++ b/test/collections/backup/mock.test.ts
@@ -66,7 +66,21 @@ class CancelMock {
           backend: BACKEND,
           path: 'path/to/backup',
           status: CancelMock.status,
+          incremental_base_backup_id: 'base-backup-001',
         })
+    );
+
+    // Backup list endpoint
+    httpApp.get(`/v1/backups/${BACKEND}`, (req, res) =>
+      res.send([
+        { id: 'full-backup', classes: ['A'], status: 'SUCCESS' },
+        {
+          id: 'incremental-backup',
+          classes: ['A'],
+          status: 'SUCCESS',
+          incremental_base_backup_id: 'full-backup',
+        },
+      ])
     );
 
     // Backup restoration endpoint
@@ -182,6 +196,17 @@ describe('Mock testing of backup cancellation', () => {
       operation: 'restore',
     });
     expect(success).toBe(false);
+  });
+
+  it('should surface incrementalBaseBackupId from the creation status', async () => {
+    const status = await client.backup.getCreateStatus({ backupId: BACKUP_ID, backend: BACKEND });
+    expect(status.incrementalBaseBackupId).toBe('base-backup-001');
+  });
+
+  it('should surface incrementalBaseBackupId when listing backups', async () => {
+    const backups = await client.backup.list(BACKEND);
+    expect(backups.find((b) => b.id === 'full-backup')?.incrementalBaseBackupId).toBeUndefined();
+    expect(backups.find((b) => b.id === 'incremental-backup')?.incrementalBaseBackupId).toBe('full-backup');
   });
 
   afterAll(() => mock.close());


### PR DESCRIPTION
## Summary

Closes #441.

Exposes `incrementalBaseBackupId` on `BackupStatusReturn` — the ID of the base backup a file-based incremental backup was built on (empty/absent when the backup is not incremental). Mirrors weaviate-python-client#2116.

The field is already in the vendored OpenAPI spec (`incremental_base_backup_id` on `BackupCreateStatusResponse` and `BackupListResponse`); it just wasn't mapped through to the public types.

## Changes

- `src/openapi/types.ts` — export `BackupListResponse`
- `src/collections/backup/types.ts` — `incrementalBaseBackupId?: string` on `BackupStatusReturn` (inherited by `BackupReturn`)
- `src/collections/backup/client.ts` — `parseStatus` maps it from the create-status response; `backup.list()` maps it from each list entry (other list-response quirks left untouched)
- `test/collections/backup/mock.test.ts` — mock the list + create-status endpoints returning `incremental_base_backup_id`; 2 tests asserting it surfaces (and stays `undefined` for a non-incremental backup)

## Testing

`npx tsc --noEmit`, `eslint`, `prettier --check` clean. `test/collections/backup/mock.test.ts` passes (8/8, including the 2 new).