### PR TITLE
fix(connection): clarify timeout units are seconds, fix ms mislabel in REST timeout error

### DIFF
--- a/src/connection/http.ts
+++ b/src/connection/http.ts
@@ -32,11 +32,11 @@ export type ProxiesParams = {
 };
 
 export type TimeoutParams = {
-  /** Define the configured timeout when querying data from Weaviate */
+  /** Define the configured timeout, in seconds, when querying data from Weaviate */
   query?: number;
-  /** Define the configured timeout when mutating data to Weaviate */
+  /** Define the configured timeout, in seconds, when mutating data to Weaviate */
   insert?: number;
-  /** Define the configured timeout when initially connecting to Weaviate */
+  /** Define the configured timeout, in seconds, when initially connecting to Weaviate */
   init?: number;
 };
 
@@ -249,7 +249,7 @@ const fetchWithTimeout = (
   return fetch(input, { ...init, signal: controller.signal })
     .catch((error) => {
       if (isAbortError(error)) {
-        throw new WeaviateRequestTimeoutError(`Request timed out after ${timeout}ms`);
+        throw new WeaviateRequestTimeoutError(`Request timed out after ${timeout * 1000}ms`);
       }
       throw error; // For other errors, rethrow them
     })


### PR DESCRIPTION
## What

- Documents that `TimeoutParams` (`query`/`insert`/`init`) are configured in **seconds**, not milliseconds.
- Fixes the REST client's timeout error message, which printed the raw seconds value with an `ms` suffix (e.g. a 30s timeout reported "Request timed out after 30ms"). Now converts to ms correctly, matching the gRPC client's existing behavior in `grpc/base.ts`.

## Why

Closes #356 — the docs didn't specify units, and @noahnu noted in that issue that some error messages incorrectly add the "ms" suffix to a seconds value.

## Testing

- `npx tsc --noEmit` passes
- `npm run lint` passes