### PR TITLE
feat(vectorizer): add configure.vectors.multi2VecAWS() module config builder

### DIFF
--- a/src/collections/config/types/vectorizer.ts
+++ b/src/collections/config/types/vectorizer.ts
@@ -19,6 +19,7 @@ type Text2VecPalmVectorizer = 'text2vec-palm';
 
 export type Vectorizer =
   | 'img2vec-neural'
+  | 'multi2vec-aws'
   | 'multi2vec-nvidia'
   | 'multi2vec-clip'
   | 'multi2vec-cohere'
@@ -740,6 +741,8 @@ export type VectorizerConfig =
 
 export type VectorizerConfigType<V> = V extends 'img2vec-neural'
   ? Img2VecNeuralConfig | undefined
+  : V extends 'multi2vec-aws'
+  ? Multi2VecAWSConfig | undefined
   : V extends 'multi2vec-nvidia'
   ? Multi2VecNvidiaConfig | undefined
   : V extends 'multi2vec-clip'

--- a/src/collections/configure/types/vectorizer.ts
+++ b/src/collections/configure/types/vectorizer.ts
@@ -163,6 +163,7 @@ export type Multi2VecNvidiaConfigCreate = Omit<Multi2VecNvidiaConfig, Multi2VecO
   textFields?: string[] | Multi2VecField[];
 };
 
+/** The configuration for the `multi2vec-aws` vectorizer. */
 export type Multi2VecAWSConfigCreate = Omit<Multi2VecAWSConfig, Multi2VecOmissions> & {
   /** The image fields to use in vectorization. Can be string of `Multi2VecField` type. If string, weight 0 will be assumed. */
   imageFields?: string[] | Multi2VecField[];
@@ -309,6 +310,8 @@ export type Text2MultiVecJinaAIConfigCreate = Text2MultiVecJinaAIConfig;
 
 export type VectorizerConfigCreateType<V> = V extends 'img2vec-neural'
   ? Img2VecNeuralConfigCreate | undefined
+  : V extends 'multi2vec-aws'
+  ? Multi2VecAWSConfigCreate | undefined
   : V extends 'multi2vec-nvidia'
   ? Multi2VecNvidiaConfigCreate | undefined
   : V extends 'multi2vec-clip'

--- a/src/collections/configure/unit.test.ts
+++ b/src/collections/configure/unit.test.ts
@@ -434,6 +434,69 @@ describe('Unit testing of the vectorizer factory class', () => {
     });
   });
 
+  it('should create the correct Multi2VecAWSConfig type with defaults', () => {
+    const config = configure.vectors.multi2VecAWS();
+    expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-aws'>>({
+      name: undefined,
+      vectorizer: {
+        name: 'multi2vec-aws',
+        config: undefined,
+      },
+    });
+  });
+
+  it('should create the correct Multi2VecAWSConfig type with all values', () => {
+    const config = configure.vectors.multi2VecAWS({
+      name: 'test',
+      model: 'amazon.titan-embed-image-v1',
+      region: 'us-east-1',
+    });
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-aws'>>({
+      name: 'test',
+      vectorizer: {
+        name: 'multi2vec-aws',
+        config: {
+          model: 'amazon.titan-embed-image-v1',
+          region: 'us-east-1',
+        },
+      },
+    });
+  });
+
+  it('should create the correct Multi2VecAWSConfig type with all values and weights', () => {
+    const config = configure.vectors.multi2VecAWS({
+      name: 'test',
+      model: 'amazon.titan-embed-image-v1',
+      region: 'us-east-1',
+      dimensions: 1024,
+      imageFields: [
+        { name: 'field1', weight: 0.1 },
+        { name: 'field2', weight: 0.2 },
+      ],
+      textFields: [
+        { name: 'field3', weight: 0.3 },
+        { name: 'field4', weight: 0.4 },
+      ],
+    });
+    expect(config).toEqual<VectorConfigCreate<never, 'test', 'hnsw', 'multi2vec-aws'>>({
+      name: 'test',
+      vectorizer: {
+        name: 'multi2vec-aws',
+        config: {
+          model: 'amazon.titan-embed-image-v1',
+          region: 'us-east-1',
+          dimensions: 1024,
+          imageFields: ['field1', 'field2'],
+          textFields: ['field3', 'field4'],
+          weights: {
+            imageFields: [0.1, 0.2],
+            textFields: [0.3, 0.4],
+          },
+        },
+      },
+    });
+  });
+
   it('should create the correct Multi2VecClipConfig type with defaults', () => {
     const config = configure.vectors.multi2VecClip();
     expect(config).toEqual<VectorConfigCreate<never, undefined, 'hnsw', 'multi2vec-clip'>>({

--- a/src/collections/configure/vectorizer.ts
+++ b/src/collections/configure/vectorizer.ts
@@ -1,6 +1,7 @@
 import { WeaviateInvalidInputError } from '../../errors.js';
 import {
   ModuleConfig,
+  Multi2VecAWSConfig,
   Multi2VecBindConfig,
   Multi2VecClipConfig,
   Multi2VecField,
@@ -1010,6 +1011,41 @@ export const vectorizer = legacyVectors;
 export const vectors = (({ text2VecPalm, multi2VecPalm, ...rest }) => ({
   ...rest,
   ...__vectors_shaded,
+
+  /**
+   * Create a `VectorConfigCreate` object with the vectorizer set to `'multi2vec-aws'`.
+   *
+   * See the [documentation](https://weaviate.io/developers/weaviate/model-providers/aws/embeddings-multimodal) for detailed usage.
+   *
+   * @param {ConfigureNonTextVectorizerOptions<N, I, 'multi2vec-aws'>} [opts] The configuration options for the `multi2vec-aws` vectorizer.
+   * @returns {VectorConfigCreate<PrimitiveKeys<T>[], N, I, 'multi2vec-aws'>} The configuration object.
+   */
+  multi2VecAWS: <N extends string | undefined = undefined, I extends VectorIndexType = 'hnsw'>(
+    opts?: ConfigureNonTextVectorizerOptions<N, I, 'multi2vec-aws'>
+  ): VectorConfigCreate<never, N, I, 'multi2vec-aws'> => {
+    const { name, quantizer, vectorIndexConfig, ...config } = opts || {};
+    const imageFields = config.imageFields?.map(mapMulti2VecField);
+    const textFields = config.textFields?.map(mapMulti2VecField);
+    let weights: Multi2VecAWSConfig['weights'] = {};
+    weights = formatMulti2VecFields(weights, 'imageFields', imageFields);
+    weights = formatMulti2VecFields(weights, 'textFields', textFields);
+    return makeVectorizer(name, {
+      quantizer,
+      vectorIndexConfig,
+      vectorizerConfig: {
+        name: 'multi2vec-aws',
+        config:
+          Object.keys(config).length === 0
+            ? undefined
+            : {
+                ...config,
+                imageFields: imageFields?.map((f) => f.name),
+                textFields: textFields?.map((f) => f.name),
+                weights: Object.keys(weights).length === 0 ? undefined : weights,
+              },
+      },
+    });
+  },
 
   /**
    * Create a `VectorConfigCreate` object with the vectorizer set to `'multi2vec-nvidia'`.


### PR DESCRIPTION
Adds a `configure.vectors.multi2VecAWS()` builder for the `multi2vec-aws` (Bedrock multimodal embeddings) vectorizer, bringing the TypeScript client to parity with the Python client, which already ships `multi2vec-aws` in `config_vectorizers.py`.

The `Multi2VecAWSConfig` return type and `Multi2VecAWSConfigCreate` options type already existed in the client — this wires up the missing pieces:

- `'multi2vec-aws'` added to the `Vectorizer` union and to `VectorizerConfigType` / `VectorizerConfigCreateType`
- `configure.vectors.multi2VecAWS()` builder, mirroring `multi2VecNvidia` / `multi2VecCohere` — supports `region`, `model`, `dimensions`, and `imageFields` / `textFields` with optional per-field `weights`
- 3 unit tests: defaults (→ `config: undefined`), all values, values + weights

Follow-up to #345, which tracked both `multi2vec-aws` and `text2vec-morph` — only `text2vec-morph` landed on the TS side.

`npm run test:unit` and `tsc --noEmit` pass; prettier / eslint clean.